### PR TITLE
🐞 fix references to wrong github repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ after_success:
       # Create a new worktree where we create documentation
       # We set the branch as gh-pages and remove all files from
       # the git repo
-      git clone git@github.com:CondeNast-Copilot/atjson.git deploy-atjson --branch gh-pages
+      git clone git@github.com:CondeNast/atjson.git deploy-atjson --branch gh-pages
 
       # Clean up old documentation for latest
       if [[ $TRAVIS_BRANCH == latest ]]; then
@@ -66,5 +66,5 @@ after_success:
       else
         git commit -m ":package::books: Release documentation for latest."
       fi
-      git push git@github.com:CondeNast-Copilot/atjson.git gh-pages
+      git push git@github.com:CondeNast/atjson.git gh-pages
     fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-:tipping_hand_woman: AtJSON has a [Code of Conduct](https://github.com/CondeNast-Copilot/atjson/blob/latest/CODE_OF_CONDUCT.md) that we expect all of our contributors to abide by, please check it out before contributing!
+:tipping_hand_woman: AtJSON has a [Code of Conduct](https://github.com/CondeNast/atjson/blob/latest/CODE_OF_CONDUCT.md) that we expect all of our contributors to abide by, please check it out before contributing!
 
 ***
 
@@ -7,7 +7,7 @@ AtJSON is comprised of a bunch of packages, monorepo style. We use [:dragon:Lern
 :computer: To get started, clone atjson onto your computer and navigate into the project.
 
 ```bash
-git clone https://github.com/CondeNast-Copilot/atjson.git
+git clone https://github.com/CondeNast/atjson.git
 cd atjson
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AtJSON [![Build Status](https://travis-ci.org/CondeNast-Copilot/atjson.svg?branch=latest)](https://travis-ci.org/CondeNast/atjson) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Maintainability](https://api.codeclimate.com/v1/badges/4ee3591f9171333e235e/maintainability)](https://codeclimate.com/github/CondeNast/atjson/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/4ee3591f9171333e235e/test_coverage)](https://codeclimate.com/github/CondeNast/atjson/test_coverage)
+# AtJSON [![Build Status](https://travis-ci.org/CondeNast/atjson.svg?branch=latest)](https://travis-ci.org/CondeNast/atjson) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Maintainability](https://api.codeclimate.com/v1/badges/4ee3591f9171333e235e/maintainability)](https://codeclimate.com/github/CondeNast/atjson/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/4ee3591f9171333e235e/test_coverage)](https://codeclimate.com/github/CondeNast/atjson/test_coverage)
 
 ## Maintainers
 * Tim Evans (@tim-evans tim_evans@condenast.com)
@@ -140,7 +140,7 @@ Objects can also be embedded in documents that can be expanded when the document
 
 We have a source document with annotations:
 
-![War and Peace](https://raw.githubusercontent.com/CondeNast-Copilot/atjson/latest/public/war-and-peace.png)
+![War and Peace](https://raw.githubusercontent.com/CondeNast/atjson/latest/public/war-and-peace.png)
 
 This marked up document equates to:
 
@@ -203,7 +203,7 @@ A number of little notes distributed that morning by a footman in red livery had
 
 This visually would look like:
 
-![War and Peace](https://raw.githubusercontent.com/CondeNast-Copilot/atjson/latest/public/war-and-peace-annotated.png)
+![War and Peace](https://raw.githubusercontent.com/CondeNast/atjson/latest/public/war-and-peace-annotated.png)
 
 
 Creating an output is pretty straightforward, and requires no knowledge about the content format. You need to know about the annotations and what attributes they may contain. Generating output based on the hierarchical representation is straightforward and minimal.

--- a/packages/@atjson/conventional-changelog-emoji/CHANGELOG.md
+++ b/packages/@atjson/conventional-changelog-emoji/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.10.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/conventional-changelog-emoji@0.9.1...@atjson/conventional-changelog-emoji@0.10.0) (2019-01-09)
+## [0.10.0](https://github.com/CondeNast/atjson/compare/@atjson/conventional-changelog-emoji@0.9.1...@atjson/conventional-changelog-emoji@0.10.0) (2019-01-09)
 
 
 ### ✨ New Features
@@ -12,7 +12,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/conventional-changelog-emoji@0.9.0...@atjson/conventional-changelog-emoji@0.9.1) (2018-12-11)
+## [0.9.1](https://github.com/CondeNast/atjson/compare/@atjson/conventional-changelog-emoji@0.9.0...@atjson/conventional-changelog-emoji@0.9.1) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/conventional-changelog-emoji
 
@@ -20,20 +20,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/conventional-changelog-emoji@0.8.7...@atjson/conventional-changelog-emoji@0.9.0) (2018-10-10)
+## [0.9.0](https://github.com/CondeNast/atjson/compare/@atjson/conventional-changelog-emoji@0.8.7...@atjson/conventional-changelog-emoji@0.9.0) (2018-10-10)
 
 **Note:** Version bump only for package @atjson/conventional-changelog-emoji
 
-## [0.8.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/conventional-changelog-emoji@0.8.6...@atjson/conventional-changelog-emoji@0.8.7) (2018-09-14)
+## [0.8.7](https://github.com/CondeNast/atjson/compare/@atjson/conventional-changelog-emoji@0.8.6...@atjson/conventional-changelog-emoji@0.8.7) (2018-09-14)
 
 **Note:** Version bump only for package @atjson/conventional-changelog-emoji
 
-## [0.8.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/conventional-changelog-emoji@0.8.5...@atjson/conventional-changelog-emoji@0.8.6) (2018-09-04)
+## [0.8.6](https://github.com/CondeNast/atjson/compare/@atjson/conventional-changelog-emoji@0.8.5...@atjson/conventional-changelog-emoji@0.8.6) (2018-09-04)
 
 
 ### 🐛 Fixes
 
-* 🐛🔒 fix vulnerability with with git-dummy-commit by using shelljs directly ([#76](https://github.com/CondeNast-Copilot/atjson/issues/76))
+* 🐛🔒 fix vulnerability with with git-dummy-commit by using shelljs directly ([#76](https://github.com/CondeNast/atjson/issues/76))
 
 
 ## 0.8.5 (2018-08-02)

--- a/packages/@atjson/conventional-changelog-emoji/README.md
+++ b/packages/@atjson/conventional-changelog-emoji/README.md
@@ -40,7 +40,7 @@ Commits look like `✌️ My awesome change (#12)`. There’s emoji at the begin
 
 ### 🙋‍♀️ Do you have an emoji that you'd like to add?
 
-Add your emoji to [this spreadsheet](https://github.com/CondeNast-Copilot/atjson/tree/latest/packages/%40atjson/conventional-commits/src/emoji.csv) with the heading that it should live under, the severity of the change, and a 🚫 or ✅ indicating whether it should be included in the changelog.
+Add your emoji to [this spreadsheet](https://github.com/CondeNast/atjson/tree/latest/packages/%40atjson/conventional-commits/src/emoji.csv) with the heading that it should live under, the severity of the change, and a 🚫 or ✅ indicating whether it should be included in the changelog.
 
 The severity can be one of the following:
 
@@ -53,9 +53,9 @@ The severity can be one of the following:
 Let’s use the commit examples used above:
 
 - 📦 Release 0.2.8
-- 🐛 Fix nested bold and italic markdown output ([#32](https://github.com/condenast-copilot/atjson/issues/24))
-- 🎉 Add horizontal rule and vertical adjustments for Google Docs paste ([#52](https://github.com/condenast-copilot/atjson/issues/52))
-- ✨👑✨ Make Annotations classes instead of JS objects ([#54](](https://github.com/condenast-copilot/atjson/issues/54)))\
+- 🐛 Fix nested bold and italic markdown output ([#32](https://github.com/CondeNast/atjson/issues/24))
+- 🎉 Add horizontal rule and vertical adjustments for Google Docs paste ([#52](https://github.com/CondeNast/atjson/issues/52))
+- ✨👑✨ Make Annotations classes instead of JS objects ([#54](](https://github.com/CondeNast/atjson/issues/54)))\
 \
   🚨 Schemas are now defined as a list of annotation classes, cf. `[Bold, Italic]`
 
@@ -63,12 +63,12 @@ And show what will be our changelog!
 
 ### 🐛 Fixes
 
-* 🐛 Fix nested bold and italic markdown output ([#32](https://github.com/condenast-copilot/atjson/issues/24))
+* 🐛 Fix nested bold and italic markdown output ([#32](https://github.com/CondeNast/atjson/issues/24))
 
 ### ✨ New Features
 
-* ✨👑✨ Make Annotations classes instead of JS objects ([#54](](https://github.com/condenast-copilot/atjson/issues/54)))
-* 🎉 Add horizontal rule and vertical adjustments for Google Docs paste ([#52](https://github.com/condenast-copilot/atjson/issues/52))
+* ✨👑✨ Make Annotations classes instead of JS objects ([#54](](https://github.com/CondeNast/atjson/issues/54)))
+* 🎉 Add horizontal rule and vertical adjustments for Google Docs paste ([#52](https://github.com/CondeNast/atjson/issues/52))
 
 ### 🚨 Breaking Changes
 

--- a/packages/@atjson/document/CHANGELOG.md
+++ b/packages/@atjson/document/CHANGELOG.md
@@ -3,16 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.15.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.14.9...@atjson/document@0.15.0) (2019-04-19)
+## [0.15.0](https://github.com/CondeNast/atjson/compare/@atjson/document@0.14.9...@atjson/document@0.15.0) (2019-04-19)
 
 
 ### ✨ New Features
 
-* ✨🥃 add an interface for declaring annotation attributes ([#130](https://github.com/CondeNast-Copilot/atjson/issues/130))
+* ✨🥃 add an interface for declaring annotation attributes ([#130](https://github.com/CondeNast/atjson/issues/130))
 
 
 
-## [0.14.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.14.8...@atjson/document@0.14.9) (2019-04-15)
+## [0.14.9](https://github.com/CondeNast/atjson/compare/@atjson/document@0.14.8...@atjson/document@0.14.9) (2019-04-15)
 
 
 ### 🐛 Fixes
@@ -21,25 +21,25 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.14.7...@atjson/document@0.14.8) (2019-04-15)
+## [0.14.8](https://github.com/CondeNast/atjson/compare/@atjson/document@0.14.7...@atjson/document@0.14.8) (2019-04-15)
 
 
 ### 🐛 Fixes
 
-* 🐝 fix slice so it only includes overlapping annotations from the parent document and the correct underlying text ([#125](https://github.com/CondeNast-Copilot/atjson/issues/125))
+* 🐝 fix slice so it only includes overlapping annotations from the parent document and the correct underlying text ([#125](https://github.com/CondeNast/atjson/issues/125))
 
 
 
-## [0.14.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.14.6...@atjson/document@0.14.7) (2019-03-21)
+## [0.14.7](https://github.com/CondeNast/atjson/compare/@atjson/document@0.14.6...@atjson/document@0.14.7) (2019-03-21)
 
 
 ### 🐛 Fixes
 
-* 🐝 Fix unknown annotations passing attributes by reference and HIR optimization bug ([#122](https://github.com/CondeNast-Copilot/atjson/issues/122))
+* 🐝 Fix unknown annotations passing attributes by reference and HIR optimization bug ([#122](https://github.com/CondeNast/atjson/issues/122))
 
 
 
-## [0.14.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.14.5...@atjson/document@0.14.6) (2019-03-19)
+## [0.14.6](https://github.com/CondeNast/atjson/compare/@atjson/document@0.14.5...@atjson/document@0.14.6) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/document
 
@@ -47,43 +47,43 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.14.4...@atjson/document@0.14.5) (2019-03-18)
+## [0.14.5](https://github.com/CondeNast/atjson/compare/@atjson/document@0.14.4...@atjson/document@0.14.5) (2019-03-18)
 
 
 ### 🐛 Fixes
 
-* 🐛 reify unknown annotations when passing them into `createAnnotation` ([#120](https://github.com/CondeNast-Copilot/atjson/issues/120))
+* 🐛 reify unknown annotations when passing them into `createAnnotation` ([#120](https://github.com/CondeNast/atjson/issues/120))
 
 
 
-## [0.14.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.14.3...@atjson/document@0.14.4) (2019-03-18)
-
-
-### 🐛 Fixes
-
-* 🚀🐛 Performance fixes ([#119](https://github.com/CondeNast-Copilot/atjson/issues/119))
-
-
-
-## [0.14.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.14.2...@atjson/document@0.14.3) (2019-03-14)
+## [0.14.4](https://github.com/CondeNast/atjson/compare/@atjson/document@0.14.3...@atjson/document@0.14.4) (2019-03-18)
 
 
 ### 🐛 Fixes
 
-* 🐝🚀 Fix performance regressions ([#118](https://github.com/CondeNast-Copilot/atjson/issues/118))
+* 🚀🐛 Performance fixes ([#119](https://github.com/CondeNast/atjson/issues/119))
 
 
 
-## [0.14.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.14.1...@atjson/document@0.14.2) (2019-02-12)
+## [0.14.3](https://github.com/CondeNast/atjson/compare/@atjson/document@0.14.2...@atjson/document@0.14.3) (2019-03-14)
 
 
 ### 🐛 Fixes
 
-* 🐝 Allow annotation classes in document constructor ([#106](https://github.com/CondeNast-Copilot/atjson/issues/106))
+* 🐝🚀 Fix performance regressions ([#118](https://github.com/CondeNast/atjson/issues/118))
 
 
 
-## [0.14.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.14.0...@atjson/document@0.14.1) (2019-01-14)
+## [0.14.2](https://github.com/CondeNast/atjson/compare/@atjson/document@0.14.1...@atjson/document@0.14.2) (2019-02-12)
+
+
+### 🐛 Fixes
+
+* 🐝 Allow annotation classes in document constructor ([#106](https://github.com/CondeNast/atjson/issues/106))
+
+
+
+## [0.14.1](https://github.com/CondeNast/atjson/compare/@atjson/document@0.14.0...@atjson/document@0.14.1) (2019-01-14)
 
 
 ### 🐛 Fixes
@@ -92,7 +92,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.13.5...@atjson/document@0.14.0) (2019-01-09)
+## [0.14.0](https://github.com/CondeNast/atjson/compare/@atjson/document@0.13.5...@atjson/document@0.14.0) (2019-01-09)
 
 
 ### ✨ New Features
@@ -106,7 +106,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.13.4...@atjson/document@0.13.5) (2019-01-07)
+## [0.13.5](https://github.com/CondeNast/atjson/compare/@atjson/document@0.13.4...@atjson/document@0.13.5) (2019-01-07)
 
 ### ✨ New Features
 
@@ -116,7 +116,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.13.3...@atjson/document@0.13.4) (2018-12-11)
+## [0.13.4](https://github.com/CondeNast/atjson/compare/@atjson/document@0.13.3...@atjson/document@0.13.4) (2018-12-11)
 
 
 ### 🐛 Fixes
@@ -125,7 +125,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.13.2...@atjson/document@0.13.3) (2018-12-11)
+## [0.13.3](https://github.com/CondeNast/atjson/compare/@atjson/document@0.13.2...@atjson/document@0.13.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/document
 
@@ -133,7 +133,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.13.1...@atjson/document@0.13.2) (2018-12-11)
+## [0.13.2](https://github.com/CondeNast/atjson/compare/@atjson/document@0.13.1...@atjson/document@0.13.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/document
 
@@ -141,35 +141,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.13.0...@atjson/document@0.13.1) (2018-12-11)
+## [0.13.1](https://github.com/CondeNast/atjson/compare/@atjson/document@0.13.0...@atjson/document@0.13.1) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/document
 
 
-## [0.13.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.12.0...@atjson/document@0.13.0) (2018-12-11)
+## [0.13.0](https://github.com/CondeNast/atjson/compare/@atjson/document@0.12.0...@atjson/document@0.13.0) (2018-12-11)
 
 
 ### ✨ New Features
 
-* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast-Copilot/atjson/issues/93))
+* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast/atjson/issues/93))
 
 
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.11.0...@atjson/document@0.12.0) (2018-11-29)
-
-
-### ✨ New Features
-
-* ✨🔮 allow Annotation classes or AnnotationJSON to all Document methods ([#90](https://github.com/CondeNast-Copilot/atjson/issues/90))
-* ✨📡 dynamically convert between types of sources ([#88](https://github.com/CondeNast-Copilot/atjson/issues/88))
-
-
-
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.9.0...@atjson/document@0.11.0) (2018-10-22)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/document@0.11.0...@atjson/document@0.12.0) (2018-11-29)
 
 
 ### ✨ New Features
 
-* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast-Copilot/atjson/issues/57))
+* ✨🔮 allow Annotation classes or AnnotationJSON to all Document methods ([#90](https://github.com/CondeNast/atjson/issues/90))
+* ✨📡 dynamically convert between types of sources ([#88](https://github.com/CondeNast/atjson/issues/88))
+
+
+
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/document@0.9.0...@atjson/document@0.11.0) (2018-10-22)
+
+
+### ✨ New Features
+
+* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast/atjson/issues/57))
 
 
 ### 🚨 Breaking Changes
@@ -189,21 +189,21 @@ A summary of changes are the following:
 🖍 Annotations are now prefixed at rest. For the CommonMark Link annotation, it will be stored as `-commonmark-link` as the `type` and the attributes will be prefixed with `-commonmark` as well, meaning that instead of seeing `href` in the `attributes`, you will see `-commonmark-href`. When the annotation JSON is hydrated into an annotation class, prefixes are automatically removed. This prevents any collisions that may (and will) happen when converting between document types.
 
 
-## [0.9.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.8.7...@atjson/document@0.9.0) (2018-10-10)
+## [0.9.0](https://github.com/CondeNast/atjson/compare/@atjson/document@0.8.7...@atjson/document@0.9.0) (2018-10-10)
 
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))
 
 
 
-## [0.8.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.8.6...@atjson/document@0.8.7) (2018-09-14)
+## [0.8.7](https://github.com/CondeNast/atjson/compare/@atjson/document@0.8.6...@atjson/document@0.8.7) (2018-09-14)
 
 **Note:** Version bump only for package @atjson/document
 
 
-## [0.8.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/document@0.8.5...@atjson/document@0.8.6) (2018-09-07)
+## [0.8.6](https://github.com/CondeNast/atjson/compare/@atjson/document@0.8.5...@atjson/document@0.8.6) (2018-09-07)
 
 ### ✨ New Features
 

--- a/packages/@atjson/editor/CHANGELOG.md
+++ b/packages/@atjson/editor/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.13.20](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.19...@atjson/editor@0.13.20) (2019-04-19)
+## [0.13.20](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.19...@atjson/editor@0.13.20) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.19](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.18...@atjson/editor@0.13.19) (2019-04-18)
+## [0.13.19](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.18...@atjson/editor@0.13.19) (2019-04-18)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.18](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.17...@atjson/editor@0.13.18) (2019-04-16)
+## [0.13.18](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.17...@atjson/editor@0.13.18) (2019-04-16)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.17](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.16...@atjson/editor@0.13.17) (2019-04-15)
+## [0.13.17](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.16...@atjson/editor@0.13.17) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.16](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.15...@atjson/editor@0.13.16) (2019-04-15)
+## [0.13.16](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.15...@atjson/editor@0.13.16) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.15](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.14...@atjson/editor@0.13.15) (2019-04-10)
+## [0.13.15](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.14...@atjson/editor@0.13.15) (2019-04-10)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -51,7 +51,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.14](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.13...@atjson/editor@0.13.14) (2019-03-21)
+## [0.13.14](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.13...@atjson/editor@0.13.14) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -59,7 +59,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.13](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.12...@atjson/editor@0.13.13) (2019-03-19)
+## [0.13.13](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.12...@atjson/editor@0.13.13) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -67,7 +67,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.12](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.11...@atjson/editor@0.13.12) (2019-03-18)
+## [0.13.12](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.11...@atjson/editor@0.13.12) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.10...@atjson/editor@0.13.11) (2019-03-18)
+## [0.13.11](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.10...@atjson/editor@0.13.11) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.9...@atjson/editor@0.13.10) (2019-03-14)
+## [0.13.10](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.9...@atjson/editor@0.13.10) (2019-03-14)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.8...@atjson/editor@0.13.9) (2019-02-27)
+## [0.13.9](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.8...@atjson/editor@0.13.9) (2019-02-27)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -99,7 +99,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.7...@atjson/editor@0.13.8) (2019-02-22)
+## [0.13.8](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.7...@atjson/editor@0.13.8) (2019-02-22)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -107,7 +107,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.6...@atjson/editor@0.13.7) (2019-02-21)
+## [0.13.7](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.6...@atjson/editor@0.13.7) (2019-02-21)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -115,7 +115,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.5...@atjson/editor@0.13.6) (2019-02-15)
+## [0.13.6](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.5...@atjson/editor@0.13.6) (2019-02-15)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -123,7 +123,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.4...@atjson/editor@0.13.5) (2019-02-15)
+## [0.13.5](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.4...@atjson/editor@0.13.5) (2019-02-15)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -131,7 +131,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.3...@atjson/editor@0.13.4) (2019-02-14)
+## [0.13.4](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.3...@atjson/editor@0.13.4) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -139,7 +139,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.2...@atjson/editor@0.13.3) (2019-02-14)
+## [0.13.3](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.2...@atjson/editor@0.13.3) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -147,7 +147,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.1...@atjson/editor@0.13.2) (2019-02-14)
+## [0.13.2](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.1...@atjson/editor@0.13.2) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -155,7 +155,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.13.0...@atjson/editor@0.13.1) (2019-02-12)
+## [0.13.1](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.13.0...@atjson/editor@0.13.1) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -163,7 +163,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.12.8...@atjson/editor@0.13.0) (2019-01-24)
+## [0.13.0](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.12.8...@atjson/editor@0.13.0) (2019-01-24)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -171,7 +171,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.12.7...@atjson/editor@0.12.8) (2019-01-14)
+## [0.12.8](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.12.7...@atjson/editor@0.12.8) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -179,7 +179,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.12.6...@atjson/editor@0.12.7) (2019-01-14)
+## [0.12.7](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.12.6...@atjson/editor@0.12.7) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -187,7 +187,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.12.5...@atjson/editor@0.12.6) (2019-01-09)
+## [0.12.6](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.12.5...@atjson/editor@0.12.6) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -195,7 +195,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.12.4...@atjson/editor@0.12.5) (2019-01-07)
+## [0.12.5](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.12.4...@atjson/editor@0.12.5) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -203,7 +203,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.12.3...@atjson/editor@0.12.4) (2018-12-11)
+## [0.12.4](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.12.3...@atjson/editor@0.12.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -211,7 +211,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.12.2...@atjson/editor@0.12.3) (2018-12-11)
+## [0.12.3](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.12.2...@atjson/editor@0.12.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -219,7 +219,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.12.1...@atjson/editor@0.12.2) (2018-12-11)
+## [0.12.2](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.12.1...@atjson/editor@0.12.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -227,25 +227,17 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.12.0...@atjson/editor@0.12.1) (2018-12-11)
+## [0.12.1](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.12.0...@atjson/editor@0.12.1) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/editor
 
 
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.11.1...@atjson/editor@0.12.0) (2018-12-11)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.11.1...@atjson/editor@0.12.0) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/editor
 
 
-## [0.11.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.11.0...@atjson/editor@0.11.1) (2018-11-29)
-
-**Note:** Version bump only for package @atjson/editor
-
-
-
-
-
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.9.0...@atjson/editor@0.11.0) (2018-10-22)
+## [0.11.1](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.11.0...@atjson/editor@0.11.1) (2018-11-29)
 
 **Note:** Version bump only for package @atjson/editor
 
@@ -253,31 +245,39 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.9.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.8.11...@atjson/editor@0.9.0) (2018-10-10)
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.9.0...@atjson/editor@0.11.0) (2018-10-22)
+
+**Note:** Version bump only for package @atjson/editor
+
+
+
+
+
+## [0.9.0](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.8.11...@atjson/editor@0.9.0) (2018-10-10)
 
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))
 
 
 
-## [0.8.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.8.10...@atjson/editor@0.8.11) (2018-09-14)
-
-**Note:** Version bump only for package @atjson/editor
-
-
-## [0.8.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.8.9...@atjson/editor@0.8.10) (2018-09-07)
+## [0.8.11](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.8.10...@atjson/editor@0.8.11) (2018-09-14)
 
 **Note:** Version bump only for package @atjson/editor
 
 
-## [0.8.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/editor@0.8.8...@atjson/editor@0.8.9) (2018-09-04)
+## [0.8.10](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.8.9...@atjson/editor@0.8.10) (2018-09-07)
+
+**Note:** Version bump only for package @atjson/editor
+
+
+## [0.8.9](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.8.8...@atjson/editor@0.8.9) (2018-09-04)
 
 
 ### 🐛 Fixes
 
-* 🐛🔒 fix vulnerability with with git-dummy-commit by using shelljs directly ([#76](https://github.com/CondeNast-Copilot/atjson/issues/76))
+* 🐛🔒 fix vulnerability with with git-dummy-commit by using shelljs directly ([#76](https://github.com/CondeNast/atjson/issues/76))
 
 
 ## 0.8.8 (2018-08-02)

--- a/packages/@atjson/hir/CHANGELOG.md
+++ b/packages/@atjson/hir/CHANGELOG.md
@@ -3,24 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.17...@atjson/hir@0.12.0) (2019-04-19)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.17...@atjson/hir@0.12.0) (2019-04-19)
 
 
 ### ✨ New Features
 
-* ✨🥃 add an interface for declaring annotation attributes ([#130](https://github.com/CondeNast-Copilot/atjson/issues/130))
+* ✨🥃 add an interface for declaring annotation attributes ([#130](https://github.com/CondeNast/atjson/issues/130))
 
 
 
-## [0.11.17](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.16...@atjson/hir@0.11.17) (2019-04-15)
-
-**Note:** Version bump only for package @atjson/hir
-
-
-
-
-
-## [0.11.16](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.15...@atjson/hir@0.11.16) (2019-04-15)
+## [0.11.17](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.16...@atjson/hir@0.11.17) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/hir
 
@@ -28,24 +20,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.15](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.14...@atjson/hir@0.11.15) (2019-03-21)
+## [0.11.16](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.15...@atjson/hir@0.11.16) (2019-04-15)
+
+**Note:** Version bump only for package @atjson/hir
+
+
+
+
+
+## [0.11.15](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.14...@atjson/hir@0.11.15) (2019-03-21)
 
 
 ### 🐛 Fixes
 
-* 🐝 Fix unknown annotations passing attributes by reference and HIR optimization bug ([#122](https://github.com/CondeNast-Copilot/atjson/issues/122))
+* 🐝 Fix unknown annotations passing attributes by reference and HIR optimization bug ([#122](https://github.com/CondeNast/atjson/issues/122))
 
 
 
-## [0.11.14](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.13...@atjson/hir@0.11.14) (2019-03-19)
-
-**Note:** Version bump only for package @atjson/hir
-
-
-
-
-
-## [0.11.13](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.12...@atjson/hir@0.11.13) (2019-03-18)
+## [0.11.14](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.13...@atjson/hir@0.11.14) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/hir
 
@@ -53,33 +45,33 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.12](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.11...@atjson/hir@0.11.12) (2019-03-18)
+## [0.11.13](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.12...@atjson/hir@0.11.13) (2019-03-18)
+
+**Note:** Version bump only for package @atjson/hir
+
+
+
+
+
+## [0.11.12](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.11...@atjson/hir@0.11.12) (2019-03-18)
 
 
 ### 🐛 Fixes
 
-* 🚀🐛 Performance fixes ([#119](https://github.com/CondeNast-Copilot/atjson/issues/119))
+* 🚀🐛 Performance fixes ([#119](https://github.com/CondeNast/atjson/issues/119))
 
 
 
-## [0.11.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.10...@atjson/hir@0.11.11) (2019-03-14)
+## [0.11.11](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.10...@atjson/hir@0.11.11) (2019-03-14)
 
 
 ### 🐛 Fixes
 
-* 🐝🚀 Fix performance regressions ([#118](https://github.com/CondeNast-Copilot/atjson/issues/118))
+* 🐝🚀 Fix performance regressions ([#118](https://github.com/CondeNast/atjson/issues/118))
 
 
 
-## [0.11.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.9...@atjson/hir@0.11.10) (2019-02-12)
-
-**Note:** Version bump only for package @atjson/hir
-
-
-
-
-
-## [0.11.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.8...@atjson/hir@0.11.9) (2019-01-14)
+## [0.11.10](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.9...@atjson/hir@0.11.10) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/hir
 
@@ -87,7 +79,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.7...@atjson/hir@0.11.8) (2019-01-09)
+## [0.11.9](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.8...@atjson/hir@0.11.9) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/hir
 
@@ -95,7 +87,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.6...@atjson/hir@0.11.7) (2019-01-07)
+## [0.11.8](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.7...@atjson/hir@0.11.8) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/hir
 
@@ -103,7 +95,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.5...@atjson/hir@0.11.6) (2018-12-11)
+## [0.11.7](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.6...@atjson/hir@0.11.7) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/hir
 
@@ -111,7 +103,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.4...@atjson/hir@0.11.5) (2018-12-11)
+## [0.11.6](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.5...@atjson/hir@0.11.6) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/hir
 
@@ -119,7 +111,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.3...@atjson/hir@0.11.4) (2018-12-11)
+## [0.11.5](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.4...@atjson/hir@0.11.5) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/hir
 
@@ -127,7 +119,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.2...@atjson/hir@0.11.3) (2018-12-11)
+## [0.11.4](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.3...@atjson/hir@0.11.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/hir
 
@@ -135,12 +127,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.1...@atjson/hir@0.11.2) (2018-12-11)
+## [0.11.3](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.2...@atjson/hir@0.11.3) (2018-12-11)
+
+**Note:** Version bump only for package @atjson/hir
+
+
+
+
+
+## [0.11.2](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.1...@atjson/hir@0.11.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/editor
 
 
-## [0.11.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.11.0...@atjson/hir@0.11.1) (2018-11-29)
+## [0.11.1](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.11.0...@atjson/hir@0.11.1) (2018-11-29)
 
 **Note:** Version bump only for package @atjson/hir
 
@@ -148,33 +148,33 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.9.0...@atjson/hir@0.11.0) (2018-10-22)
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.9.0...@atjson/hir@0.11.0) (2018-10-22)
 
 
 ### ✨ New Features
 
-* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast-Copilot/atjson/issues/57))
+* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast/atjson/issues/57))
 
 
-## [0.9.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.8.10...@atjson/hir@0.9.0) (2018-10-10)
+## [0.9.0](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.8.10...@atjson/hir@0.9.0) (2018-10-10)
 
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))
 
 
 
-## [0.8.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.8.9...@atjson/hir@0.8.10) (2018-09-14)
-
-**Note:** Version bump only for package @atjson/hir
-
-## [0.8.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.8.8...@atjson/hir@0.8.9) (2018-09-07)
+## [0.8.10](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.8.9...@atjson/hir@0.8.10) (2018-09-14)
 
 **Note:** Version bump only for package @atjson/hir
 
+## [0.8.9](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.8.8...@atjson/hir@0.8.9) (2018-09-07)
 
-## [0.8.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/hir@0.8.7...@atjson/hir@0.8.8) (2018-09-04)
+**Note:** Version bump only for package @atjson/hir
+
+
+## [0.8.8](https://github.com/CondeNast/atjson/compare/@atjson/hir@0.8.7...@atjson/hir@0.8.8) (2018-09-04)
 
 **Note:** Version bump only for package @atjson/hir
 

--- a/packages/@atjson/hir/package.json
+++ b/packages/@atjson/hir/package.json
@@ -6,7 +6,7 @@
     "Blaine Cook <blaine_cook@condenast.com>",
     "Tim Evans <tim_evans@condenast.com>"
   ],
-  "repository": "https://github.com/CondeNast-Copilot/atjson",
+  "repository": "https://github.com/CondeNast/atjson",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
   "types": "dist/commonjs/index.d.ts",

--- a/packages/@atjson/offset-annotations/CHANGELOG.md
+++ b/packages/@atjson/offset-annotations/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.14.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.14.0...@atjson/offset-annotations@0.14.1) (2019-04-19)
+## [0.14.1](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.14.0...@atjson/offset-annotations@0.14.1) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
@@ -11,24 +11,16 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.18...@atjson/offset-annotations@0.14.0) (2019-04-18)
+## [0.14.0](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.18...@atjson/offset-annotations@0.14.0) (2019-04-18)
 
 
 ### ✨ New Features
 
-* ✨ ⛱  add sandbox to iframe-embed attributes ([#129](https://github.com/CondeNast-Copilot/atjson/issues/129))
+* ✨ ⛱  add sandbox to iframe-embed attributes ([#129](https://github.com/CondeNast/atjson/issues/129))
 
 
 
-## [0.13.18](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.17...@atjson/offset-annotations@0.13.18) (2019-04-15)
-
-**Note:** Version bump only for package @atjson/offset-annotations
-
-
-
-
-
-## [0.13.17](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.16...@atjson/offset-annotations@0.13.17) (2019-04-15)
+## [0.13.18](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.17...@atjson/offset-annotations@0.13.18) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
@@ -36,7 +28,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.16](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.15...@atjson/offset-annotations@0.13.16) (2019-03-21)
+## [0.13.17](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.16...@atjson/offset-annotations@0.13.17) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
@@ -44,7 +36,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.15](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.14...@atjson/offset-annotations@0.13.15) (2019-03-19)
+## [0.13.16](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.15...@atjson/offset-annotations@0.13.16) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
@@ -52,7 +44,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.14](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.13...@atjson/offset-annotations@0.13.14) (2019-03-18)
+## [0.13.15](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.14...@atjson/offset-annotations@0.13.15) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
@@ -60,7 +52,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.13](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.12...@atjson/offset-annotations@0.13.13) (2019-03-18)
+## [0.13.14](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.13...@atjson/offset-annotations@0.13.14) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
@@ -68,7 +60,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.12](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.11...@atjson/offset-annotations@0.13.12) (2019-03-14)
+## [0.13.13](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.12...@atjson/offset-annotations@0.13.13) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
@@ -76,7 +68,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.10...@atjson/offset-annotations@0.13.11) (2019-02-27)
+## [0.13.12](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.11...@atjson/offset-annotations@0.13.12) (2019-03-14)
+
+**Note:** Version bump only for package @atjson/offset-annotations
+
+
+
+
+
+## [0.13.11](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.10...@atjson/offset-annotations@0.13.11) (2019-02-27)
 
 
 ### 🐛 Fixes
@@ -85,33 +85,25 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.9...@atjson/offset-annotations@0.13.10) (2019-02-14)
+## [0.13.10](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.9...@atjson/offset-annotations@0.13.10) (2019-02-14)
 
 
 ### 🐛 Fixes
 
-* 🐝 Fix imports ([#110](https://github.com/CondeNast-Copilot/atjson/issues/110))
+* 🐝 Fix imports ([#110](https://github.com/CondeNast/atjson/issues/110))
 
 
 
-## [0.13.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.8...@atjson/offset-annotations@0.13.9) (2019-02-14)
+## [0.13.9](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.8...@atjson/offset-annotations@0.13.9) (2019-02-14)
 
 
 ### 🐛 Fixes
 
-* 🐝 Add missing CaptionSource and captions to iframe embeds ([#109](https://github.com/CondeNast-Copilot/atjson/issues/109))
+* 🐝 Add missing CaptionSource and captions to iframe embeds ([#109](https://github.com/CondeNast/atjson/issues/109))
 
 
 
-## [0.13.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.7...@atjson/offset-annotations@0.13.8) (2019-02-12)
-
-**Note:** Version bump only for package @atjson/offset-annotations
-
-
-
-
-
-## [0.13.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.6...@atjson/offset-annotations@0.13.7) (2019-01-14)
+## [0.13.8](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.7...@atjson/offset-annotations@0.13.8) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
@@ -119,7 +111,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.5...@atjson/offset-annotations@0.13.6) (2019-01-09)
+## [0.13.7](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.6...@atjson/offset-annotations@0.13.7) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
@@ -127,7 +119,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.4...@atjson/offset-annotations@0.13.5) (2019-01-07)
+## [0.13.6](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.5...@atjson/offset-annotations@0.13.6) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
@@ -135,7 +127,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.3...@atjson/offset-annotations@0.13.4) (2018-12-11)
+## [0.13.5](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.4...@atjson/offset-annotations@0.13.5) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
@@ -143,7 +135,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.2...@atjson/offset-annotations@0.13.3) (2018-12-11)
+## [0.13.4](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.3...@atjson/offset-annotations@0.13.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
@@ -151,7 +143,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.1...@atjson/offset-annotations@0.13.2) (2018-12-11)
+## [0.13.3](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.2...@atjson/offset-annotations@0.13.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
@@ -159,27 +151,35 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.13.0...@atjson/offset-annotations@0.13.1) (2018-12-11)
+## [0.13.2](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.1...@atjson/offset-annotations@0.13.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/offset-annotations
 
 
 
-## [0.13.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.12.0...@atjson/offset-annotations@0.13.0) (2018-12-11)
+
+
+## [0.13.1](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.13.0...@atjson/offset-annotations@0.13.1) (2018-12-11)
+
+**Note:** Version bump only for package @atjson/offset-annotations
+
+
+
+## [0.13.0](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.12.0...@atjson/offset-annotations@0.13.0) (2018-12-11)
 
 
 ### ✨ New Features
 
-* ✨👩‍💻 Auto-unfurl URLs that are pasted in into an embed ([#87](https://github.com/CondeNast-Copilot/atjson/issues/87))
+* ✨👩‍💻 Auto-unfurl URLs that are pasted in into an embed ([#87](https://github.com/CondeNast/atjson/issues/87))
 
 
 
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-annotations@0.11.0...@atjson/offset-annotations@0.12.0) (2018-11-29)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/offset-annotations@0.11.0...@atjson/offset-annotations@0.12.0) (2018-11-29)
 
 
 ### ✨ New Features
 
-* ✨📡 dynamically convert between types of sources ([#88](https://github.com/CondeNast-Copilot/atjson/issues/88))
+* ✨📡 dynamically convert between types of sources ([#88](https://github.com/CondeNast/atjson/issues/88))
 
 
 
@@ -188,4 +188,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ✨ New Features
 
-* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast-Copilot/atjson/issues/57))
+* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast/atjson/issues/57))

--- a/packages/@atjson/offset-core-components/CHANGELOG.md
+++ b/packages/@atjson/offset-core-components/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.11.19](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.18...@atjson/offset-core-components@0.11.19) (2019-04-19)
+## [0.11.19](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.18...@atjson/offset-core-components@0.11.19) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.18](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.17...@atjson/offset-core-components@0.11.18) (2019-04-16)
+## [0.11.18](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.17...@atjson/offset-core-components@0.11.18) (2019-04-16)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.17](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.16...@atjson/offset-core-components@0.11.17) (2019-04-15)
+## [0.11.17](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.16...@atjson/offset-core-components@0.11.17) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -27,24 +27,16 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.16](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.15...@atjson/offset-core-components@0.11.16) (2019-04-15)
+## [0.11.16](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.15...@atjson/offset-core-components@0.11.16) (2019-04-15)
 
 
 ### 🐛 Fixes
 
-* 🐝 fix slice so it only includes overlapping annotations from the parent document and the correct underlying text ([#125](https://github.com/CondeNast-Copilot/atjson/issues/125))
+* 🐝 fix slice so it only includes overlapping annotations from the parent document and the correct underlying text ([#125](https://github.com/CondeNast/atjson/issues/125))
 
 
 
-## [0.11.15](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.14...@atjson/offset-core-components@0.11.15) (2019-03-21)
-
-**Note:** Version bump only for package @atjson/offset-core-components
-
-
-
-
-
-## [0.11.14](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.13...@atjson/offset-core-components@0.11.14) (2019-03-19)
+## [0.11.15](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.14...@atjson/offset-core-components@0.11.15) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -52,7 +44,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.13](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.12...@atjson/offset-core-components@0.11.13) (2019-03-18)
+## [0.11.14](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.13...@atjson/offset-core-components@0.11.14) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -60,7 +52,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.12](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.11...@atjson/offset-core-components@0.11.12) (2019-03-18)
+## [0.11.13](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.12...@atjson/offset-core-components@0.11.13) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -68,7 +60,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.10...@atjson/offset-core-components@0.11.11) (2019-03-14)
+## [0.11.12](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.11...@atjson/offset-core-components@0.11.12) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -76,7 +68,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.9...@atjson/offset-core-components@0.11.10) (2019-02-12)
+## [0.11.11](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.10...@atjson/offset-core-components@0.11.11) (2019-03-14)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -84,7 +76,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.8...@atjson/offset-core-components@0.11.9) (2019-01-14)
+## [0.11.10](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.9...@atjson/offset-core-components@0.11.10) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -92,7 +84,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.7...@atjson/offset-core-components@0.11.8) (2019-01-09)
+## [0.11.9](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.8...@atjson/offset-core-components@0.11.9) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -100,7 +92,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.6...@atjson/offset-core-components@0.11.7) (2019-01-07)
+## [0.11.8](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.7...@atjson/offset-core-components@0.11.8) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -108,7 +100,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.5...@atjson/offset-core-components@0.11.6) (2018-12-11)
+## [0.11.7](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.6...@atjson/offset-core-components@0.11.7) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -116,7 +108,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.4...@atjson/offset-core-components@0.11.5) (2018-12-11)
+## [0.11.6](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.5...@atjson/offset-core-components@0.11.6) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -124,7 +116,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.3...@atjson/offset-core-components@0.11.4) (2018-12-11)
+## [0.11.5](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.4...@atjson/offset-core-components@0.11.5) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -132,7 +124,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.2...@atjson/offset-core-components@0.11.3) (2018-12-11)
+## [0.11.4](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.3...@atjson/offset-core-components@0.11.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
@@ -140,20 +132,28 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.1...@atjson/offset-core-components@0.11.2) (2018-12-11)
+## [0.11.3](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.2...@atjson/offset-core-components@0.11.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
 
-## [0.11.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.11.0...@atjson/offset-core-components@0.11.1) (2018-11-29)
+
+
+
+## [0.11.2](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.1...@atjson/offset-core-components@0.11.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/offset-core-components
 
 
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-core-components@0.9.0...@atjson/offset-core-components@0.11.0) (2018-10-22)
+## [0.11.1](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.11.0...@atjson/offset-core-components@0.11.1) (2018-11-29)
+
+**Note:** Version bump only for package @atjson/offset-core-components
+
+
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/offset-core-components@0.9.0...@atjson/offset-core-components@0.11.0) (2018-10-22)
 
 ## 0.9.0 (2018-10-10)
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))

--- a/packages/@atjson/offset-inspector/CHANGELOG.md
+++ b/packages/@atjson/offset-inspector/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.12.20](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.19...@atjson/offset-inspector@0.12.20) (2019-04-19)
+## [0.12.20](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.19...@atjson/offset-inspector@0.12.20) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.19](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.18...@atjson/offset-inspector@0.12.19) (2019-04-18)
+## [0.12.19](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.18...@atjson/offset-inspector@0.12.19) (2019-04-18)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.18](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.17...@atjson/offset-inspector@0.12.18) (2019-04-16)
+## [0.12.18](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.17...@atjson/offset-inspector@0.12.18) (2019-04-16)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.17](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.16...@atjson/offset-inspector@0.12.17) (2019-04-15)
+## [0.12.17](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.16...@atjson/offset-inspector@0.12.17) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -35,24 +35,16 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.16](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.15...@atjson/offset-inspector@0.12.16) (2019-04-15)
+## [0.12.16](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.15...@atjson/offset-inspector@0.12.16) (2019-04-15)
 
 
 ### 🐛 Fixes
 
-* 🐝 fix slice so it only includes overlapping annotations from the parent document and the correct underlying text ([#125](https://github.com/CondeNast-Copilot/atjson/issues/125))
+* 🐝 fix slice so it only includes overlapping annotations from the parent document and the correct underlying text ([#125](https://github.com/CondeNast/atjson/issues/125))
 
 
 
-## [0.12.15](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.14...@atjson/offset-inspector@0.12.15) (2019-04-10)
-
-**Note:** Version bump only for package @atjson/offset-inspector
-
-
-
-
-
-## [0.12.14](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.13...@atjson/offset-inspector@0.12.14) (2019-03-21)
+## [0.12.15](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.14...@atjson/offset-inspector@0.12.15) (2019-04-10)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -60,7 +52,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.13](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.12...@atjson/offset-inspector@0.12.13) (2019-03-19)
+## [0.12.14](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.13...@atjson/offset-inspector@0.12.14) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -68,7 +60,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.12](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.11...@atjson/offset-inspector@0.12.12) (2019-03-18)
+## [0.12.13](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.12...@atjson/offset-inspector@0.12.13) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -76,7 +68,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.10...@atjson/offset-inspector@0.12.11) (2019-03-18)
+## [0.12.12](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.11...@atjson/offset-inspector@0.12.12) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -84,7 +76,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.9...@atjson/offset-inspector@0.12.10) (2019-03-14)
+## [0.12.11](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.10...@atjson/offset-inspector@0.12.11) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -92,7 +84,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.8...@atjson/offset-inspector@0.12.9) (2019-02-27)
+## [0.12.10](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.9...@atjson/offset-inspector@0.12.10) (2019-03-14)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -100,7 +92,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.7...@atjson/offset-inspector@0.12.8) (2019-02-22)
+## [0.12.9](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.8...@atjson/offset-inspector@0.12.9) (2019-02-27)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -108,7 +100,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.6...@atjson/offset-inspector@0.12.7) (2019-02-21)
+## [0.12.8](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.7...@atjson/offset-inspector@0.12.8) (2019-02-22)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -116,7 +108,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.5...@atjson/offset-inspector@0.12.6) (2019-02-15)
+## [0.12.7](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.6...@atjson/offset-inspector@0.12.7) (2019-02-21)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -124,7 +116,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.4...@atjson/offset-inspector@0.12.5) (2019-02-15)
+## [0.12.6](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.5...@atjson/offset-inspector@0.12.6) (2019-02-15)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -132,7 +124,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.3...@atjson/offset-inspector@0.12.4) (2019-02-14)
+## [0.12.5](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.4...@atjson/offset-inspector@0.12.5) (2019-02-15)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -140,7 +132,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.2...@atjson/offset-inspector@0.12.3) (2019-02-14)
+## [0.12.4](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.3...@atjson/offset-inspector@0.12.4) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -148,7 +140,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.1...@atjson/offset-inspector@0.12.2) (2019-02-14)
+## [0.12.3](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.2...@atjson/offset-inspector@0.12.3) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -156,7 +148,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.12.0...@atjson/offset-inspector@0.12.1) (2019-02-12)
+## [0.12.2](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.1...@atjson/offset-inspector@0.12.2) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -164,7 +156,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.11.10...@atjson/offset-inspector@0.12.0) (2019-01-24)
+## [0.12.1](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.12.0...@atjson/offset-inspector@0.12.1) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -172,7 +164,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.11.9...@atjson/offset-inspector@0.11.10) (2019-01-14)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.11.10...@atjson/offset-inspector@0.12.0) (2019-01-24)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -180,7 +172,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.11.8...@atjson/offset-inspector@0.11.9) (2019-01-14)
+## [0.11.10](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.11.9...@atjson/offset-inspector@0.11.10) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -188,7 +180,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.11.7...@atjson/offset-inspector@0.11.8) (2019-01-09)
+## [0.11.9](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.11.8...@atjson/offset-inspector@0.11.9) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -196,7 +188,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.11.6...@atjson/offset-inspector@0.11.7) (2019-01-07)
+## [0.11.8](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.11.7...@atjson/offset-inspector@0.11.8) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -204,7 +196,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.11.5...@atjson/offset-inspector@0.11.6) (2018-12-11)
+## [0.11.7](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.11.6...@atjson/offset-inspector@0.11.7) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -212,7 +204,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.11.4...@atjson/offset-inspector@0.11.5) (2018-12-11)
+## [0.11.6](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.11.5...@atjson/offset-inspector@0.11.6) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -220,7 +212,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.11.3...@atjson/offset-inspector@0.11.4) (2018-12-11)
+## [0.11.5](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.11.4...@atjson/offset-inspector@0.11.5) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -228,7 +220,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.11.2...@atjson/offset-inspector@0.11.3) (2018-12-11)
+## [0.11.4](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.11.3...@atjson/offset-inspector@0.11.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -236,12 +228,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.11.1...@atjson/offset-inspector@0.11.2) (2018-12-11)
-
-**Note:** Version bump only for package @atjson/offset-inspector
-
-
-## [0.11.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.11.0...@atjson/offset-inspector@0.11.1) (2018-11-29)
+## [0.11.3](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.11.2...@atjson/offset-inspector@0.11.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -249,7 +236,20 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/offset-inspector@0.9.0...@atjson/offset-inspector@0.11.0) (2018-10-22)
+## [0.11.2](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.11.1...@atjson/offset-inspector@0.11.2) (2018-12-11)
+
+**Note:** Version bump only for package @atjson/offset-inspector
+
+
+## [0.11.1](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.11.0...@atjson/offset-inspector@0.11.1) (2018-11-29)
+
+**Note:** Version bump only for package @atjson/offset-inspector
+
+
+
+
+
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.9.0...@atjson/offset-inspector@0.11.0) (2018-10-22)
 
 **Note:** Version bump only for package @atjson/offset-inspector
 
@@ -262,4 +262,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))

--- a/packages/@atjson/renderer-commonmark/CHANGELOG.md
+++ b/packages/@atjson/renderer-commonmark/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.15.18](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.17...@atjson/renderer-commonmark@0.15.18) (2019-04-19)
+## [0.15.18](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.17...@atjson/renderer-commonmark@0.15.18) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.17](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.16...@atjson/renderer-commonmark@0.15.17) (2019-04-18)
+## [0.15.17](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.16...@atjson/renderer-commonmark@0.15.17) (2019-04-18)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.16](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.15...@atjson/renderer-commonmark@0.15.16) (2019-04-16)
+## [0.15.16](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.15...@atjson/renderer-commonmark@0.15.16) (2019-04-16)
 
 
 ### 🐛 Fixes
@@ -28,7 +28,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.15](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.14...@atjson/renderer-commonmark@0.15.15) (2019-04-15)
+## [0.15.15](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.14...@atjson/renderer-commonmark@0.15.15) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -36,7 +36,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.14](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.13...@atjson/renderer-commonmark@0.15.14) (2019-04-15)
+## [0.15.14](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.13...@atjson/renderer-commonmark@0.15.14) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -44,7 +44,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.13](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.12...@atjson/renderer-commonmark@0.15.13) (2019-04-10)
+## [0.15.13](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.12...@atjson/renderer-commonmark@0.15.13) (2019-04-10)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -52,7 +52,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.12](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.11...@atjson/renderer-commonmark@0.15.12) (2019-03-21)
+## [0.15.12](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.11...@atjson/renderer-commonmark@0.15.12) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -60,7 +60,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.10...@atjson/renderer-commonmark@0.15.11) (2019-03-19)
+## [0.15.11](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.10...@atjson/renderer-commonmark@0.15.11) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -68,7 +68,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.9...@atjson/renderer-commonmark@0.15.10) (2019-03-18)
+## [0.15.10](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.9...@atjson/renderer-commonmark@0.15.10) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -76,25 +76,25 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.8...@atjson/renderer-commonmark@0.15.9) (2019-03-18)
+## [0.15.9](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.8...@atjson/renderer-commonmark@0.15.9) (2019-03-18)
 
 
 ### 🐛 Fixes
 
-* 🚀🐛 Performance fixes ([#119](https://github.com/CondeNast-Copilot/atjson/issues/119))
+* 🚀🐛 Performance fixes ([#119](https://github.com/CondeNast/atjson/issues/119))
 
 
 
-## [0.15.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.7...@atjson/renderer-commonmark@0.15.8) (2019-03-14)
+## [0.15.8](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.7...@atjson/renderer-commonmark@0.15.8) (2019-03-14)
 
 
 ### 🐛 Fixes
 
-* 🐝🚀 Fix performance regressions ([#118](https://github.com/CondeNast-Copilot/atjson/issues/118))
+* 🐝🚀 Fix performance regressions ([#118](https://github.com/CondeNast/atjson/issues/118))
 
 
 
-## [0.15.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.6...@atjson/renderer-commonmark@0.15.7) (2019-02-27)
+## [0.15.7](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.6...@atjson/renderer-commonmark@0.15.7) (2019-02-27)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -102,7 +102,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.5...@atjson/renderer-commonmark@0.15.6) (2019-02-22)
+## [0.15.6](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.5...@atjson/renderer-commonmark@0.15.6) (2019-02-22)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -110,25 +110,25 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.4...@atjson/renderer-commonmark@0.15.5) (2019-02-21)
+## [0.15.5](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.4...@atjson/renderer-commonmark@0.15.5) (2019-02-21)
 
 
 ### 🐛 Fixes
 
-* 🐝 Preserve space before sentence-terminating number ([#114](https://github.com/CondeNast-Copilot/atjson/issues/114))
+* 🐝 Preserve space before sentence-terminating number ([#114](https://github.com/CondeNast/atjson/issues/114))
 
 
 
-## [0.15.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.3...@atjson/renderer-commonmark@0.15.4) (2019-02-15)
+## [0.15.4](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.3...@atjson/renderer-commonmark@0.15.4) (2019-02-15)
 
 
 ### 🐛 Fixes
 
-* 🐝 Export punctuation utils ([#113](https://github.com/CondeNast-Copilot/atjson/issues/113))
+* 🐝 Export punctuation utils ([#113](https://github.com/CondeNast/atjson/issues/113))
 
 
 
-## [0.15.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.2...@atjson/renderer-commonmark@0.15.3) (2019-02-15)
+## [0.15.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.2...@atjson/renderer-commonmark@0.15.3) (2019-02-15)
 
 
 ### 🐛 Fixes
@@ -137,7 +137,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.1...@atjson/renderer-commonmark@0.15.2) (2019-02-14)
+## [0.15.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.1...@atjson/renderer-commonmark@0.15.2) (2019-02-14)
 
 
 ### 🐛 Fixes
@@ -146,7 +146,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.15.0...@atjson/renderer-commonmark@0.15.1) (2019-02-14)
+## [0.15.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.15.0...@atjson/renderer-commonmark@0.15.1) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -154,16 +154,16 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.14.1...@atjson/renderer-commonmark@0.15.0) (2019-02-14)
+## [0.15.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.14.1...@atjson/renderer-commonmark@0.15.0) (2019-02-14)
 
 
 ### ✨ New Features
 
-* 🍢✨ Allow using classified names for rendering hooks (`Bold` & `bold` / `GiphyEmbed` & `giphy-embed`) ([#107](https://github.com/CondeNast-Copilot/atjson/issues/107))
+* 🍢✨ Allow using classified names for rendering hooks (`Bold` & `bold` / `GiphyEmbed` & `giphy-embed`) ([#107](https://github.com/CondeNast/atjson/issues/107))
 
 
 
-## [0.14.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.14.0...@atjson/renderer-commonmark@0.14.1) (2019-02-12)
+## [0.14.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.14.0...@atjson/renderer-commonmark@0.14.1) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -171,24 +171,16 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.13.8...@atjson/renderer-commonmark@0.14.0) (2019-01-24)
+## [0.14.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.13.8...@atjson/renderer-commonmark@0.14.0) (2019-01-24)
 
 
 ### 🐛 Fixes
 
-* 🐝 : Fix bug for rendering invalid delimiter runs ([#103](https://github.com/CondeNast-Copilot/atjson/issues/103))
+* 🐝 : Fix bug for rendering invalid delimiter runs ([#103](https://github.com/CondeNast/atjson/issues/103))
 
 
 
-## [0.13.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.13.7...@atjson/renderer-commonmark@0.13.8) (2019-01-14)
-
-**Note:** Version bump only for package @atjson/renderer-commonmark
-
-
-
-
-
-## [0.13.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.13.6...@atjson/renderer-commonmark@0.13.7) (2019-01-14)
+## [0.13.8](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.13.7...@atjson/renderer-commonmark@0.13.8) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -196,24 +188,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.13.5...@atjson/renderer-commonmark@0.13.6) (2019-01-09)
+## [0.13.7](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.13.6...@atjson/renderer-commonmark@0.13.7) (2019-01-14)
+
+**Note:** Version bump only for package @atjson/renderer-commonmark
+
+
+
+
+
+## [0.13.6](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.13.5...@atjson/renderer-commonmark@0.13.6) (2019-01-09)
 
 
 ### 🐛 Fixes
 
-* 🐛 Limit markdown escape sequences for [] and numbers followed by . ([#95](https://github.com/CondeNast-Copilot/atjson/issues/95))
+* 🐛 Limit markdown escape sequences for [] and numbers followed by . ([#95](https://github.com/CondeNast/atjson/issues/95))
 
 
 
-## [0.13.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.13.4...@atjson/renderer-commonmark@0.13.5) (2019-01-07)
-
-**Note:** Version bump only for package @atjson/renderer-commonmark
-
-
-
-
-
-## [0.13.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.13.3...@atjson/renderer-commonmark@0.13.4) (2018-12-11)
+## [0.13.5](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.13.4...@atjson/renderer-commonmark@0.13.5) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -221,7 +213,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.13.2...@atjson/renderer-commonmark@0.13.3) (2018-12-11)
+## [0.13.4](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.13.3...@atjson/renderer-commonmark@0.13.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -229,7 +221,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.13.1...@atjson/renderer-commonmark@0.13.2) (2018-12-11)
+## [0.13.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.13.2...@atjson/renderer-commonmark@0.13.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -237,7 +229,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.13.0...@atjson/renderer-commonmark@0.13.1) (2018-12-11)
+## [0.13.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.13.1...@atjson/renderer-commonmark@0.13.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
@@ -245,60 +237,68 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.12.0...@atjson/renderer-commonmark@0.13.0) (2018-12-11)
+## [0.13.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.13.0...@atjson/renderer-commonmark@0.13.1) (2018-12-11)
+
+**Note:** Version bump only for package @atjson/renderer-commonmark
+
+
+
+
+
+## [0.13.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.12.0...@atjson/renderer-commonmark@0.13.0) (2018-12-11)
 
 
 ### ✨ New Features
 
-* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast-Copilot/atjson/issues/93))
+* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast/atjson/issues/93))
 
 
 
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.11.0...@atjson/renderer-commonmark@0.12.0) (2018-11-29)
-
-
-### ✨ New Features
-
-* ✨📡 dynamically convert between types of sources ([#88](https://github.com/CondeNast-Copilot/atjson/issues/88))
-
-
-
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.10.0...@atjson/renderer-commonmark@0.11.0) (2018-10-22)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.11.0...@atjson/renderer-commonmark@0.12.0) (2018-11-29)
 
 
 ### ✨ New Features
 
-* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast-Copilot/atjson/issues/57))
+* ✨📡 dynamically convert between types of sources ([#88](https://github.com/CondeNast/atjson/issues/88))
 
 
-## [0.10.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.9.4...@atjson/renderer-commonmark@0.10.0) (2018-10-10)
+
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.10.0...@atjson/renderer-commonmark@0.11.0) (2018-10-22)
 
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast/atjson/issues/57))
+
+
+## [0.10.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.9.4...@atjson/renderer-commonmark@0.10.0) (2018-10-10)
+
+
+### ✨ New Features
+
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))
 
 
 
-## [0.9.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.9.3...@atjson/renderer-commonmark@0.9.4) (2018-09-14)
+## [0.9.4](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.9.3...@atjson/renderer-commonmark@0.9.4) (2018-09-14)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
 
-## [0.9.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.9.2...@atjson/renderer-commonmark@0.9.3) (2018-09-07)
+## [0.9.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.9.2...@atjson/renderer-commonmark@0.9.3) (2018-09-07)
 
 
 ### 🐛 Fixes
 
-* 💣🐛 Remove common punctuation from escaped chars ([#77](https://github.com/CondeNast-Copilot/atjson/issues/77))
+* 💣🐛 Remove common punctuation from escaped chars ([#77](https://github.com/CondeNast/atjson/issues/77))
 
 
-## [0.9.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.9.1...@atjson/renderer-commonmark@0.9.2) (2018-09-04)
+## [0.9.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.9.1...@atjson/renderer-commonmark@0.9.2) (2018-09-04)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
 
-## [0.9.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.9.0...@atjson/renderer-commonmark@0.9.1) (2018-08-07)
+## [0.9.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.9.0...@atjson/renderer-commonmark@0.9.1) (2018-08-07)
 
 
 ### 🐛 Fixes
@@ -311,7 +311,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ✨ New Features
 
-* ✨ allow a HIR to be passed to a renderer ([#73](https://github.com/CondeNast-Copilot/atjson/issues/73))
+* ✨ allow a HIR to be passed to a renderer ([#73](https://github.com/CondeNast/atjson/issues/73))
 
 ## 0.8.4 (2018-07-25)
 

--- a/packages/@atjson/renderer-graphviz/CHANGELOG.md
+++ b/packages/@atjson/renderer-graphviz/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.12.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.12.8...@atjson/renderer-graphviz@0.12.9) (2019-04-19)
+## [0.12.9](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.12.8...@atjson/renderer-graphviz@0.12.9) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.12.7...@atjson/renderer-graphviz@0.12.8) (2019-04-15)
+## [0.12.8](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.12.7...@atjson/renderer-graphviz@0.12.8) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.12.6...@atjson/renderer-graphviz@0.12.7) (2019-04-15)
+## [0.12.7](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.12.6...@atjson/renderer-graphviz@0.12.7) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.12.5...@atjson/renderer-graphviz@0.12.6) (2019-03-21)
+## [0.12.6](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.12.5...@atjson/renderer-graphviz@0.12.6) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.12.4...@atjson/renderer-graphviz@0.12.5) (2019-03-19)
+## [0.12.5](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.12.4...@atjson/renderer-graphviz@0.12.5) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.12.3...@atjson/renderer-graphviz@0.12.4) (2019-03-18)
+## [0.12.4](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.12.3...@atjson/renderer-graphviz@0.12.4) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -51,33 +51,25 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.12.2...@atjson/renderer-graphviz@0.12.3) (2019-03-18)
+## [0.12.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.12.2...@atjson/renderer-graphviz@0.12.3) (2019-03-18)
 
 
 ### 🐛 Fixes
 
-* 🚀🐛 Performance fixes ([#119](https://github.com/CondeNast-Copilot/atjson/issues/119))
+* 🚀🐛 Performance fixes ([#119](https://github.com/CondeNast/atjson/issues/119))
 
 
 
-## [0.12.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.12.1...@atjson/renderer-graphviz@0.12.2) (2019-03-14)
+## [0.12.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.12.1...@atjson/renderer-graphviz@0.12.2) (2019-03-14)
 
 
 ### 🐛 Fixes
 
-* 🐝🚀 Fix performance regressions ([#118](https://github.com/CondeNast-Copilot/atjson/issues/118))
+* 🐝🚀 Fix performance regressions ([#118](https://github.com/CondeNast/atjson/issues/118))
 
 
 
-## [0.12.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.12.0...@atjson/renderer-graphviz@0.12.1) (2019-02-12)
-
-**Note:** Version bump only for package @atjson/renderer-graphviz
-
-
-
-
-
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.11.9...@atjson/renderer-graphviz@0.12.0) (2019-01-24)
+## [0.12.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.12.0...@atjson/renderer-graphviz@0.12.1) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -85,7 +77,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.11.8...@atjson/renderer-graphviz@0.11.9) (2019-01-14)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.11.9...@atjson/renderer-graphviz@0.12.0) (2019-01-24)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -93,7 +85,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.11.7...@atjson/renderer-graphviz@0.11.8) (2019-01-09)
+## [0.11.9](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.11.8...@atjson/renderer-graphviz@0.11.9) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -101,7 +93,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.11.6...@atjson/renderer-graphviz@0.11.7) (2019-01-07)
+## [0.11.8](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.11.7...@atjson/renderer-graphviz@0.11.8) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -109,7 +101,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.11.5...@atjson/renderer-graphviz@0.11.6) (2018-12-11)
+## [0.11.7](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.11.6...@atjson/renderer-graphviz@0.11.7) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -117,7 +109,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.11.4...@atjson/renderer-graphviz@0.11.5) (2018-12-11)
+## [0.11.6](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.11.5...@atjson/renderer-graphviz@0.11.6) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -125,7 +117,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.11.3...@atjson/renderer-graphviz@0.11.4) (2018-12-11)
+## [0.11.5](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.11.4...@atjson/renderer-graphviz@0.11.5) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -133,7 +125,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.11.2...@atjson/renderer-graphviz@0.11.3) (2018-12-11)
+## [0.11.4](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.11.3...@atjson/renderer-graphviz@0.11.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
@@ -141,43 +133,51 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.11.1...@atjson/renderer-graphviz@0.11.2) (2018-12-11)
+## [0.11.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.11.2...@atjson/renderer-graphviz@0.11.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
 
-## [0.11.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.11.0...@atjson/renderer-graphviz@0.11.1) (2018-11-29)
+
+
+
+## [0.11.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.11.1...@atjson/renderer-graphviz@0.11.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
 
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.9.0...@atjson/renderer-graphviz@0.11.0) (2018-10-22)
+## [0.11.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.11.0...@atjson/renderer-graphviz@0.11.1) (2018-11-29)
+
+**Note:** Version bump only for package @atjson/renderer-graphviz
+
+
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.9.0...@atjson/renderer-graphviz@0.11.0) (2018-10-22)
 
 
 ### ✨ New Features
 
-* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast-Copilot/atjson/issues/57))
+* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast/atjson/issues/57))
 
 
-## [0.9.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.8.11...@atjson/renderer-graphviz@0.9.0) (2018-10-10)
+## [0.9.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.8.11...@atjson/renderer-graphviz@0.9.0) (2018-10-10)
 
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))
 
 
-## [0.8.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.8.10...@atjson/renderer-graphviz@0.8.11) (2018-09-14)
-
-**Note:** Version bump only for package @atjson/renderer-graphviz
-
-
-## [0.8.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.8.9...@atjson/renderer-graphviz@0.8.10) (2018-09-07)
+## [0.8.11](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.8.10...@atjson/renderer-graphviz@0.8.11) (2018-09-14)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 
 
-## [0.8.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-graphviz@0.8.8...@atjson/renderer-graphviz@0.8.9) (2018-09-04)
+## [0.8.10](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.8.9...@atjson/renderer-graphviz@0.8.10) (2018-09-07)
+
+**Note:** Version bump only for package @atjson/renderer-graphviz
+
+
+## [0.8.9](https://github.com/CondeNast/atjson/compare/@atjson/renderer-graphviz@0.8.8...@atjson/renderer-graphviz@0.8.9) (2018-09-04)
 
 **Note:** Version bump only for package @atjson/renderer-graphviz
 

--- a/packages/@atjson/renderer-hir/CHANGELOG.md
+++ b/packages/@atjson/renderer-hir/CHANGELOG.md
@@ -3,24 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.14.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.13.9...@atjson/renderer-hir@0.14.0) (2019-04-19)
+## [0.14.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.13.9...@atjson/renderer-hir@0.14.0) (2019-04-19)
 
 
 ### ✨ New Features
 
-* ✨🥃 add an interface for declaring annotation attributes ([#130](https://github.com/CondeNast-Copilot/atjson/issues/130))
+* ✨🥃 add an interface for declaring annotation attributes ([#130](https://github.com/CondeNast/atjson/issues/130))
 
 
 
-## [0.13.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.13.8...@atjson/renderer-hir@0.13.9) (2019-04-16)
-
-**Note:** Version bump only for package @atjson/renderer-hir
-
-
-
-
-
-## [0.13.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.13.7...@atjson/renderer-hir@0.13.8) (2019-04-15)
+## [0.13.9](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.13.8...@atjson/renderer-hir@0.13.9) (2019-04-16)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
@@ -28,7 +20,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.13.6...@atjson/renderer-hir@0.13.7) (2019-04-15)
+## [0.13.8](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.13.7...@atjson/renderer-hir@0.13.8) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
@@ -36,24 +28,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.13.5...@atjson/renderer-hir@0.13.6) (2019-04-10)
+## [0.13.7](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.13.6...@atjson/renderer-hir@0.13.7) (2019-04-15)
+
+**Note:** Version bump only for package @atjson/renderer-hir
+
+
+
+
+
+## [0.13.6](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.13.5...@atjson/renderer-hir@0.13.6) (2019-04-10)
 
 
 ### 🐛 Fixes
 
-* 🐛 ⚛️ Fix React Renderer so it works again ([#124](https://github.com/CondeNast-Copilot/atjson/issues/124))
+* 🐛 ⚛️ Fix React Renderer so it works again ([#124](https://github.com/CondeNast/atjson/issues/124))
 
 
 
-## [0.13.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.13.4...@atjson/renderer-hir@0.13.5) (2019-03-21)
-
-**Note:** Version bump only for package @atjson/renderer-hir
-
-
-
-
-
-## [0.13.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.13.3...@atjson/renderer-hir@0.13.4) (2019-03-19)
+## [0.13.5](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.13.4...@atjson/renderer-hir@0.13.5) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
@@ -61,7 +53,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.13.2...@atjson/renderer-hir@0.13.3) (2019-03-18)
+## [0.13.4](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.13.3...@atjson/renderer-hir@0.13.4) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
@@ -69,16 +61,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.13.1...@atjson/renderer-hir@0.13.2) (2019-03-18)
+## [0.13.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.13.2...@atjson/renderer-hir@0.13.3) (2019-03-18)
+
+**Note:** Version bump only for package @atjson/renderer-hir
+
+
+
+
+
+## [0.13.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.13.1...@atjson/renderer-hir@0.13.2) (2019-03-18)
 
 
 ### 🐛 Fixes
 
-* 🚀🐛 Performance fixes ([#119](https://github.com/CondeNast-Copilot/atjson/issues/119))
+* 🚀🐛 Performance fixes ([#119](https://github.com/CondeNast/atjson/issues/119))
 
 
 
-## [0.13.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.13.0...@atjson/renderer-hir@0.13.1) (2019-03-14)
+## [0.13.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.13.0...@atjson/renderer-hir@0.13.1) (2019-03-14)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
@@ -86,24 +86,16 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.12.1...@atjson/renderer-hir@0.13.0) (2019-02-14)
+## [0.13.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.12.1...@atjson/renderer-hir@0.13.0) (2019-02-14)
 
 
 ### ✨ New Features
 
-* 🍢✨ Allow using classified names for rendering hooks (`Bold` & `bold` / `GiphyEmbed` & `giphy-embed`) ([#107](https://github.com/CondeNast-Copilot/atjson/issues/107))
+* 🍢✨ Allow using classified names for rendering hooks (`Bold` & `bold` / `GiphyEmbed` & `giphy-embed`) ([#107](https://github.com/CondeNast/atjson/issues/107))
 
 
 
-## [0.12.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.12.0...@atjson/renderer-hir@0.12.1) (2019-02-12)
-
-**Note:** Version bump only for package @atjson/renderer-hir
-
-
-
-
-
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.11.9...@atjson/renderer-hir@0.12.0) (2019-01-24)
+## [0.12.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.12.0...@atjson/renderer-hir@0.12.1) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
@@ -111,7 +103,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.11.8...@atjson/renderer-hir@0.11.9) (2019-01-14)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.11.9...@atjson/renderer-hir@0.12.0) (2019-01-24)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
@@ -119,7 +111,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.11.7...@atjson/renderer-hir@0.11.8) (2019-01-09)
+## [0.11.9](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.11.8...@atjson/renderer-hir@0.11.9) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
@@ -127,7 +119,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.11.6...@atjson/renderer-hir@0.11.7) (2019-01-07)
+## [0.11.8](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.11.7...@atjson/renderer-hir@0.11.8) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
@@ -135,7 +127,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.11.5...@atjson/renderer-hir@0.11.6) (2018-12-11)
+## [0.11.7](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.11.6...@atjson/renderer-hir@0.11.7) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
@@ -143,7 +135,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.11.4...@atjson/renderer-hir@0.11.5) (2018-12-11)
+## [0.11.6](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.11.5...@atjson/renderer-hir@0.11.6) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
@@ -151,7 +143,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.11.3...@atjson/renderer-hir@0.11.4) (2018-12-11)
+## [0.11.5](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.11.4...@atjson/renderer-hir@0.11.5) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
@@ -159,7 +151,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.11.2...@atjson/renderer-hir@0.11.3) (2018-12-11)
+## [0.11.4](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.11.3...@atjson/renderer-hir@0.11.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
@@ -167,22 +159,30 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.11.1...@atjson/renderer-hir@0.11.2) (2018-12-11)
+## [0.11.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.11.2...@atjson/renderer-hir@0.11.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
 
-## [0.11.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.11.0...@atjson/renderer-hir@0.11.1) (2018-11-29)
+
+
+
+## [0.11.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.11.1...@atjson/renderer-hir@0.11.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
 
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.10.0...@atjson/renderer-hir@0.11.0) (2018-10-22)
+## [0.11.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.11.0...@atjson/renderer-hir@0.11.1) (2018-11-29)
+
+**Note:** Version bump only for package @atjson/renderer-hir
+
+
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.10.0...@atjson/renderer-hir@0.11.0) (2018-10-22)
 
 
 ### ✨ New Features
 
-* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast-Copilot/atjson/issues/57))
+* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast/atjson/issues/57))
 
 
 ### 🚨 Breaking Changes
@@ -192,33 +192,33 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 🎨 Renderers now take `Annotation`s instead of the `attributes`.  When additional context is required to render an annotation, a `context` object is passed as the second argument, which provides references to the `parent`, `next`, `previous`, and `children` annotations to the current annotation.
 
 
-## [0.10.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.9.3...@atjson/renderer-hir@0.10.0) (2018-10-10)
+## [0.10.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.9.3...@atjson/renderer-hir@0.10.0) (2018-10-10)
 
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))
 
 
 
-## [0.9.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.9.2...@atjson/renderer-hir@0.9.3) (2018-09-14)
-
-**Note:** Version bump only for package @atjson/renderer-hir
-
-
-## [0.9.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.9.1...@atjson/renderer-hir@0.9.2) (2018-09-07)
+## [0.9.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.9.2...@atjson/renderer-hir@0.9.3) (2018-09-14)
 
 **Note:** Version bump only for package @atjson/renderer-hir
 
 
-## [0.9.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-hir@0.9.0...@atjson/renderer-hir@0.9.1) (2018-09-04)
+## [0.9.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.9.1...@atjson/renderer-hir@0.9.2) (2018-09-07)
+
+**Note:** Version bump only for package @atjson/renderer-hir
+
+
+## [0.9.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-hir@0.9.0...@atjson/renderer-hir@0.9.1) (2018-09-04)
 
 ## 0.9.0 (2018-08-02)
 
 
 ### ✨ New Features
 
-* ✨ allow a HIR to be passed to a renderer ([#73](https://github.com/CondeNast-Copilot/atjson/issues/73))
+* ✨ allow a HIR to be passed to a renderer ([#73](https://github.com/CondeNast/atjson/issues/73))
 
 ## 0.8.4 (2018-07-25)
 

--- a/packages/@atjson/renderer-plain-text/CHANGELOG.md
+++ b/packages/@atjson/renderer-plain-text/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.13.15](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.14...@atjson/renderer-plain-text@0.13.15) (2019-04-19)
+## [0.13.15](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.14...@atjson/renderer-plain-text@0.13.15) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.14](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.13...@atjson/renderer-plain-text@0.13.14) (2019-04-18)
+## [0.13.14](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.13...@atjson/renderer-plain-text@0.13.14) (2019-04-18)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.13](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.12...@atjson/renderer-plain-text@0.13.13) (2019-04-16)
+## [0.13.13](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.12...@atjson/renderer-plain-text@0.13.13) (2019-04-16)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.12](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.11...@atjson/renderer-plain-text@0.13.12) (2019-04-15)
+## [0.13.12](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.11...@atjson/renderer-plain-text@0.13.12) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.10...@atjson/renderer-plain-text@0.13.11) (2019-04-15)
+## [0.13.11](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.10...@atjson/renderer-plain-text@0.13.11) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.9...@atjson/renderer-plain-text@0.13.10) (2019-04-10)
+## [0.13.10](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.9...@atjson/renderer-plain-text@0.13.10) (2019-04-10)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -51,7 +51,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.8...@atjson/renderer-plain-text@0.13.9) (2019-03-21)
+## [0.13.9](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.8...@atjson/renderer-plain-text@0.13.9) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -59,7 +59,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.7...@atjson/renderer-plain-text@0.13.8) (2019-03-19)
+## [0.13.8](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.7...@atjson/renderer-plain-text@0.13.8) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -67,7 +67,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.6...@atjson/renderer-plain-text@0.13.7) (2019-03-18)
+## [0.13.7](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.6...@atjson/renderer-plain-text@0.13.7) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.5...@atjson/renderer-plain-text@0.13.6) (2019-03-18)
+## [0.13.6](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.5...@atjson/renderer-plain-text@0.13.6) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.4...@atjson/renderer-plain-text@0.13.5) (2019-03-14)
+## [0.13.5](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.4...@atjson/renderer-plain-text@0.13.5) (2019-03-14)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.3...@atjson/renderer-plain-text@0.13.4) (2019-02-27)
+## [0.13.4](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.3...@atjson/renderer-plain-text@0.13.4) (2019-02-27)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -99,7 +99,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.2...@atjson/renderer-plain-text@0.13.3) (2019-02-14)
+## [0.13.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.2...@atjson/renderer-plain-text@0.13.3) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -107,7 +107,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.1...@atjson/renderer-plain-text@0.13.2) (2019-02-14)
+## [0.13.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.1...@atjson/renderer-plain-text@0.13.2) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -115,7 +115,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.13.0...@atjson/renderer-plain-text@0.13.1) (2019-02-12)
+## [0.13.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.13.0...@atjson/renderer-plain-text@0.13.1) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -123,7 +123,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.12.7...@atjson/renderer-plain-text@0.13.0) (2019-01-24)
+## [0.13.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.12.7...@atjson/renderer-plain-text@0.13.0) (2019-01-24)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -131,7 +131,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.12.6...@atjson/renderer-plain-text@0.12.7) (2019-01-14)
+## [0.12.7](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.12.6...@atjson/renderer-plain-text@0.12.7) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -139,7 +139,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.12.5...@atjson/renderer-plain-text@0.12.6) (2019-01-09)
+## [0.12.6](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.12.5...@atjson/renderer-plain-text@0.12.6) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -147,7 +147,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.12.4...@atjson/renderer-plain-text@0.12.5) (2019-01-07)
+## [0.12.5](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.12.4...@atjson/renderer-plain-text@0.12.5) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -155,7 +155,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.12.3...@atjson/renderer-plain-text@0.12.4) (2018-12-11)
+## [0.12.4](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.12.3...@atjson/renderer-plain-text@0.12.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -163,7 +163,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.12.2...@atjson/renderer-plain-text@0.12.3) (2018-12-11)
+## [0.12.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.12.2...@atjson/renderer-plain-text@0.12.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -171,7 +171,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.12.1...@atjson/renderer-plain-text@0.12.2) (2018-12-11)
+## [0.12.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.12.1...@atjson/renderer-plain-text@0.12.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -179,7 +179,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.12.0...@atjson/renderer-plain-text@0.12.1) (2018-12-11)
+## [0.12.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.12.0...@atjson/renderer-plain-text@0.12.1) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
@@ -187,49 +187,49 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.11.1...@atjson/renderer-plain-text@0.12.0) (2018-12-11)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.11.1...@atjson/renderer-plain-text@0.12.0) (2018-12-11)
 
 
 ### ✨ New Features
 
-* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast-Copilot/atjson/issues/93))
+* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast/atjson/issues/93))
 
 
 
-## [0.11.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.11.0...@atjson/renderer-plain-text@0.11.1) (2018-11-29)
+## [0.11.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.11.0...@atjson/renderer-plain-text@0.11.1) (2018-11-29)
 
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
 
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.9.0...@atjson/renderer-plain-text@0.11.0) (2018-10-22)
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.9.0...@atjson/renderer-plain-text@0.11.0) (2018-10-22)
 
 
 ### ✨ New Features
 
-* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast-Copilot/atjson/issues/57))
+* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast/atjson/issues/57))
 
 
-## [0.9.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.8.11...@atjson/renderer-plain-text@0.9.0) (2018-10-10)
+## [0.9.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.8.11...@atjson/renderer-plain-text@0.9.0) (2018-10-10)
 
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))
 
 
 
-## [0.8.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.8.10...@atjson/renderer-plain-text@0.8.11) (2018-09-14)
-
-**Note:** Version bump only for package @atjson/renderer-plain-text
-
-
-## [0.8.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.8.9...@atjson/renderer-plain-text@0.8.10) (2018-09-07)
+## [0.8.11](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.8.10...@atjson/renderer-plain-text@0.8.11) (2018-09-14)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 
 
-## [0.8.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-plain-text@0.8.8...@atjson/renderer-plain-text@0.8.9) (2018-09-04)
+## [0.8.10](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.8.9...@atjson/renderer-plain-text@0.8.10) (2018-09-07)
+
+**Note:** Version bump only for package @atjson/renderer-plain-text
+
+
+## [0.8.9](https://github.com/CondeNast/atjson/compare/@atjson/renderer-plain-text@0.8.8...@atjson/renderer-plain-text@0.8.9) (2018-09-04)
 
 **Note:** Version bump only for package @atjson/renderer-plain-text
 

--- a/packages/@atjson/renderer-react/CHANGELOG.md
+++ b/packages/@atjson/renderer-react/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.12.14](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.13...@atjson/renderer-react@0.12.14) (2019-04-19)
+## [0.12.14](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.13...@atjson/renderer-react@0.12.14) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.13](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.12...@atjson/renderer-react@0.12.13) (2019-04-18)
+## [0.12.13](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.12...@atjson/renderer-react@0.12.13) (2019-04-18)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.12](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.11...@atjson/renderer-react@0.12.12) (2019-04-16)
+## [0.12.12](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.11...@atjson/renderer-react@0.12.12) (2019-04-16)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.10...@atjson/renderer-react@0.12.11) (2019-04-15)
+## [0.12.11](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.10...@atjson/renderer-react@0.12.11) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.9...@atjson/renderer-react@0.12.10) (2019-04-15)
+## [0.12.10](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.9...@atjson/renderer-react@0.12.10) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.8...@atjson/renderer-react@0.12.9) (2019-04-10)
+## [0.12.9](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.8...@atjson/renderer-react@0.12.9) (2019-04-10)
 
 
 ### 🐛 Fixes
@@ -52,24 +52,16 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.7...@atjson/renderer-react@0.12.8) (2019-04-10)
+## [0.12.8](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.7...@atjson/renderer-react@0.12.8) (2019-04-10)
 
 
 ### 🐛 Fixes
 
-* 🐛 ⚛️ Fix React Renderer so it works again ([#124](https://github.com/CondeNast-Copilot/atjson/issues/124))
+* 🐛 ⚛️ Fix React Renderer so it works again ([#124](https://github.com/CondeNast/atjson/issues/124))
 
 
 
-## [0.12.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.6...@atjson/renderer-react@0.12.7) (2019-03-21)
-
-**Note:** Version bump only for package @atjson/renderer-react
-
-
-
-
-
-## [0.12.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.5...@atjson/renderer-react@0.12.6) (2019-03-19)
+## [0.12.7](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.6...@atjson/renderer-react@0.12.7) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -77,7 +69,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.4...@atjson/renderer-react@0.12.5) (2019-03-18)
+## [0.12.6](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.5...@atjson/renderer-react@0.12.6) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -85,7 +77,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.3...@atjson/renderer-react@0.12.4) (2019-03-18)
+## [0.12.5](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.4...@atjson/renderer-react@0.12.5) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -93,7 +85,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.2...@atjson/renderer-react@0.12.3) (2019-03-14)
+## [0.12.4](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.3...@atjson/renderer-react@0.12.4) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -101,7 +93,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.1...@atjson/renderer-react@0.12.2) (2019-02-14)
+## [0.12.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.2...@atjson/renderer-react@0.12.3) (2019-03-14)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -109,7 +101,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.12.0...@atjson/renderer-react@0.12.1) (2019-02-12)
+## [0.12.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.1...@atjson/renderer-react@0.12.2) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -117,7 +109,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.11.9...@atjson/renderer-react@0.12.0) (2019-01-24)
+## [0.12.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.12.0...@atjson/renderer-react@0.12.1) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -125,7 +117,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.11.8...@atjson/renderer-react@0.11.9) (2019-01-14)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.11.9...@atjson/renderer-react@0.12.0) (2019-01-24)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -133,7 +125,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.11.7...@atjson/renderer-react@0.11.8) (2019-01-09)
+## [0.11.9](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.11.8...@atjson/renderer-react@0.11.9) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -141,7 +133,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.11.6...@atjson/renderer-react@0.11.7) (2019-01-07)
+## [0.11.8](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.11.7...@atjson/renderer-react@0.11.8) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -149,7 +141,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.11.5...@atjson/renderer-react@0.11.6) (2018-12-11)
+## [0.11.7](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.11.6...@atjson/renderer-react@0.11.7) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -157,7 +149,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.11.4...@atjson/renderer-react@0.11.5) (2018-12-11)
+## [0.11.6](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.11.5...@atjson/renderer-react@0.11.6) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -165,7 +157,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.11.3...@atjson/renderer-react@0.11.4) (2018-12-11)
+## [0.11.5](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.11.4...@atjson/renderer-react@0.11.5) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -173,7 +165,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.11.2...@atjson/renderer-react@0.11.3) (2018-12-11)
+## [0.11.4](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.11.3...@atjson/renderer-react@0.11.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
@@ -181,43 +173,51 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.11.1...@atjson/renderer-react@0.11.2) (2018-12-11)
+## [0.11.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.11.2...@atjson/renderer-react@0.11.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
 
-## [0.11.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.11.0...@atjson/renderer-react@0.11.1) (2018-11-29)
+
+
+
+## [0.11.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.11.1...@atjson/renderer-react@0.11.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
 
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.9.0...@atjson/renderer-react@0.11.0) (2018-10-22)
+## [0.11.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.11.0...@atjson/renderer-react@0.11.1) (2018-11-29)
+
+**Note:** Version bump only for package @atjson/renderer-react
+
+
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.9.0...@atjson/renderer-react@0.11.0) (2018-10-22)
 
 
 ### ✨ New Features
 
-* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast-Copilot/atjson/issues/57))
+* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast/atjson/issues/57))
 
 
-## [0.9.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.8.11...@atjson/renderer-react@0.9.0) (2018-10-10)
+## [0.9.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.8.11...@atjson/renderer-react@0.9.0) (2018-10-10)
 
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))
 
 
 
-## [0.8.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.8.10...@atjson/renderer-react@0.8.11) (2018-09-14)
-
-**Note:** Version bump only for package @atjson/renderer-react
-
-
-## [0.8.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.8.9...@atjson/renderer-react@0.8.10) (2018-09-07)
+## [0.8.11](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.8.10...@atjson/renderer-react@0.8.11) (2018-09-14)
 
 **Note:** Version bump only for package @atjson/renderer-react
 
-## [0.8.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-react@0.8.8...@atjson/renderer-react@0.8.9) (2018-09-04)
+
+## [0.8.10](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.8.9...@atjson/renderer-react@0.8.10) (2018-09-07)
+
+**Note:** Version bump only for package @atjson/renderer-react
+
+## [0.8.9](https://github.com/CondeNast/atjson/compare/@atjson/renderer-react@0.8.8...@atjson/renderer-react@0.8.9) (2018-09-04)
 
 **Note:** Version bump only for package @atjson/renderer-react
 

--- a/packages/@atjson/renderer-webcomponent/CHANGELOG.md
+++ b/packages/@atjson/renderer-webcomponent/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.12.12](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.12.11...@atjson/renderer-webcomponent@0.12.12) (2019-04-19)
+## [0.12.12](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.12.11...@atjson/renderer-webcomponent@0.12.12) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.12.10...@atjson/renderer-webcomponent@0.12.11) (2019-04-16)
+## [0.12.11](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.12.10...@atjson/renderer-webcomponent@0.12.11) (2019-04-16)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.12.9...@atjson/renderer-webcomponent@0.12.10) (2019-04-15)
+## [0.12.10](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.12.9...@atjson/renderer-webcomponent@0.12.10) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.12.8...@atjson/renderer-webcomponent@0.12.9) (2019-04-15)
+## [0.12.9](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.12.8...@atjson/renderer-webcomponent@0.12.9) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.12.7...@atjson/renderer-webcomponent@0.12.8) (2019-04-10)
+## [0.12.8](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.12.7...@atjson/renderer-webcomponent@0.12.8) (2019-04-10)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.12.6...@atjson/renderer-webcomponent@0.12.7) (2019-03-21)
+## [0.12.7](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.12.6...@atjson/renderer-webcomponent@0.12.7) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -51,7 +51,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.12.5...@atjson/renderer-webcomponent@0.12.6) (2019-03-19)
+## [0.12.6](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.12.5...@atjson/renderer-webcomponent@0.12.6) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -59,7 +59,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.12.4...@atjson/renderer-webcomponent@0.12.5) (2019-03-18)
+## [0.12.5](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.12.4...@atjson/renderer-webcomponent@0.12.5) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -67,7 +67,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.12.3...@atjson/renderer-webcomponent@0.12.4) (2019-03-18)
+## [0.12.4](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.12.3...@atjson/renderer-webcomponent@0.12.4) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.12.2...@atjson/renderer-webcomponent@0.12.3) (2019-03-14)
+## [0.12.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.12.2...@atjson/renderer-webcomponent@0.12.3) (2019-03-14)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.12.1...@atjson/renderer-webcomponent@0.12.2) (2019-02-14)
+## [0.12.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.12.1...@atjson/renderer-webcomponent@0.12.2) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.12.0...@atjson/renderer-webcomponent@0.12.1) (2019-02-12)
+## [0.12.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.12.0...@atjson/renderer-webcomponent@0.12.1) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -99,7 +99,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.11.9...@atjson/renderer-webcomponent@0.12.0) (2019-01-24)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.11.9...@atjson/renderer-webcomponent@0.12.0) (2019-01-24)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -107,7 +107,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.11.8...@atjson/renderer-webcomponent@0.11.9) (2019-01-14)
+## [0.11.9](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.11.8...@atjson/renderer-webcomponent@0.11.9) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -115,7 +115,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.11.7...@atjson/renderer-webcomponent@0.11.8) (2019-01-09)
+## [0.11.8](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.11.7...@atjson/renderer-webcomponent@0.11.8) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -123,7 +123,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.11.6...@atjson/renderer-webcomponent@0.11.7) (2019-01-07)
+## [0.11.7](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.11.6...@atjson/renderer-webcomponent@0.11.7) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -131,7 +131,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.11.5...@atjson/renderer-webcomponent@0.11.6) (2018-12-11)
+## [0.11.6](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.11.5...@atjson/renderer-webcomponent@0.11.6) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -139,7 +139,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.11.4...@atjson/renderer-webcomponent@0.11.5) (2018-12-11)
+## [0.11.5](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.11.4...@atjson/renderer-webcomponent@0.11.5) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -147,7 +147,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.11.3...@atjson/renderer-webcomponent@0.11.4) (2018-12-11)
+## [0.11.4](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.11.3...@atjson/renderer-webcomponent@0.11.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -155,7 +155,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.11.2...@atjson/renderer-webcomponent@0.11.3) (2018-12-11)
+## [0.11.3](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.11.2...@atjson/renderer-webcomponent@0.11.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -163,18 +163,18 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.11.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.11.1...@atjson/renderer-webcomponent@0.11.2) (2018-12-11)
+## [0.11.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.11.1...@atjson/renderer-webcomponent@0.11.2) (2018-12-11)
 
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
 
-## [0.11.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.11.0...@atjson/renderer-webcomponent@0.11.1) (2018-11-29)
+## [0.11.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.11.0...@atjson/renderer-webcomponent@0.11.1) (2018-11-29)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
 
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-webcomponent@0.9.0...@atjson/renderer-webcomponent@0.11.0) (2018-10-22)
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-webcomponent@0.9.0...@atjson/renderer-webcomponent@0.11.0) (2018-10-22)
 
 **Note:** Version bump only for package @atjson/renderer-webcomponent
 
@@ -184,4 +184,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))

--- a/packages/@atjson/source-commonmark/CHANGELOG.md
+++ b/packages/@atjson/source-commonmark/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.14.16](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.15...@atjson/source-commonmark@0.14.16) (2019-04-19)
+## [0.14.16](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.15...@atjson/source-commonmark@0.14.16) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.15](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.14...@atjson/source-commonmark@0.14.15) (2019-04-18)
+## [0.14.15](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.14...@atjson/source-commonmark@0.14.15) (2019-04-18)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.14](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.13...@atjson/source-commonmark@0.14.14) (2019-04-15)
+## [0.14.14](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.13...@atjson/source-commonmark@0.14.14) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.13](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.12...@atjson/source-commonmark@0.14.13) (2019-04-15)
+## [0.14.13](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.12...@atjson/source-commonmark@0.14.13) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.12](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.11...@atjson/source-commonmark@0.14.12) (2019-04-10)
+## [0.14.12](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.11...@atjson/source-commonmark@0.14.12) (2019-04-10)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.10...@atjson/source-commonmark@0.14.11) (2019-03-21)
+## [0.14.11](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.10...@atjson/source-commonmark@0.14.11) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -51,16 +51,16 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.9...@atjson/source-commonmark@0.14.10) (2019-03-19)
+## [0.14.10](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.9...@atjson/source-commonmark@0.14.10) (2019-03-19)
 
 
 ### 🐛 Fixes
 
-* 🐝 : Remove code for parcel workaround ([#121](https://github.com/CondeNast-Copilot/atjson/issues/121))
+* 🐝 : Remove code for parcel workaround ([#121](https://github.com/CondeNast/atjson/issues/121))
 
 
 
-## [0.14.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.8...@atjson/source-commonmark@0.14.9) (2019-03-18)
+## [0.14.9](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.8...@atjson/source-commonmark@0.14.9) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -68,24 +68,16 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.7...@atjson/source-commonmark@0.14.8) (2019-03-18)
+## [0.14.8](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.7...@atjson/source-commonmark@0.14.8) (2019-03-18)
 
 
 ### 🐛 Fixes
 
-* 🚀🐛 Performance fixes ([#119](https://github.com/CondeNast-Copilot/atjson/issues/119))
+* 🚀🐛 Performance fixes ([#119](https://github.com/CondeNast/atjson/issues/119))
 
 
 
-## [0.14.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.6...@atjson/source-commonmark@0.14.7) (2019-03-14)
-
-**Note:** Version bump only for package @atjson/source-commonmark
-
-
-
-
-
-## [0.14.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.5...@atjson/source-commonmark@0.14.6) (2019-02-27)
+## [0.14.7](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.6...@atjson/source-commonmark@0.14.7) (2019-03-14)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -93,7 +85,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.4...@atjson/source-commonmark@0.14.5) (2019-02-15)
+## [0.14.6](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.5...@atjson/source-commonmark@0.14.6) (2019-02-27)
+
+**Note:** Version bump only for package @atjson/source-commonmark
+
+
+
+
+
+## [0.14.5](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.4...@atjson/source-commonmark@0.14.5) (2019-02-15)
 
 
 ### 🐛 Fixes
@@ -102,7 +102,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.3...@atjson/source-commonmark@0.14.4) (2019-02-14)
+## [0.14.4](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.3...@atjson/source-commonmark@0.14.4) (2019-02-14)
 
 
 ### 🐛 Fixes
@@ -111,7 +111,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.2...@atjson/source-commonmark@0.14.3) (2019-02-14)
+## [0.14.3](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.2...@atjson/source-commonmark@0.14.3) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -119,7 +119,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.1...@atjson/source-commonmark@0.14.2) (2019-02-14)
+## [0.14.2](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.1...@atjson/source-commonmark@0.14.2) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -127,7 +127,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.14.0...@atjson/source-commonmark@0.14.1) (2019-02-12)
+## [0.14.1](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.14.0...@atjson/source-commonmark@0.14.1) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -135,7 +135,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.13.8...@atjson/source-commonmark@0.14.0) (2019-01-24)
+## [0.14.0](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.13.8...@atjson/source-commonmark@0.14.0) (2019-01-24)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -143,24 +143,16 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.13.7...@atjson/source-commonmark@0.13.8) (2019-01-14)
+## [0.13.8](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.13.7...@atjson/source-commonmark@0.13.8) (2019-01-14)
 
 
 ### 🐛 Fixes
 
-* 🐞 pass closing token in addition to the opening token ([#99](https://github.com/CondeNast-Copilot/atjson/issues/99))
+* 🐞 pass closing token in addition to the opening token ([#99](https://github.com/CondeNast/atjson/issues/99))
 
 
 
-## [0.13.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.13.6...@atjson/source-commonmark@0.13.7) (2019-01-14)
-
-**Note:** Version bump only for package @atjson/source-commonmark
-
-
-
-
-
-## [0.13.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.13.5...@atjson/source-commonmark@0.13.6) (2019-01-09)
+## [0.13.7](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.13.6...@atjson/source-commonmark@0.13.7) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -168,7 +160,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.13.4...@atjson/source-commonmark@0.13.5) (2019-01-07)
+## [0.13.6](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.13.5...@atjson/source-commonmark@0.13.6) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -176,7 +168,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.13.3...@atjson/source-commonmark@0.13.4) (2018-12-11)
+## [0.13.5](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.13.4...@atjson/source-commonmark@0.13.5) (2019-01-07)
+
+**Note:** Version bump only for package @atjson/source-commonmark
+
+
+
+
+
+## [0.13.4](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.13.3...@atjson/source-commonmark@0.13.4) (2018-12-11)
 
 
 ### 🐛 Fixes
@@ -185,7 +185,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.13.2...@atjson/source-commonmark@0.13.3) (2018-12-11)
+## [0.13.3](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.13.2...@atjson/source-commonmark@0.13.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -193,7 +193,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.13.1...@atjson/source-commonmark@0.13.2) (2018-12-11)
+## [0.13.2](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.13.1...@atjson/source-commonmark@0.13.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -201,7 +201,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.13.0...@atjson/source-commonmark@0.13.1) (2018-12-11)
+## [0.13.1](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.13.0...@atjson/source-commonmark@0.13.1) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
@@ -209,51 +209,51 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.12.0...@atjson/source-commonmark@0.13.0) (2018-12-11)
+## [0.13.0](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.12.0...@atjson/source-commonmark@0.13.0) (2018-12-11)
 
 
 ### ✨ New Features
 
-* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast-Copilot/atjson/issues/93))
+* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast/atjson/issues/93))
 
 
 
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.11.0...@atjson/source-commonmark@0.12.0) (2018-11-29)
-
-
-### ✨ New Features
-
-* ✨📡 dynamically convert between types of sources ([#88](https://github.com/CondeNast-Copilot/atjson/issues/88))
-
-
-
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.9.0...@atjson/source-commonmark@0.11.0) (2018-10-22)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.11.0...@atjson/source-commonmark@0.12.0) (2018-11-29)
 
 
 ### ✨ New Features
 
-* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast-Copilot/atjson/issues/57))
+* ✨📡 dynamically convert between types of sources ([#88](https://github.com/CondeNast/atjson/issues/88))
 
-## [0.9.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.8.11...@atjson/source-commonmark@0.9.0) (2018-10-10)
+
+
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.9.0...@atjson/source-commonmark@0.11.0) (2018-10-22)
 
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast/atjson/issues/57))
+
+## [0.9.0](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.8.11...@atjson/source-commonmark@0.9.0) (2018-10-10)
+
+
+### ✨ New Features
+
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))
 
 
 
-## [0.8.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.8.10...@atjson/source-commonmark@0.8.11) (2018-09-14)
+## [0.8.11](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.8.10...@atjson/source-commonmark@0.8.11) (2018-09-14)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
 
-## [0.8.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.8.9...@atjson/source-commonmark@0.8.10) (2018-09-07)
+## [0.8.10](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.8.9...@atjson/source-commonmark@0.8.10) (2018-09-07)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 
 
-## [0.8.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-commonmark@0.8.8...@atjson/source-commonmark@0.8.9) (2018-09-04)
+## [0.8.9](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.8.8...@atjson/source-commonmark@0.8.9) (2018-09-04)
 
 **Note:** Version bump only for package @atjson/source-commonmark
 

--- a/packages/@atjson/source-gdocs-paste/CHANGELOG.md
+++ b/packages/@atjson/source-gdocs-paste/CHANGELOG.md
@@ -3,24 +3,16 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.15.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.14.4...@atjson/source-gdocs-paste@0.15.0) (2019-04-19)
+## [0.15.0](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.14.4...@atjson/source-gdocs-paste@0.15.0) (2019-04-19)
 
 
 ### ✨ New Features
 
-* ✨🥃 add an interface for declaring annotation attributes ([#130](https://github.com/CondeNast-Copilot/atjson/issues/130))
+* ✨🥃 add an interface for declaring annotation attributes ([#130](https://github.com/CondeNast/atjson/issues/130))
 
 
 
-## [0.14.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.14.3...@atjson/source-gdocs-paste@0.14.4) (2019-04-18)
-
-**Note:** Version bump only for package @atjson/source-gdocs-paste
-
-
-
-
-
-## [0.14.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.14.2...@atjson/source-gdocs-paste@0.14.3) (2019-04-16)
+## [0.14.4](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.14.3...@atjson/source-gdocs-paste@0.14.4) (2019-04-18)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -28,7 +20,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.14.1...@atjson/source-gdocs-paste@0.14.2) (2019-04-15)
+## [0.14.3](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.14.2...@atjson/source-gdocs-paste@0.14.3) (2019-04-16)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -36,7 +28,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.14.0...@atjson/source-gdocs-paste@0.14.1) (2019-04-15)
+## [0.14.2](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.14.1...@atjson/source-gdocs-paste@0.14.2) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -44,24 +36,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.18...@atjson/source-gdocs-paste@0.14.0) (2019-04-10)
+## [0.14.1](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.14.0...@atjson/source-gdocs-paste@0.14.1) (2019-04-15)
+
+**Note:** Version bump only for package @atjson/source-gdocs-paste
+
+
+
+
+
+## [0.14.0](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.18...@atjson/source-gdocs-paste@0.14.0) (2019-04-10)
 
 
 ### ✨ New Features
 
-* ✨ Add public app to source-html ([#123](https://github.com/CondeNast-Copilot/atjson/issues/123))
+* ✨ Add public app to source-html ([#123](https://github.com/CondeNast/atjson/issues/123))
 
 
 
-## [0.13.18](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.17...@atjson/source-gdocs-paste@0.13.18) (2019-03-21)
-
-**Note:** Version bump only for package @atjson/source-gdocs-paste
-
-
-
-
-
-## [0.13.17](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.16...@atjson/source-gdocs-paste@0.13.17) (2019-03-19)
+## [0.13.18](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.17...@atjson/source-gdocs-paste@0.13.18) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -69,7 +61,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.16](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.15...@atjson/source-gdocs-paste@0.13.16) (2019-03-18)
+## [0.13.17](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.16...@atjson/source-gdocs-paste@0.13.17) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -77,7 +69,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.15](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.14...@atjson/source-gdocs-paste@0.13.15) (2019-03-18)
+## [0.13.16](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.15...@atjson/source-gdocs-paste@0.13.16) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -85,7 +77,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.14](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.13...@atjson/source-gdocs-paste@0.13.14) (2019-03-14)
+## [0.13.15](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.14...@atjson/source-gdocs-paste@0.13.15) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -93,7 +85,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.13](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.12...@atjson/source-gdocs-paste@0.13.13) (2019-02-27)
+## [0.13.14](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.13...@atjson/source-gdocs-paste@0.13.14) (2019-03-14)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -101,7 +93,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.12](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.11...@atjson/source-gdocs-paste@0.13.12) (2019-02-14)
+## [0.13.13](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.12...@atjson/source-gdocs-paste@0.13.13) (2019-02-27)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -109,7 +101,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.10...@atjson/source-gdocs-paste@0.13.11) (2019-02-14)
+## [0.13.12](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.11...@atjson/source-gdocs-paste@0.13.12) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -117,7 +109,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.9...@atjson/source-gdocs-paste@0.13.10) (2019-02-12)
+## [0.13.11](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.10...@atjson/source-gdocs-paste@0.13.11) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -125,16 +117,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.8...@atjson/source-gdocs-paste@0.13.9) (2019-01-25)
+## [0.13.10](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.9...@atjson/source-gdocs-paste@0.13.10) (2019-02-12)
+
+**Note:** Version bump only for package @atjson/source-gdocs-paste
+
+
+
+
+
+## [0.13.9](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.8...@atjson/source-gdocs-paste@0.13.9) (2019-01-25)
 
 
 ### 🐛 Fixes
 
-* 🐜 Fix converter to offset to remove (Sub)Titles ([#104](https://github.com/CondeNast-Copilot/atjson/issues/104))
+* 🐜 Fix converter to offset to remove (Sub)Titles ([#104](https://github.com/CondeNast/atjson/issues/104))
 
 
 
-## [0.13.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.7...@atjson/source-gdocs-paste@0.13.8) (2019-01-14)
+## [0.13.8](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.7...@atjson/source-gdocs-paste@0.13.8) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -142,7 +142,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.6...@atjson/source-gdocs-paste@0.13.7) (2019-01-09)
+## [0.13.7](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.6...@atjson/source-gdocs-paste@0.13.7) (2019-01-09)
 
 
 ### 🐛 Fixes
@@ -152,7 +152,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.5...@atjson/source-gdocs-paste@0.13.6) (2019-01-09)
+## [0.13.6](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.5...@atjson/source-gdocs-paste@0.13.6) (2019-01-09)
 
 
 ### 🐛 Fixes
@@ -161,7 +161,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.4...@atjson/source-gdocs-paste@0.13.5) (2019-01-07)
+## [0.13.5](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.4...@atjson/source-gdocs-paste@0.13.5) (2019-01-07)
 
 ### 🐛 Fixes
 
@@ -171,7 +171,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.3...@atjson/source-gdocs-paste@0.13.4) (2018-12-11)
+## [0.13.4](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.3...@atjson/source-gdocs-paste@0.13.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -179,7 +179,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.2...@atjson/source-gdocs-paste@0.13.3) (2018-12-11)
+## [0.13.3](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.2...@atjson/source-gdocs-paste@0.13.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -187,7 +187,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.1...@atjson/source-gdocs-paste@0.13.2) (2018-12-11)
+## [0.13.2](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.1...@atjson/source-gdocs-paste@0.13.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -195,7 +195,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.13.0...@atjson/source-gdocs-paste@0.13.1) (2018-12-11)
+## [0.13.1](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.13.0...@atjson/source-gdocs-paste@0.13.1) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
@@ -203,61 +203,61 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.12.0...@atjson/source-gdocs-paste@0.13.0) (2018-12-11)
+## [0.13.0](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.12.0...@atjson/source-gdocs-paste@0.13.0) (2018-12-11)
 
 
 ### ✨ New Features
 
-* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast-Copilot/atjson/issues/93))
+* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast/atjson/issues/93))
 
 
 ### 🐛 Fixes
 
-* 🐛 Close any open annotations from Google Docs paste ([#92](https://github.com/CondeNast-Copilot/atjson/issues/92))
+* 🐛 Close any open annotations from Google Docs paste ([#92](https://github.com/CondeNast/atjson/issues/92))
 
 
 
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.11.0...@atjson/source-gdocs-paste@0.12.0) (2018-11-29)
-
-
-### ✨ New Features
-
-* ✨📡 dynamically convert between types of sources ([#88](https://github.com/CondeNast-Copilot/atjson/issues/88))
-
-
-
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.9.0...@atjson/source-gdocs-paste@0.11.0) (2018-10-22)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.11.0...@atjson/source-gdocs-paste@0.12.0) (2018-11-29)
 
 
 ### ✨ New Features
 
-* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast-Copilot/atjson/issues/57))
+* ✨📡 dynamically convert between types of sources ([#88](https://github.com/CondeNast/atjson/issues/88))
 
 
-## [0.9.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.8.11...@atjson/source-gdocs-paste@0.9.0) (2018-10-10)
+
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.9.0...@atjson/source-gdocs-paste@0.11.0) (2018-10-22)
 
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast/atjson/issues/57))
+
+
+## [0.9.0](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.8.11...@atjson/source-gdocs-paste@0.9.0) (2018-10-10)
+
+
+### ✨ New Features
+
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))
 
 
 
-## [0.8.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.8.10...@atjson/source-gdocs-paste@0.8.11) (2018-09-14)
+## [0.8.11](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.8.10...@atjson/source-gdocs-paste@0.8.11) (2018-09-14)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
-## [0.8.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.8.9...@atjson/source-gdocs-paste@0.8.10) (2018-09-07)
+## [0.8.10](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.8.9...@atjson/source-gdocs-paste@0.8.10) (2018-09-07)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
 
-## [0.8.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.8.8...@atjson/source-gdocs-paste@0.8.9) (2018-09-04)
+## [0.8.9](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.8.8...@atjson/source-gdocs-paste@0.8.9) (2018-09-04)
 
 
 ### 🐛 Fixes
 
-* 🐛🔒 fix vulnerability with with git-dummy-commit by using shelljs directly ([#76](https://github.com/CondeNast-Copilot/atjson/issues/76))
+* 🐛🔒 fix vulnerability with with git-dummy-commit by using shelljs directly ([#76](https://github.com/CondeNast/atjson/issues/76))
 
 ## 0.8.8 (2018-08-02)
 

--- a/packages/@atjson/source-html/CHANGELOG.md
+++ b/packages/@atjson/source-html/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.14.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.14.3...@atjson/source-html@0.14.4) (2019-04-19)
+## [0.14.4](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.14.3...@atjson/source-html@0.14.4) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.14.2...@atjson/source-html@0.14.3) (2019-04-18)
+## [0.14.3](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.14.2...@atjson/source-html@0.14.3) (2019-04-18)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.14.1...@atjson/source-html@0.14.2) (2019-04-15)
+## [0.14.2](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.14.1...@atjson/source-html@0.14.2) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.14.0...@atjson/source-html@0.14.1) (2019-04-15)
+## [0.14.1](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.14.0...@atjson/source-html@0.14.1) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -35,24 +35,16 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.16...@atjson/source-html@0.14.0) (2019-04-10)
+## [0.14.0](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.16...@atjson/source-html@0.14.0) (2019-04-10)
 
 
 ### ✨ New Features
 
-* ✨ Add public app to source-html ([#123](https://github.com/CondeNast-Copilot/atjson/issues/123))
+* ✨ Add public app to source-html ([#123](https://github.com/CondeNast/atjson/issues/123))
 
 
 
-## [0.13.16](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.15...@atjson/source-html@0.13.16) (2019-03-21)
-
-**Note:** Version bump only for package @atjson/source-html
-
-
-
-
-
-## [0.13.15](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.14...@atjson/source-html@0.13.15) (2019-03-19)
+## [0.13.16](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.15...@atjson/source-html@0.13.16) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -60,7 +52,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.14](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.13...@atjson/source-html@0.13.14) (2019-03-18)
+## [0.13.15](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.14...@atjson/source-html@0.13.15) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -68,7 +60,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.13](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.12...@atjson/source-html@0.13.13) (2019-03-18)
+## [0.13.14](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.13...@atjson/source-html@0.13.14) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -76,24 +68,24 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.12](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.11...@atjson/source-html@0.13.12) (2019-03-14)
+## [0.13.13](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.12...@atjson/source-html@0.13.13) (2019-03-18)
+
+**Note:** Version bump only for package @atjson/source-html
+
+
+
+
+
+## [0.13.12](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.11...@atjson/source-html@0.13.12) (2019-03-14)
 
 
 ### 🐛 Fixes
 
-* 🐝🚀 Fix performance regressions ([#118](https://github.com/CondeNast-Copilot/atjson/issues/118))
+* 🐝🚀 Fix performance regressions ([#118](https://github.com/CondeNast/atjson/issues/118))
 
 
 
-## [0.13.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.10...@atjson/source-html@0.13.11) (2019-02-27)
-
-**Note:** Version bump only for package @atjson/source-html
-
-
-
-
-
-## [0.13.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.9...@atjson/source-html@0.13.10) (2019-02-14)
+## [0.13.11](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.10...@atjson/source-html@0.13.11) (2019-02-27)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -101,7 +93,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.8...@atjson/source-html@0.13.9) (2019-02-14)
+## [0.13.10](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.9...@atjson/source-html@0.13.10) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -109,7 +101,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.7...@atjson/source-html@0.13.8) (2019-02-12)
+## [0.13.9](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.8...@atjson/source-html@0.13.9) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -117,7 +109,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.6...@atjson/source-html@0.13.7) (2019-01-14)
+## [0.13.8](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.7...@atjson/source-html@0.13.8) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -125,7 +117,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.5...@atjson/source-html@0.13.6) (2019-01-09)
+## [0.13.7](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.6...@atjson/source-html@0.13.7) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -133,7 +125,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.4...@atjson/source-html@0.13.5) (2019-01-07)
+## [0.13.6](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.5...@atjson/source-html@0.13.6) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -141,7 +133,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.3...@atjson/source-html@0.13.4) (2018-12-11)
+## [0.13.5](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.4...@atjson/source-html@0.13.5) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -149,7 +141,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.2...@atjson/source-html@0.13.3) (2018-12-11)
+## [0.13.4](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.3...@atjson/source-html@0.13.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -157,7 +149,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.1...@atjson/source-html@0.13.2) (2018-12-11)
+## [0.13.3](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.2...@atjson/source-html@0.13.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -165,7 +157,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.13.0...@atjson/source-html@0.13.1) (2018-12-11)
+## [0.13.2](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.1...@atjson/source-html@0.13.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-html
 
@@ -173,52 +165,60 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.12.0...@atjson/source-html@0.13.0) (2018-12-11)
+## [0.13.1](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.13.0...@atjson/source-html@0.13.1) (2018-12-11)
+
+**Note:** Version bump only for package @atjson/source-html
+
+
+
+
+
+## [0.13.0](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.12.0...@atjson/source-html@0.13.0) (2018-12-11)
 
 
 ### ✨ New Features
 
-* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast-Copilot/atjson/issues/93))
+* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast/atjson/issues/93))
 
 
 
-## [0.12.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.11.0...@atjson/source-html@0.12.0) (2018-11-29)
-
-
-### ✨ New Features
-
-* ✨📡 dynamically convert between types of sources ([#88](https://github.com/CondeNast-Copilot/atjson/issues/88))
-
-
-
-## [0.11.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.9.0...@atjson/source-html@0.11.0) (2018-10-22)
+## [0.12.0](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.11.0...@atjson/source-html@0.12.0) (2018-11-29)
 
 
 ### ✨ New Features
 
-* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast-Copilot/atjson/issues/57))
+* ✨📡 dynamically convert between types of sources ([#88](https://github.com/CondeNast/atjson/issues/88))
 
 
-## [0.9.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.8.11...@atjson/source-html@0.9.0) (2018-10-10)
+
+## [0.11.0](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.9.0...@atjson/source-html@0.11.0) (2018-10-22)
 
 
 ### ✨ New Features
 
-* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast-Copilot/atjson/issues/85))
+* ✨👑✨ Make Annotations classes instead of JS objects ([#57](https://github.com/CondeNast/atjson/issues/57))
+
+
+## [0.9.0](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.8.11...@atjson/source-html@0.9.0) (2018-10-10)
+
+
+### ✨ New Features
+
+* ✨🤠 Typed Annotation Collections / Joins! ([#85](https://github.com/CondeNast/atjson/issues/85))
 
 
 
-## [0.8.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.8.10...@atjson/source-html@0.8.11) (2018-09-14)
+## [0.8.11](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.8.10...@atjson/source-html@0.8.11) (2018-09-14)
 
 **Note:** Version bump only for package @atjson/source-html
 
 
-## [0.8.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.8.9...@atjson/source-html@0.8.10) (2018-09-07)
+## [0.8.10](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.8.9...@atjson/source-html@0.8.10) (2018-09-07)
 
 **Note:** Version bump only for package @atjson/source-html
 
 
-## [0.8.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-html@0.8.8...@atjson/source-html@0.8.9) (2018-09-04)
+## [0.8.9](https://github.com/CondeNast/atjson/compare/@atjson/source-html@0.8.8...@atjson/source-html@0.8.9) (2018-09-04)
 
 **Note:** Version bump only for package @atjson/source-html
 

--- a/packages/@atjson/source-mobiledoc/CHANGELOG.md
+++ b/packages/@atjson/source-mobiledoc/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.13.23](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.22...@atjson/source-mobiledoc@0.13.23) (2019-04-19)
+## [0.13.23](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.22...@atjson/source-mobiledoc@0.13.23) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.22](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.21...@atjson/source-mobiledoc@0.13.22) (2019-04-18)
+## [0.13.22](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.21...@atjson/source-mobiledoc@0.13.22) (2019-04-18)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.21](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.20...@atjson/source-mobiledoc@0.13.21) (2019-04-16)
+## [0.13.21](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.20...@atjson/source-mobiledoc@0.13.21) (2019-04-16)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.20](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.19...@atjson/source-mobiledoc@0.13.20) (2019-04-15)
+## [0.13.20](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.19...@atjson/source-mobiledoc@0.13.20) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.19](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.18...@atjson/source-mobiledoc@0.13.19) (2019-04-15)
+## [0.13.19](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.18...@atjson/source-mobiledoc@0.13.19) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -43,7 +43,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.18](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.17...@atjson/source-mobiledoc@0.13.18) (2019-03-21)
+## [0.13.18](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.17...@atjson/source-mobiledoc@0.13.18) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -51,7 +51,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.17](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.16...@atjson/source-mobiledoc@0.13.17) (2019-03-19)
+## [0.13.17](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.16...@atjson/source-mobiledoc@0.13.17) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -59,7 +59,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.16](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.15...@atjson/source-mobiledoc@0.13.16) (2019-03-18)
+## [0.13.16](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.15...@atjson/source-mobiledoc@0.13.16) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -67,7 +67,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.15](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.14...@atjson/source-mobiledoc@0.13.15) (2019-03-18)
+## [0.13.15](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.14...@atjson/source-mobiledoc@0.13.15) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -75,7 +75,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.14](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.13...@atjson/source-mobiledoc@0.13.14) (2019-03-14)
+## [0.13.14](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.13...@atjson/source-mobiledoc@0.13.14) (2019-03-14)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -83,7 +83,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.13](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.12...@atjson/source-mobiledoc@0.13.13) (2019-02-27)
+## [0.13.13](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.12...@atjson/source-mobiledoc@0.13.13) (2019-02-27)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -91,7 +91,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.12](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.11...@atjson/source-mobiledoc@0.13.12) (2019-02-14)
+## [0.13.12](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.11...@atjson/source-mobiledoc@0.13.12) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -99,7 +99,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.11](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.10...@atjson/source-mobiledoc@0.13.11) (2019-02-14)
+## [0.13.11](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.10...@atjson/source-mobiledoc@0.13.11) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -107,7 +107,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.10](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.9...@atjson/source-mobiledoc@0.13.10) (2019-02-12)
+## [0.13.10](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.9...@atjson/source-mobiledoc@0.13.10) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -115,7 +115,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.8...@atjson/source-mobiledoc@0.13.9) (2019-01-14)
+## [0.13.9](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.8...@atjson/source-mobiledoc@0.13.9) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -123,7 +123,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.7...@atjson/source-mobiledoc@0.13.8) (2019-01-09)
+## [0.13.8](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.7...@atjson/source-mobiledoc@0.13.8) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -131,7 +131,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.6...@atjson/source-mobiledoc@0.13.7) (2019-01-07)
+## [0.13.7](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.6...@atjson/source-mobiledoc@0.13.7) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -139,7 +139,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.5...@atjson/source-mobiledoc@0.13.6) (2018-12-21)
+## [0.13.6](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.5...@atjson/source-mobiledoc@0.13.6) (2018-12-21)
 
 
 ### 🐛 Fixes
@@ -148,7 +148,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.4...@atjson/source-mobiledoc@0.13.5) (2018-12-13)
+## [0.13.5](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.4...@atjson/source-mobiledoc@0.13.5) (2018-12-13)
 
 
 ### 🐛 Fixes
@@ -157,7 +157,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.3...@atjson/source-mobiledoc@0.13.4) (2018-12-11)
+## [0.13.4](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.3...@atjson/source-mobiledoc@0.13.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -165,7 +165,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.2...@atjson/source-mobiledoc@0.13.3) (2018-12-11)
+## [0.13.3](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.2...@atjson/source-mobiledoc@0.13.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -173,7 +173,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.1...@atjson/source-mobiledoc@0.13.2) (2018-12-11)
+## [0.13.2](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.1...@atjson/source-mobiledoc@0.13.2) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -181,7 +181,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.13.0...@atjson/source-mobiledoc@0.13.1) (2018-12-11)
+## [0.13.1](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.13.0...@atjson/source-mobiledoc@0.13.1) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-mobiledoc
 
@@ -189,12 +189,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-mobiledoc@0.12.0...@atjson/source-mobiledoc@0.13.0) (2018-12-11)
+## [0.13.0](https://github.com/CondeNast/atjson/compare/@atjson/source-mobiledoc@0.12.0...@atjson/source-mobiledoc@0.13.0) (2018-12-11)
 
 
 ### ✨ New Features
 
-* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast-Copilot/atjson/issues/93))
+* ✨ Coerce or convert to sources ([#93](https://github.com/CondeNast/atjson/issues/93))
 
 
 
@@ -203,4 +203,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ✨ New Features
 
-* ✨ Add Mobiledoc source ([#91](https://github.com/CondeNast-Copilot/atjson/issues/91))
+* ✨ Add Mobiledoc source ([#91](https://github.com/CondeNast/atjson/issues/91))

--- a/packages/@atjson/source-prism/CHANGELOG.md
+++ b/packages/@atjson/source-prism/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.16.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.16.4...@atjson/source-prism@0.16.5) (2019-04-19)
+## [0.16.5](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.16.4...@atjson/source-prism@0.16.5) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/source-prism
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.16.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.16.3...@atjson/source-prism@0.16.4) (2019-04-18)
+## [0.16.4](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.16.3...@atjson/source-prism@0.16.4) (2019-04-18)
 
 **Note:** Version bump only for package @atjson/source-prism
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.16.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.16.2...@atjson/source-prism@0.16.3) (2019-04-16)
+## [0.16.3](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.16.2...@atjson/source-prism@0.16.3) (2019-04-16)
 
 **Note:** Version bump only for package @atjson/source-prism
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.16.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.16.1...@atjson/source-prism@0.16.2) (2019-04-15)
+## [0.16.2](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.16.1...@atjson/source-prism@0.16.2) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/source-prism
 
@@ -35,7 +35,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.16.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.16.0...@atjson/source-prism@0.16.1) (2019-04-15)
+## [0.16.1](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.16.0...@atjson/source-prism@0.16.1) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/source-prism
 
@@ -43,66 +43,25 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.16.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.15.9...@atjson/source-prism@0.16.0) (2019-04-10)
+## [0.16.0](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.15.9...@atjson/source-prism@0.16.0) (2019-04-10)
 
 
 ### ✨ New Features
 
-* ✨ Add public app to source-html ([#123](https://github.com/CondeNast-Copilot/atjson/issues/123))
+* ✨ Add public app to source-html ([#123](https://github.com/CondeNast/atjson/issues/123))
 
 
 
-## [0.15.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.15.8...@atjson/source-prism@0.15.9) (2019-03-21)
-
-
-### 🐛 Fixes
-
-* 🐝 Fix unknown annotations passing attributes by reference and HIR optimization bug ([#122](https://github.com/CondeNast-Copilot/atjson/issues/122))
-
-
-
-## [0.15.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.15.7...@atjson/source-prism@0.15.8) (2019-03-19)
-
-**Note:** Version bump only for package @atjson/source-prism
-
-
-
-
-
-## [0.15.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.15.6...@atjson/source-prism@0.15.7) (2019-03-18)
-
-**Note:** Version bump only for package @atjson/source-prism
-
-
-
-
-
-## [0.15.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.15.5...@atjson/source-prism@0.15.6) (2019-03-18)
-
-**Note:** Version bump only for package @atjson/source-prism
-
-
-
-
-
-## [0.15.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.15.4...@atjson/source-prism@0.15.5) (2019-03-14)
+## [0.15.9](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.15.8...@atjson/source-prism@0.15.9) (2019-03-21)
 
 
 ### 🐛 Fixes
 
-* 🐝🚀 Fix performance regressions ([#118](https://github.com/CondeNast-Copilot/atjson/issues/118))
+* 🐝 Fix unknown annotations passing attributes by reference and HIR optimization bug ([#122](https://github.com/CondeNast/atjson/issues/122))
 
 
 
-## [0.15.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.15.3...@atjson/source-prism@0.15.4) (2019-02-27)
-
-**Note:** Version bump only for package @atjson/source-prism
-
-
-
-
-
-## [0.15.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.15.2...@atjson/source-prism@0.15.3) (2019-02-14)
+## [0.15.8](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.15.7...@atjson/source-prism@0.15.8) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/source-prism
 
@@ -110,7 +69,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.15.1...@atjson/source-prism@0.15.2) (2019-02-14)
+## [0.15.7](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.15.6...@atjson/source-prism@0.15.7) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/source-prism
 
@@ -118,7 +77,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.15.0...@atjson/source-prism@0.15.1) (2019-02-12)
+## [0.15.6](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.15.5...@atjson/source-prism@0.15.6) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/source-prism
 
@@ -126,7 +85,16 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.15.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.14.1...@atjson/source-prism@0.15.0) (2019-01-24)
+## [0.15.5](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.15.4...@atjson/source-prism@0.15.5) (2019-03-14)
+
+
+### 🐛 Fixes
+
+* 🐝🚀 Fix performance regressions ([#118](https://github.com/CondeNast/atjson/issues/118))
+
+
+
+## [0.15.4](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.15.3...@atjson/source-prism@0.15.4) (2019-02-27)
 
 **Note:** Version bump only for package @atjson/source-prism
 
@@ -134,7 +102,39 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-prism@0.14.0...@atjson/source-prism@0.14.1) (2019-01-14)
+## [0.15.3](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.15.2...@atjson/source-prism@0.15.3) (2019-02-14)
+
+**Note:** Version bump only for package @atjson/source-prism
+
+
+
+
+
+## [0.15.2](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.15.1...@atjson/source-prism@0.15.2) (2019-02-14)
+
+**Note:** Version bump only for package @atjson/source-prism
+
+
+
+
+
+## [0.15.1](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.15.0...@atjson/source-prism@0.15.1) (2019-02-12)
+
+**Note:** Version bump only for package @atjson/source-prism
+
+
+
+
+
+## [0.15.0](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.14.1...@atjson/source-prism@0.15.0) (2019-01-24)
+
+**Note:** Version bump only for package @atjson/source-prism
+
+
+
+
+
+## [0.14.1](https://github.com/CondeNast/atjson/compare/@atjson/source-prism@0.14.0...@atjson/source-prism@0.14.1) (2019-01-14)
 
 
 ### 🐛 Fixes

--- a/packages/@atjson/source-url/CHANGELOG.md
+++ b/packages/@atjson/source-url/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.14.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.14.4...@atjson/source-url@0.14.5) (2019-04-19)
+## [0.14.5](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.14.4...@atjson/source-url@0.14.5) (2019-04-19)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -11,7 +11,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.14.3...@atjson/source-url@0.14.4) (2019-04-18)
+## [0.14.4](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.14.3...@atjson/source-url@0.14.4) (2019-04-18)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -19,7 +19,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.14.2...@atjson/source-url@0.14.3) (2019-04-16)
+## [0.14.3](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.14.2...@atjson/source-url@0.14.3) (2019-04-16)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -27,7 +27,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.14.1...@atjson/source-url@0.14.2) (2019-04-15)
+## [0.14.2](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.14.1...@atjson/source-url@0.14.2) (2019-04-15)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -35,33 +35,25 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.14.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.14.0...@atjson/source-url@0.14.1) (2019-04-15)
+## [0.14.1](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.14.0...@atjson/source-url@0.14.1) (2019-04-15)
 
 
 ### 🐛 Fixes
 
-* 🐝 fix slice so it only includes overlapping annotations from the parent document and the correct underlying text ([#125](https://github.com/CondeNast-Copilot/atjson/issues/125))
+* 🐝 fix slice so it only includes overlapping annotations from the parent document and the correct underlying text ([#125](https://github.com/CondeNast/atjson/issues/125))
 
 
 
-## [0.14.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.13.9...@atjson/source-url@0.14.0) (2019-04-10)
+## [0.14.0](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.13.9...@atjson/source-url@0.14.0) (2019-04-10)
 
 
 ### ✨ New Features
 
-* ✨ Add public app to source-html ([#123](https://github.com/CondeNast-Copilot/atjson/issues/123))
+* ✨ Add public app to source-html ([#123](https://github.com/CondeNast/atjson/issues/123))
 
 
 
-## [0.13.9](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.13.8...@atjson/source-url@0.13.9) (2019-03-21)
-
-**Note:** Version bump only for package @atjson/source-url
-
-
-
-
-
-## [0.13.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.13.7...@atjson/source-url@0.13.8) (2019-03-19)
+## [0.13.9](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.13.8...@atjson/source-url@0.13.9) (2019-03-21)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -69,7 +61,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.13.6...@atjson/source-url@0.13.7) (2019-03-18)
+## [0.13.8](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.13.7...@atjson/source-url@0.13.8) (2019-03-19)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -77,7 +69,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.13.5...@atjson/source-url@0.13.6) (2019-03-18)
+## [0.13.7](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.13.6...@atjson/source-url@0.13.7) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -85,7 +77,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.13.4...@atjson/source-url@0.13.5) (2019-03-14)
+## [0.13.6](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.13.5...@atjson/source-url@0.13.6) (2019-03-18)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -93,7 +85,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.13.3...@atjson/source-url@0.13.4) (2019-02-27)
+## [0.13.5](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.13.4...@atjson/source-url@0.13.5) (2019-03-14)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -101,7 +93,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.13.2...@atjson/source-url@0.13.3) (2019-02-14)
+## [0.13.4](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.13.3...@atjson/source-url@0.13.4) (2019-02-27)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -109,7 +101,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.13.1...@atjson/source-url@0.13.2) (2019-02-14)
+## [0.13.3](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.13.2...@atjson/source-url@0.13.3) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -117,7 +109,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.13.0...@atjson/source-url@0.13.1) (2019-02-12)
+## [0.13.2](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.13.1...@atjson/source-url@0.13.2) (2019-02-14)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -125,7 +117,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.13.0](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.12.8...@atjson/source-url@0.13.0) (2019-01-24)
+## [0.13.1](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.13.0...@atjson/source-url@0.13.1) (2019-02-12)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -133,7 +125,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.8](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.12.7...@atjson/source-url@0.12.8) (2019-01-14)
+## [0.13.0](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.12.8...@atjson/source-url@0.13.0) (2019-01-24)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -141,7 +133,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.7](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.12.6...@atjson/source-url@0.12.7) (2019-01-09)
+## [0.12.8](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.12.7...@atjson/source-url@0.12.8) (2019-01-14)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -149,7 +141,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.6](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.12.5...@atjson/source-url@0.12.6) (2019-01-07)
+## [0.12.7](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.12.6...@atjson/source-url@0.12.7) (2019-01-09)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -157,7 +149,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.5](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.12.4...@atjson/source-url@0.12.5) (2018-12-11)
+## [0.12.6](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.12.5...@atjson/source-url@0.12.6) (2019-01-07)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -165,7 +157,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.4](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.12.3...@atjson/source-url@0.12.4) (2018-12-11)
+## [0.12.5](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.12.4...@atjson/source-url@0.12.5) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -173,7 +165,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.3](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.12.2...@atjson/source-url@0.12.3) (2018-12-11)
+## [0.12.4](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.12.3...@atjson/source-url@0.12.4) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -181,7 +173,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.2](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.12.1...@atjson/source-url@0.12.2) (2018-12-11)
+## [0.12.3](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.12.2...@atjson/source-url@0.12.3) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -189,7 +181,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 
 
-## [0.12.1](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-url@0.12.0...@atjson/source-url@0.12.1) (2018-12-11)
+## [0.12.2](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.12.1...@atjson/source-url@0.12.2) (2018-12-11)
+
+**Note:** Version bump only for package @atjson/source-url
+
+
+
+
+
+## [0.12.1](https://github.com/CondeNast/atjson/compare/@atjson/source-url@0.12.0...@atjson/source-url@0.12.1) (2018-12-11)
 
 **Note:** Version bump only for package @atjson/source-url
 
@@ -198,4 +198,4 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### ✨ New Features
 
-* ✨👩‍💻 Auto-unfurl URLs that are pasted in into an embed ([#87](https://github.com/CondeNast-Copilot/atjson/issues/87))
+* ✨👩‍💻 Auto-unfurl URLs that are pasted in into an embed ([#87](https://github.com/CondeNast/atjson/issues/87))


### PR DESCRIPTION
Pretty self-explanatory, we had some breaking links in our scripts, READMEs, and CHANGELOGs