### PR TITLE
Add HTML renderer for atjson

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/blockquote.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/blockquote.ts
@@ -3,8 +3,4 @@ import { BlockAnnotation } from '@atjson/document';
 export default class Blockquote extends BlockAnnotation {
   static type = 'blockquote';
   static vendorPrefix = 'offset';
-  attributes!: {
-    attribution: string;
-    accreditation: string;
-  };
 }

--- a/packages/@atjson/offset-annotations/src/annotations/code.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/code.ts
@@ -1,12 +1,11 @@
 import { Annotation } from '@atjson/document';
 
-export default class Code extends Annotation {
+export default class Code extends Annotation<{
+  style: 'block' | 'inline' | 'fence';
+  info?: string;
+}> {
   static vendorPrefix = 'offset';
   static type = 'code';
-  attributes!: {
-    style: 'block' | 'inline' | 'fence';
-    info?: string;
-  };
 
   get rank() {
     if (this.attributes.style === 'inline') {

--- a/packages/@atjson/offset-annotations/src/annotations/heading.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/heading.ts
@@ -1,9 +1,8 @@
 import { BlockAnnotation } from '@atjson/document';
 
-export default class Heading extends BlockAnnotation {
+export default class Heading extends BlockAnnotation<{
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+}> {
   static type = 'heading';
   static vendorPrefix = 'offset';
-  attributes!: {
-    level: 1 | 2 | 3 | 4 | 5 | 6;
-  };
 }

--- a/packages/@atjson/offset-annotations/src/annotations/html.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/html.ts
@@ -1,11 +1,10 @@
 import { Annotation } from '@atjson/document';
 
-export default class HTML extends Annotation {
+export default class HTML extends Annotation<{
+  style: 'inline' | 'block';
+}> {
   static vendorPrefix = 'offset';
   static type = 'html';
-  attributes!: {
-    style: 'inline' | 'block';
-  };
 
   get rank() {
     if (this.attributes.style === 'inline') {

--- a/packages/@atjson/offset-annotations/src/annotations/iframe-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/iframe-embed.ts
@@ -11,18 +11,16 @@ export function without<T>(array: T[], value: T): T[] {
   }, result);
 }
 
-export default class IframeEmbed extends ObjectAnnotation {
+export default class IframeEmbed extends ObjectAnnotation<{
+  url: string;
+  width?: string;
+  height?: string;
+  caption?: CaptionSource;
+  sandbox?: string;
+}> {
   static type = 'iframe-embed';
   static vendorPrefix = 'offset';
   static subdocuments = { caption: CaptionSource };
-
-  attributes!: {
-    url: string;
-    width?: string;
-    height?: string;
-    caption?: CaptionSource;
-    sandbox?: string;
-  };
 
   get url() {
     try {

--- a/packages/@atjson/offset-annotations/src/annotations/image.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/image.ts
@@ -24,15 +24,14 @@ export class ImageDescriptionSource extends Document {
   ];
 }
 
-export default class Image extends ObjectAnnotation {
+export default class Image extends ObjectAnnotation<{
+  url: string;
+  title?: string;
+  description: ImageDescriptionSource;
+}> {
   static vendorPrefix = 'offset';
   static type = 'image';
   static subdocuments = {
     description: ImageDescriptionSource
-  };
-  attributes!: {
-    url: string;
-    title: string;
-    description: ImageDescriptionSource;
   };
 }

--- a/packages/@atjson/offset-annotations/src/annotations/link.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/link.ts
@@ -1,10 +1,9 @@
 import { InlineAnnotation } from '@atjson/document';
 
-export default class Link extends InlineAnnotation {
+export default class Link extends InlineAnnotation<{
+  url: string;
+  title: string;
+}> {
   static type = 'link';
   static vendorPrefix = 'offset';
-  attributes!: {
-    url: string;
-    title: string;
-  };
 }

--- a/packages/@atjson/offset-annotations/src/annotations/list.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/list.ts
@@ -1,14 +1,13 @@
 
 import { BlockAnnotation } from '@atjson/document';
 
-export default class List extends BlockAnnotation {
+export default class List extends BlockAnnotation<{
+  type: string;
+  delimiter?: string;
+  tight?: boolean;
+  level?: number;
+  startsAt?: number;
+}> {
   static vendorPrefix = 'offset';
   static type = 'list';
-  attributes!: {
-    type: string;
-    delimiter?: string;
-    tight?: boolean;
-    level?: number;
-    startsAt?: number;
-  };
 }

--- a/packages/@atjson/renderer-html/.npmignore
+++ b/packages/@atjson/renderer-html/.npmignore
@@ -1,0 +1,11 @@
+.vscode
+.travis.yml
+dist/**/test
+dist/**/node_modules
+ember-cli-build.js
+scripts
+test
+testem.js
+tmp
+tsconfig.json
+tsling.json

--- a/packages/@atjson/renderer-html/.npmrc
+++ b/packages/@atjson/renderer-html/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/@atjson/renderer-html/README.md
+++ b/packages/@atjson/renderer-html/README.md
@@ -1,0 +1,35 @@
+# 🧭 @atjson/renderer-html
+
+Take an annotated document and render it into HTML. By default, this will take an offset document and render it to HTML.
+
+## 🎈 Extending
+
+The HTML renderer has a `$` method that's designed to make it easy to extend and write your own output to HTML.
+
+To extend the current HTML renderer to support YouTube embeds (the kind that show up when you use the share menu), we'd use the following code:
+
+```ts
+import { YouTubeEmbed } from '@atjson/offset-annotations';
+import HTMLRenderer from '@atjson/renderer-html';
+
+export default MyHTMLRenderer extends HTMLRenderer {
+  *YoutubeEmbed(embed: YouTubeEmbed) {
+    return yield* this.$('iframe', {
+      attributes: {
+        width: embed.attributes.width,
+        height: embed.attributes.height,
+        src: embed.attributes.url,
+        frameborder: '0',
+        allow: 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture',
+        allowfullscreen: true
+      }
+    });
+  }
+}
+```
+
+Now when we put in a video, like `https://www.youtube.com/watch?v=RrkL9e2w7gQ`, we'll get the following:
+
+```html
+<iframe width="560" height="315" src="https://www.youtube.com/embed/RrkL9e2w7gQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+```

--- a/packages/@atjson/renderer-html/package.json
+++ b/packages/@atjson/renderer-html/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@atjson/renderer-html",
+  "version": "0.17.1",
+  "description": "Render HTML documents from atjson",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/modules/index.js",
+  "types": "dist/commonjs/index.d.ts",
+  "scripts": {
+    "build": "rm -rf dist; tsc -p . && tsc -p . --module ESNext --outDir dist/modules/ --target ES2017",
+    "lint": "tslint -c ./tslint.json 'src/**/*.ts'",
+    "prepublishOnly": "npm run build",
+    "test": "../../../node_modules/.bin/jest packages/@atjson/$(basename $PWD) --config=../../../package.json"
+  },
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@atjson/renderer-hir": "file:../renderer-hir"
+  },
+  "devDependencies": {
+    "@atjson/offset-annotations": "file:../offset-annotations"
+  }
+}

--- a/packages/@atjson/renderer-html/src/index.ts
+++ b/packages/@atjson/renderer-html/src/index.ts
@@ -1,0 +1,143 @@
+import {
+  Code,
+  Heading,
+  Image,
+  Link,
+  List
+} from '@atjson/offset-annotations';
+import Renderer from '@atjson/renderer-hir';
+
+export default class HTMLRenderer extends Renderer {
+
+  /**
+   * Renders an HTML string from an object.
+   *
+   * To invoke this, use `yield* this.$()` to get the output.
+   * This will forward the children to this function to get wrapped
+   * in the HTML tag.
+   *
+   * @param tagName The HTML tag name to use.
+   * @param props The HTML attributes (if there are any) and whether the element is self-closing.
+   */
+  *$(tagName: string, props?: { attributes?: any, selfClosing?: boolean }) {
+    let attributes = props ? props.attributes || {} : {};
+    let htmlAttributes = Object.keys(attributes).reduce((results, key) => {
+      let value = attributes[key];
+      if (typeof value === 'number') {
+        results.push(`${key}=${value}`);
+      } else if (typeof value === 'boolean' && value === true) {
+        results.push(`${key}`);
+      } else if (value != null && value !== false) {
+        results.push(`${key}="${value}"`);
+      }
+      return results;
+    }, [] as string[]);
+    let innerHTML: string[] = yield;
+
+    let selfClosing = props ? props.selfClosing : false;
+    if (selfClosing) {
+      if (htmlAttributes.length) {
+        return `<${tagName} ${htmlAttributes.join(' ')} />`;
+      }
+
+      return `<${tagName} />`;
+    }
+
+    if (htmlAttributes.length) {
+      return `<${tagName} ${htmlAttributes.join(' ')}>${innerHTML.join('')}</${tagName}>`;
+    }
+
+    return `<${tagName}>${innerHTML.join('')}</${tagName}>`;
+  }
+
+  *root() {
+    let html = yield;
+    return html.join('');
+  }
+
+  *Blockquote() {
+    return yield* this.$('blockquote');
+  }
+
+  *Bold() {
+    return yield* this.$('strong');
+  }
+
+  *Code(code: Code) {
+    let codeSnippet = yield* this.$('code');
+
+    if (code.attributes.style === 'block' || code.attributes.style === 'fence') {
+      return `<pre>${codeSnippet}</pre>`;
+    }
+    return codeSnippet;
+  }
+
+  *Heading(heading: Heading) {
+    return yield* this.$(`h${heading.attributes.level}`);
+  }
+
+  *HorizontalRule() {
+    return yield* this.$('hr', { selfClosing: true });
+  }
+
+  *Image(image: Image) {
+    return yield* this.$('img', {
+      attributes: {
+        src: image.attributes.url,
+        title: image.attributes.title,
+        alt: image.attributes.description ?
+          (this.constructor as typeof HTMLRenderer).render(image.attributes.description) : undefined
+      },
+      selfClosing: true
+    });
+  }
+
+  *Italic() {
+    return yield* this.$('em');
+  }
+
+  *LineBreak() {
+    return yield* this.$('br', { selfClosing: true });
+  }
+
+  *Link(link: Link) {
+    return yield* this.$('a', {
+      attributes: {
+        href: link.attributes.url,
+        title: link.attributes.title
+      }
+    });
+  }
+
+  *List(list: List) {
+    let tagName = list.attributes.type === 'numbered' ? 'ol' : 'ul';
+
+    return yield* this.$(tagName, {
+      attributes: {
+        starts: list.attributes.startsAt,
+        compact: list.attributes.tight,
+        type: list.attributes.delimiter
+      }
+    });
+  }
+
+  *ListItem() {
+    return yield* this.$('li');
+  }
+
+  *Paragraph() {
+    return yield* this.$('p');
+  }
+
+  *Subscript() {
+    return yield* this.$('sub');
+  }
+
+  *Superscript() {
+    return yield* this.$('sup');
+  }
+
+  *Underline() {
+    return yield* this.$('u');
+  }
+}

--- a/packages/@atjson/renderer-html/test/renderer-test.ts
+++ b/packages/@atjson/renderer-html/test/renderer-test.ts
@@ -1,0 +1,264 @@
+import OffsetSource, {
+  Blockquote,
+  Bold,
+  Code,
+  Heading,
+  HorizontalRule,
+  Image,
+  ImageDescriptionSource,
+  Italic,
+  LineBreak,
+  Link,
+  List,
+  ListItem,
+  Paragraph,
+  Subscript,
+  Superscript,
+  Underline
+} from '@atjson/offset-annotations';
+import Renderer from '../src';
+
+describe('renderer-html', () => {
+  test('blockquote', () => {
+    let doc = new OffsetSource({
+      content: 'Hello',
+      annotations: [new Blockquote({ start: 0, end: 5 })]
+    });
+
+    expect(Renderer.render(doc)).toEqual('<blockquote>Hello</blockquote>');
+  });
+
+  test('bold', () => {
+    let doc = new OffsetSource({
+      content: 'Hello',
+      annotations: [new Bold({ start: 0, end: 5 })]
+    });
+
+    expect(Renderer.render(doc)).toEqual('<strong>Hello</strong>');
+  });
+
+  test('code', () => {
+    let code = new Code({ start: 0, end: 5 });
+    let doc = new OffsetSource({
+      content: 'Hello',
+      annotations: [code]
+    });
+
+    expect(Renderer.render(doc)).toEqual('<code>Hello</code>');
+
+    code.attributes.style = 'block';
+    expect(Renderer.render(doc)).toEqual('<pre><code>Hello</code></pre>');
+  });
+
+  describe('heading', () => {
+    test.each([1, 2, 3, 4, 5, 6] as const)('level %s', level => {
+      let doc = new OffsetSource({
+        content: 'Hello',
+        annotations: [new Heading({ start: 0, end: 5, attributes: { level } })]
+      });
+
+      expect(Renderer.render(doc)).toEqual(`<h${level}>Hello</h${level}>`);
+    });
+  });
+
+  test('horizontal rule', () => {
+    let doc = new OffsetSource({
+      content: '\uFFFC',
+      annotations: [new HorizontalRule({ start: 0, end: 1 })]
+    });
+
+    expect(Renderer.render(doc)).toEqual(`<hr />`);
+  });
+
+  test('image', () => {
+    let image = new Image({
+      start: 0,
+      end: 1,
+      attributes: {
+        url: 'https://media.newyorker.com/photos/5d30e1b9d957560008da95d7/master/w_1023,c_limit/Haigney-Hippo.gif',
+        description: new ImageDescriptionSource({
+          content: 'Hippo Hula Hooping',
+          annotations: []
+        }),
+        title: 'Haigney Hippo'
+      }
+    });
+
+    let doc = new OffsetSource({
+      content: '\uFFFC',
+      annotations: [image]
+    });
+
+    expect(Renderer.render(doc)).toEqual(`<img src="https://media.newyorker.com/photos/5d30e1b9d957560008da95d7/master/w_1023,c_limit/Haigney-Hippo.gif" title="Haigney Hippo" alt="Hippo Hula Hooping" />`);
+
+    delete image.attributes.title;
+    expect(Renderer.render(doc)).toEqual(`<img src="https://media.newyorker.com/photos/5d30e1b9d957560008da95d7/master/w_1023,c_limit/Haigney-Hippo.gif" alt="Hippo Hula Hooping" />`);
+  });
+
+  test('italic', () => {
+    let doc = new OffsetSource({
+      content: 'Hello',
+      annotations: [new Italic({ start: 0, end: 5 })]
+    });
+
+    expect(Renderer.render(doc)).toEqual('<em>Hello</em>');
+  });
+
+  test('line break', () => {
+    let doc = new OffsetSource({
+      content: '\uFFFC',
+      annotations: [new LineBreak({ start: 0, end: 1 })]
+    });
+
+    expect(Renderer.render(doc)).toEqual(`<br />`);
+  });
+
+  test('link', () => {
+    let doc = new OffsetSource({
+      content: 'Hello',
+      annotations: [new Link({
+        start: 0,
+        end: 5,
+        attributes: {
+          url: 'https://condenast.com',
+          title: 'Condé Nast'
+        }
+      })]
+    });
+
+    expect(Renderer.render(doc)).toEqual(`<a href="https://condenast.com" title="Condé Nast">Hello</a>`);
+  });
+
+  describe('ordered list', () => {
+    test('default start position', () => {
+      let doc = new OffsetSource({
+        content: 'one\ntwo',
+        annotations: [
+          new List({
+            start: 0,
+            end: 7,
+            attributes: {
+              type: 'numbered'
+            }
+          }),
+          new ListItem({ start: 0, end: 3 }),
+          new ListItem({ start: 4, end: 7 })
+        ]
+      });
+      expect(Renderer.render(doc)).toEqual(`<ol><li>one</li>\n<li>two</li></ol>`);
+    });
+
+    test('start position', () => {
+      let doc = new OffsetSource({
+        content: 'one\ntwo',
+        annotations: [
+          new List({
+            start: 0,
+            end: 7,
+            attributes: {
+              type: 'numbered',
+              startsAt: 3
+            }
+          }),
+          new ListItem({ start: 0, end: 3 }),
+          new ListItem({ start: 4, end: 7 })
+        ]
+      });
+      expect(Renderer.render(doc)).toEqual(`<ol starts=3><li>one</li>\n<li>two</li></ol>`);
+    });
+
+    test('compact', () => {
+      let doc = new OffsetSource({
+        content: 'one\ntwo',
+        annotations: [
+          new List({
+            start: 0,
+            end: 7,
+            attributes: {
+              type: 'numbered',
+              tight: true
+            }
+          }),
+          new ListItem({ start: 0, end: 3 }),
+          new ListItem({ start: 4, end: 7 })
+        ]
+      });
+      expect(Renderer.render(doc)).toEqual(`<ol compact><li>one</li>\n<li>two</li></ol>`);
+    });
+  });
+
+  describe('unordered list', () => {
+    test('default delimiter', () => {
+      let doc = new OffsetSource({
+        content: 'one\ntwo',
+        annotations: [
+          new List({
+            start: 0,
+            end: 7,
+            attributes: {
+              type: 'bulleted'
+            }
+          }),
+          new ListItem({ start: 0, end: 3 }),
+          new ListItem({ start: 4, end: 7 })
+        ]
+      });
+      expect(Renderer.render(doc)).toEqual(`<ul><li>one</li>\n<li>two</li></ul>`);
+    });
+
+    test('different delimiter', () => {
+      let doc = new OffsetSource({
+        content: 'one\ntwo',
+        annotations: [
+          new List({
+            start: 0,
+            end: 7,
+            attributes: {
+              type: 'bulleted',
+              delimiter: 'square'
+            }
+          }),
+          new ListItem({ start: 0, end: 3 }),
+          new ListItem({ start: 4, end: 7 })
+        ]
+      });
+      expect(Renderer.render(doc)).toEqual(`<ul type="square"><li>one</li>\n<li>two</li></ul>`);
+    });
+  });
+
+  test('paragraph', () => {
+    let doc = new OffsetSource({
+      content: 'Hello',
+      annotations: [new Paragraph({ start: 0, end: 5 })]
+    });
+
+    expect(Renderer.render(doc)).toEqual('<p>Hello</p>');
+  });
+
+  test('subscript', () => {
+    let doc = new OffsetSource({
+      content: 'Hello',
+      annotations: [new Subscript({ start: 0, end: 5 })]
+    });
+
+    expect(Renderer.render(doc)).toEqual('<sub>Hello</sub>');
+  });
+
+  test('superscript', () => {
+    let doc = new OffsetSource({
+      content: 'Hello',
+      annotations: [new Superscript({ start: 0, end: 5 })]
+    });
+
+    expect(Renderer.render(doc)).toEqual('<sup>Hello</sup>');
+  });
+
+  test('underline', () => {
+    let doc = new OffsetSource({
+      content: 'Hello',
+      annotations: [new Underline({ start: 0, end: 5 })]
+    });
+
+    expect(Renderer.render(doc)).toEqual('<u>Hello</u>');
+  });
+});

--- a/packages/@atjson/renderer-html/tsconfig.json
+++ b/packages/@atjson/renderer-html/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/commonjs"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/@atjson/renderer-html/tslint.json
+++ b/packages/@atjson/renderer-html/tslint.json
@@ -1,0 +1,30 @@
+{
+  "extends": "tslint:recommended",
+  "defaultSeverity": "warning",
+  "rules": {
+    "arrow-parens": [true, "ban-single-arg-parens"],
+    "curly": [true, "ignore-same-line"],
+    "forin": false,
+    "interface-name": [true, "never-prefix"],
+    "max-classes-per-file": [false],
+    "max-line-length": [false],
+    "member-access": [true, "no-public"],
+    "no-empty-interface": false,
+    "object-literal-sort-keys": false,
+    "ordered-imports": [
+      true,
+      {
+        "import-sources-order": "lowercase-last",
+        "named-imports-order": "lowercase-last"
+      }
+    ],
+    "prefer-const": false,
+    "quotemark": [true, "single"],
+    "trailing-comma": [true, { "multiline": "never", "singleline": "never" }],
+    "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore", "allow-pascal-case"],
+    "whitespace": [true,
+      "check-branch", "check-decl", "check-module", "check-operator", "check-preblock",
+      "check-rest-spread", "check-separator", "check-type", "check-type-operator", "check-typecast"
+    ]
+  }
+}

--- a/packages/@atjson/source-html/src/converter.ts
+++ b/packages/@atjson/source-html/src/converter.ts
@@ -1,4 +1,4 @@
-import OffsetSource from '@atjson/offset-annotations';
+import OffsetSource, { Code } from '@atjson/offset-annotations';
 import { Image, OrderedList } from './annotations';
 import HTMLSource from './source';
 
@@ -58,6 +58,23 @@ HTMLSource.defineConverterTo(OffsetSource, doc => {
       }
     });
   });
+
+  let $pre = doc.where({ type: '-html-pre' }).as('pre');
+  let $code = doc.where({ type: '-html-code' }).as('codeElements');
+
+  $pre.join($code, (pre, code) => pre.start < code.start && code.end < pre.end).update(({ pre, codeElements }) => {
+    let code = codeElements[0];
+    doc.replaceAnnotation(code, new Code({
+      start: code.start,
+      end: code.end,
+      attributes: {
+        style: 'block'
+      }
+    }));
+    doc.removeAnnotation(pre);
+  });
+
+  doc.where({ type: '-html-code' }).set({ type: '-offset-code', attributes: { '-offset-style': 'inline' } });
 
   return doc;
 });

--- a/packages/@atjson/source-html/src/converter.ts
+++ b/packages/@atjson/source-html/src/converter.ts
@@ -1,6 +1,19 @@
+import Document from '@atjson/document';
 import OffsetSource, { Code } from '@atjson/offset-annotations';
 import { Image, OrderedList } from './annotations';
 import HTMLSource from './source';
+
+function getText(doc: Document) {
+  let text = '';
+  let index = 0;
+  let parseTokens = doc.where({ type: '-atjson-parse-token' });
+  parseTokens.forEach(token => {
+    text += doc.content.slice(index, token.start);
+    index = token.end;
+  });
+
+  return text;
+}
 
 HTMLSource.defineConverterTo(OffsetSource, doc => {
   doc.where({ type: '-html-a' }).set({ type: '-offset-link' }).rename({ attributes: { '-html-href': '-offset-url' } });
@@ -62,17 +75,25 @@ HTMLSource.defineConverterTo(OffsetSource, doc => {
   let $pre = doc.where({ type: '-html-pre' }).as('pre');
   let $code = doc.where({ type: '-html-code' }).as('codeElements');
 
-  $pre.join($code, (pre, code) => pre.start < code.start && code.end < pre.end).update(({ pre, codeElements }) => {
-    let code = codeElements[0];
-    doc.replaceAnnotation(code, new Code({
-      start: code.start,
-      end: code.end,
-      attributes: {
-        style: 'block'
+  $pre.join($code, (pre, code) => pre.start < code.start && code.end < pre.end)
+    .update(({ pre, codeElements }) => {
+      if (codeElements.length > 1) return;
+
+      let code = codeElements[0];
+      if (!getText(doc.slice(pre.start, code.start)).match(/^\s*$/) ||
+          !getText(doc.slice(code.end, pre.end)).match(/^\s*$/)) {
+        return;
       }
-    }));
-    doc.removeAnnotation(pre);
-  });
+
+      doc.replaceAnnotation(code, new Code({
+        start: code.start,
+        end: code.end,
+        attributes: {
+          style: 'block'
+        }
+      }));
+      doc.removeAnnotation(pre);
+    });
 
   doc.where({ type: '-html-code' }).set({ type: '-offset-code', attributes: { '-offset-style': 'inline' } });
 

--- a/packages/@atjson/source-html/test/source-html-test.ts
+++ b/packages/@atjson/source-html/test/source-html-test.ts
@@ -349,17 +349,55 @@ describe('@atjson/source-html', () => {
       });
     });
 
-    test('pre code', () => {
-      let doc = HTMLSource.fromRaw(`<pre><code>console.log('wowowowow');</code></pre>`);
-      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
-      expect(hir).toMatchObject({
-        type: 'root',
-        attributes: {},
-        children: [{
-          type: 'code',
-          attributes: { style: 'block' },
-          children: [`console.log('wowowowow');`]
-        }]
+    describe('code blocks', () => {
+      test('pre code', () => {
+        let doc = HTMLSource.fromRaw(`<pre> <code>console.log('wowowowow');</code>\n</pre>`);
+        let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
+        expect(hir).toMatchObject({
+          type: 'root',
+          attributes: {},
+          children: [' ', {
+            type: 'code',
+            attributes: { style: 'block' },
+            children: [`console.log('wowowowow');`]
+          }, '\n']
+        });
+      });
+
+      test('multiple code blocks inside of pre', () => {
+        let doc = HTMLSource.fromRaw(`<pre><code>console.log('wow');</code><code>console.log('wowowow');</code></pre>`).convertTo(OffsetSource);
+        doc.where(a => a.type === 'unknown').remove();
+
+        let hir = new HIR(doc).toJSON();
+        expect(hir).toMatchObject({
+          type: 'root',
+          attributes: {},
+          children: [{
+            type: 'code',
+            attributes: { style: 'inline' },
+            children: [`console.log('wow');`]
+          }, {
+            type: 'code',
+            attributes: { style: 'inline' },
+            children: [`console.log('wowowow');`]
+          }]
+        });
+      });
+
+      test('text inside of pre, but not code', () => {
+        let doc = HTMLSource.fromRaw(`<pre>hi<code>console.log('wowowow');</code></pre>`).convertTo(OffsetSource);
+        doc.where(a => a.type === 'unknown').remove();
+
+        let hir = new HIR(doc).toJSON();
+        expect(hir).toMatchObject({
+          type: 'root',
+          attributes: {},
+          children: ['hi', {
+            type: 'code',
+            attributes: { style: 'inline' },
+            children: [`console.log('wowowow');`]
+          }]
+        });
       });
     });
 

--- a/packages/@atjson/source-html/test/source-html-test.ts
+++ b/packages/@atjson/source-html/test/source-html-test.ts
@@ -335,6 +335,34 @@ describe('@atjson/source-html', () => {
       });
     });
 
+    test('code', () => {
+      let doc = HTMLSource.fromRaw(`<code>console.log('wowowowow');</code>`);
+      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
+      expect(hir).toMatchObject({
+        type: 'root',
+        attributes: {},
+        children: [{
+          type: 'code',
+          attributes: { style: 'inline' },
+          children: [`console.log('wowowowow');`]
+        }]
+      });
+    });
+
+    test('pre code', () => {
+      let doc = HTMLSource.fromRaw(`<pre><code>console.log('wowowowow');</code></pre>`);
+      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
+      expect(hir).toMatchObject({
+        type: 'root',
+        attributes: {},
+        children: [{
+          type: 'code',
+          attributes: { style: 'block' },
+          children: [`console.log('wowowowow');`]
+        }]
+      });
+    });
+
     test('ul, ol, li', () => {
       let doc = HTMLSource.fromRaw('<ol start="2"><li>Second</li><li>Third</li></ol><ul><li>First</li><li>Second</li></ul>');
       let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();


### PR DESCRIPTION
We're trying to integrate atjson with CKEditor, so this is one of the first steps! We need to have a round-trip renderer from HTML so we can allow our editors to switch between CKEditor and our markdown editor.

This gives us a nice extension point as well (using the `$` function) to add our own renderers when we'll need them. 😄 