### PR TITLE
✨ Reduce magic in converting documents.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,7 @@
       "dependencies": {
         "node-sass": {
           "version": "4.11.0",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-          "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+          "bundled": true,
           "requires": {
             "async-foreach": "^0.1.3",
             "chalk": "^1.1.1",
@@ -79,8 +78,7 @@
       "dependencies": {
         "node-sass": {
           "version": "4.11.0",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-          "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+          "bundled": true,
           "requires": {
             "async-foreach": "^0.1.3",
             "chalk": "^1.1.1",
@@ -204,8 +202,7 @@
       "dependencies": {
         "entities": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+          "bundled": true
         }
       }
     },
@@ -4953,7 +4950,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
         "camelcase": "^2.0.0",
@@ -4994,7 +4991,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
         "ansi-styles": "^2.2.1",
@@ -5095,8 +5092,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -5117,14 +5113,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -5139,20 +5133,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -5269,8 +5260,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -5282,7 +5272,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -5297,7 +5286,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -5305,14 +5293,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -5331,7 +5317,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -5412,8 +5397,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -5425,7 +5409,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -5511,8 +5494,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -5548,7 +5530,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5568,7 +5549,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -5612,14 +5592,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -8528,8 +8506,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8550,14 +8527,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8572,20 +8547,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8702,8 +8674,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8715,7 +8686,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8730,7 +8700,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8738,14 +8707,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8764,7 +8731,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8845,8 +8811,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8858,7 +8823,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8944,8 +8908,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8981,7 +8944,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9001,7 +8963,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9045,14 +9006,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -12180,7 +12139,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -12665,7 +12624,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minimist-options": {
@@ -13396,7 +13355,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -16690,7 +16649,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"

--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -121,7 +121,7 @@ export default class Document {
       converters[this.contentType] = {};
     }
 
-    if (!(to instanceof Document)) {
+    if (!(to.prototype instanceof Document)) {
       throw new Error(`📦 We've detected that you have multiple versions of \`@atjson/document\` installed— ${to.name} doesn't extend the same Document class as ${this.name}.\nThis may be because @atjson/document is being installed as a sub-dependency of an npm package and as a top-level package, and their versions don't match. It could also be that your build includes two versions of @atjson/document.`);
     }
     converters[this.contentType][to.contentType] = converter;

--- a/packages/@atjson/document/test/converter-test.ts
+++ b/packages/@atjson/document/test/converter-test.ts
@@ -2,11 +2,9 @@ import TestSource, { Bold, Paragraph } from './test-source';
 import { TextSource } from './text-source-test';
 
 describe('Document#convert', () => {
-  test('sources without conversions are coerced', () => {
+  test('sources without conversions throw errors', () => {
     let textDoc = TextSource.fromRaw('Hello, World!');
-    let testDoc = textDoc.convertTo(TestSource);
-    expect(testDoc).toBeInstanceOf(TestSource);
-    expect(testDoc.all().toJSON()).toEqual(textDoc.all().toJSON());
+    expect(() => textDoc.convertTo(TestSource)).toThrowError();
   });
 
   test('sources with conversions are called', () => {
@@ -38,7 +36,7 @@ describe('Document#convert', () => {
     }]);
   });
 
-  test('converting to the same type is a no-op', () => {
+  test('converting to the same type will throw an error if one is not defined', () => {
     let testDoc = new TestSource({
       content: 'Hello, World!',
       annotations: [
@@ -47,6 +45,6 @@ describe('Document#convert', () => {
       ]
     });
 
-    expect(testDoc.convertTo(TestSource).toJSON()).toEqual(testDoc.toJSON());
+    expect(() => testDoc.convertTo(TestSource)).toThrowError();
   });
 });

--- a/packages/@atjson/source-commonmark/test/extensions-test.ts
+++ b/packages/@atjson/source-commonmark/test/extensions-test.ts
@@ -18,9 +18,11 @@ class MarkdownItSource extends CommonmarkSource {
 }
 
 MarkdownItSource.defineConverterTo(OffsetSource, doc => {
-  doc.where({ type: '-commonmark-s' }).set({ type: '-offset-strikethrough' });
   let convertCommonmark = getConverterFor(CommonmarkSource, OffsetSource);
-  return convertCommonmark(doc);
+  convertCommonmark(doc);
+  doc.where({ type: '-commonmark-s' }).set({ type: '-offset-strikethrough' });
+
+  return doc;
 });
 
 describe('strikethrough', () => {

--- a/packages/@atjson/source-commonmark/test/extensions-test.ts
+++ b/packages/@atjson/source-commonmark/test/extensions-test.ts
@@ -1,4 +1,4 @@
-import { InlineAnnotation } from '@atjson/document';
+import { InlineAnnotation, getConverterFor } from '@atjson/document';
 import OffsetSource from '@atjson/offset-annotations';
 import * as MarkdownIt from 'markdown-it';
 import CommonmarkSource from '../src';
@@ -19,8 +19,8 @@ class MarkdownItSource extends CommonmarkSource {
 
 MarkdownItSource.defineConverterTo(OffsetSource, doc => {
   doc.where({ type: '-commonmark-s' }).set({ type: '-offset-strikethrough' });
-
-  return doc.convertTo(CommonmarkSource).convertTo(OffsetSource);
+  let convertCommonmark = getConverterFor(CommonmarkSource, OffsetSource);
+  return convertCommonmark(doc);
 });
 
 describe('strikethrough', () => {

--- a/packages/@atjson/source-prism/src/converter.ts
+++ b/packages/@atjson/source-prism/src/converter.ts
@@ -4,6 +4,9 @@ import HTMLSource from '@atjson/source-html';
 import PRISMSource from './source';
 
 PRISMSource.defineConverterTo(OffsetSource, doc => {
+  let convertHTML = getConverterFor(HTMLSource, OffsetSource);
+  convertHTML(doc);
+
   doc.where({ type: '-html-head' }).update(head => {
     doc.where(a => a.start >= head.start && a.end <= head.end).remove();
     doc.deleteText(head.start, head.end);
@@ -14,6 +17,5 @@ PRISMSource.defineConverterTo(OffsetSource, doc => {
     doc.deleteText(media.start, media.end);
   });
 
-  let convertHTML = getConverterFor(HTMLSource, OffsetSource);
-  return convertHTML(doc);
+  return doc;
 });

--- a/packages/@atjson/source-prism/src/converter.ts
+++ b/packages/@atjson/source-prism/src/converter.ts
@@ -1,3 +1,4 @@
+import { getConverterFor } from '@atjson/document';
 import OffsetSource from '@atjson/offset-annotations';
 import HTMLSource from '@atjson/source-html';
 import PRISMSource from './source';
@@ -13,5 +14,6 @@ PRISMSource.defineConverterTo(OffsetSource, doc => {
     doc.deleteText(media.start, media.end);
   });
 
-  return doc.convertTo(HTMLSource).convertTo(OffsetSource);
+  let convertHTML = getConverterFor(HTMLSource, OffsetSource);
+  return convertHTML(doc);
 });


### PR DESCRIPTION
🚨 When converting a document, it will no longer coerce a document. You will need to do this yourself!

🚨 You can no longer nest converters inside of another converter. Instead import `getConverterFor` from @atjson/document and use the function supplied from that.

These improvements are designed to improve the developer experience of atjson for developers. We've encountered some frustrations where:


1. Conversions wouldn't run because there are two different versions of @atjson/document installed.

    📝 If you are using atjson, update your dependencies to this version. Any version increment after this shouldn't break your converters.

2. Converters would get called, but the document was made up of only UnknownAnnotations.

    👩🏽‍🏫 You're no longer allowed to nest converters. This change was done to make converting less confusing, because it was super weird to have all your annotations be "Unknown" if you ran a converter before running the rest of your conversion code. Also, it will no longer clone the document, so this should hopefully make some conversions speedier! 🐰

3. It was unclear when convertTo would actually run any code.

     📣 We've changed this so all converters are user-defined code. If there is no converter defined, it will let you know!