### PR TITLE
Make @atjson/document a peer dependency instead of a dependency

### DIFF
--- a/packages/@atjson/editor/package.json
+++ b/packages/@atjson/editor/package.json
@@ -20,12 +20,17 @@
     "last 2 Chrome versions"
   ],
   "dependencies": {
-    "@atjson/document": "file:../document",
     "@atjson/hir": "file:../hir",
     "@atjson/offset-core-components": "file:../offset-core-components",
     "@atjson/renderer-commonmark": "file:../renderer-commonmark",
     "@atjson/renderer-webcomponent": "file:../renderer-webcomponent",
     "@types/dom-inputevent": "^1.0.1",
     "node-sass": "^4.11.0"
+  },
+  "devDependencies": {
+    "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/hir/package.json
+++ b/packages/@atjson/hir/package.json
@@ -21,8 +21,13 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/document": "file:../document",
     "@types/uuid": "^3.4.4",
     "uuid": "^3.3.2"
+  },
+  "devDependencies": {
+    "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/offset-annotations/package.json
+++ b/packages/@atjson/offset-annotations/package.json
@@ -15,7 +15,10 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "devDependencies": {
     "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/offset-core-components/package.json
+++ b/packages/@atjson/offset-core-components/package.json
@@ -19,7 +19,12 @@
     "last 2 Chrome versions"
   ],
   "dependencies": {
-    "@atjson/document": "file:../document",
     "node-sass": "^4.11.0"
+  },
+  "devDependencies": {
+    "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/offset-inspector/package.json
+++ b/packages/@atjson/offset-inspector/package.json
@@ -19,10 +19,15 @@
     "last 2 Chrome versions"
   ],
   "dependencies": {
-    "@atjson/document": "file:../document",
     "@atjson/editor": "file:../editor",
     "@atjson/offset-core-components": "file:../offset-core-components",
     "@atjson/renderer-commonmark": "file:../renderer-commonmark",
     "@atjson/renderer-webcomponent": "file:../renderer-webcomponent"
+  },
+  "devDependencies": {
+    "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/renderer-commonmark/package.json
+++ b/packages/@atjson/renderer-commonmark/package.json
@@ -17,11 +17,14 @@
     "access": "public"
   },
   "devDependencies": {
+    "@atjson/document": "file:../document",
     "@atjson/source-commonmark": "file:../source-commonmark"
   },
   "dependencies": {
-    "@atjson/document": "file:../document",
     "@atjson/offset-annotations": "file:../offset-annotations",
     "@atjson/renderer-hir": "file:../renderer-hir"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/renderer-graphviz/package.json
+++ b/packages/@atjson/renderer-graphviz/package.json
@@ -16,7 +16,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/document": "file:../document",
     "@atjson/hir": "file:../hir"
+  },
+  "devDependencies": {
+    "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/renderer-hir/package.json
+++ b/packages/@atjson/renderer-hir/package.json
@@ -16,7 +16,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/document": "file:../document",
     "@atjson/hir": "file:../hir"
+  },
+  "devDependencies": {
+    "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/renderer-html/package.json
+++ b/packages/@atjson/renderer-html/package.json
@@ -19,6 +19,10 @@
     "@atjson/renderer-hir": "file:../renderer-hir"
   },
   "devDependencies": {
+    "@atjson/document": "file:../document",
     "@atjson/offset-annotations": "file:../offset-annotations"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/renderer-plain-text/package.json
+++ b/packages/@atjson/renderer-plain-text/package.json
@@ -16,9 +16,13 @@
     "access": "public"
   },
   "devDependencies": {
+    "@atjson/document": "file:../document",
     "@atjson/source-html": "file:../source-html"
   },
   "dependencies": {
     "@atjson/renderer-hir": "file:../renderer-hir"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/renderer-webcomponent/package.json
+++ b/packages/@atjson/renderer-webcomponent/package.json
@@ -16,8 +16,13 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/document": "file:../document",
     "@atjson/hir": "file:../hir",
     "@atjson/renderer-hir": "file:../renderer-hir"
+  },
+  "devDependencies": {
+    "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/source-commonmark/package.json
+++ b/packages/@atjson/source-commonmark/package.json
@@ -16,7 +16,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/document": "file:../document",
     "@atjson/offset-annotations": "file:../offset-annotations",
     "@types/entities": "^1.1.0",
     "@types/markdown-it": "^0.0.4",
@@ -24,6 +23,10 @@
     "markdown-it": "^8.4.1"
   },
   "devDependencies": {
+    "@atjson/document": "file:../document",
     "@atjson/source-html": "file:../source-html"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/source-gdocs-paste/package.json
+++ b/packages/@atjson/source-gdocs-paste/package.json
@@ -20,7 +20,12 @@
     "last 2 Chrome versions"
   ],
   "dependencies": {
-    "@atjson/document": "file:../document",
     "@atjson/offset-annotations": "file:../offset-annotations"
+  },
+  "devDependencies": {
+    "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/source-html/package.json
+++ b/packages/@atjson/source-html/package.json
@@ -20,8 +20,13 @@
     "last 2 Chrome versions"
   ],
   "dependencies": {
-    "@atjson/document": "file:../document",
     "@atjson/offset-annotations": "file:../offset-annotations",
     "parse5": "^4.0.0"
+  },
+  "devDependencies": {
+    "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/source-mobiledoc/package.json
+++ b/packages/@atjson/source-mobiledoc/package.json
@@ -16,7 +16,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/document": "file:../document",
     "@atjson/offset-annotations": "file:../offset-annotations"
+  },
+  "devDependencies": {
+    "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/source-prism/package.json
+++ b/packages/@atjson/source-prism/package.json
@@ -20,11 +20,16 @@
     "last 2 Chrome versions"
   ],
   "dependencies": {
-    "@atjson/document": "file:../document",
     "@atjson/offset-annotations": "file:../offset-annotations",
     "@atjson/source-html": "file:../source-html",
     "@types/sax": "^1.0.1",
     "entities": "^1.1.2",
     "sax": "^1.2.4"
+  },
+  "devDependencies": {
+    "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }

--- a/packages/@atjson/source-url/package.json
+++ b/packages/@atjson/source-url/package.json
@@ -20,7 +20,12 @@
     "last 2 Chrome versions"
   ],
   "dependencies": {
-    "@atjson/document": "file:../document",
     "@atjson/offset-annotations": "file:../offset-annotations"
+  },
+  "devDependencies": {
+    "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": ">= 0.17.0 < 1"
   }
 }


### PR DESCRIPTION
This should fix some dependency hell where installs of many sources / renderers result in a borked build.