### PR TITLE
Remove id from HIR.toJSON

### DIFF
--- a/packages/@atjson/hir/src/hir-node.ts
+++ b/packages/@atjson/hir/src/hir-node.ts
@@ -71,22 +71,24 @@ export default class HIRNode {
     }
   }
 
-  toJSON(options?: { includeParseTokens: boolean }): JSON {
+  toJSON(options?: { includeParseTokens: boolean, removeIdProperty: boolean }): JSON {
     if (this.annotation instanceof Text) {
       return this.text;
     }
-
-    return {
-      id: this.id,
+    let node = {
       type: this.type,
       attributes: toJSON(this.annotation.attributes),
       children: this.children(options).map(child => {
         return child.toJSON(options);
       })
     };
+    if (!options || !options.removeIdProperty) {
+      node.id = this.id;
+    }
+    return node;
   }
 
-  children(options?: { includeParseTokens: boolean }): HIRNode[] {
+  children(options?: { includeParseTokens: boolean, removeIdProperty: boolean }): HIRNode[] {
     if (this.child) {
       let children = [this.child].concat(this.child.siblings());
       if (!options || !options.includeParseTokens) {

--- a/packages/@atjson/hir/src/hir-node.ts
+++ b/packages/@atjson/hir/src/hir-node.ts
@@ -71,24 +71,21 @@ export default class HIRNode {
     }
   }
 
-  toJSON(options?: { includeParseTokens: boolean, removeIdProperty: boolean }): JSON {
+  toJSON(options?: { includeParseTokens?: boolean, removeIdProperty?: boolean }): JSON {
     if (this.annotation instanceof Text) {
       return this.text;
     }
-    let node = {
+    return {
+      id: !(options && options.removeIdProperty) ? this.id : undefined,
       type: this.type,
       attributes: toJSON(this.annotation.attributes),
       children: this.children(options).map(child => {
         return child.toJSON(options);
       })
     };
-    if (!options || !options.removeIdProperty) {
-      node.id = this.id;
-    }
-    return node;
   }
 
-  children(options?: { includeParseTokens: boolean, removeIdProperty: boolean }): HIRNode[] {
+  children(options?: { includeParseTokens?: boolean, removeIdProperty?: boolean }): HIRNode[] {
     if (this.child) {
       let children = [this.child].concat(this.child.siblings());
       if (!options || !options.includeParseTokens) {

--- a/packages/@atjson/hir/src/hir-node.ts
+++ b/packages/@atjson/hir/src/hir-node.ts
@@ -75,14 +75,17 @@ export default class HIRNode {
     if (this.annotation instanceof Text) {
       return this.text;
     }
-    return {
-      id: !(options && options.removeIdProperty) ? this.id : undefined,
+    let json: any = {
       type: this.type,
       attributes: toJSON(this.annotation.attributes),
       children: this.children(options).map(child => {
         return child.toJSON(options);
       })
-    };
+    }
+    if (!(options && options.removeIdProperty)) {
+      json.id = this.id;
+    }
+    return json;
   }
 
   children(options?: { includeParseTokens?: boolean, removeIdProperty?: boolean }): HIRNode[] {

--- a/packages/@atjson/hir/src/hir.ts
+++ b/packages/@atjson/hir/src/hir.ts
@@ -39,7 +39,7 @@ export default class HIR {
     this.rootNode.insertText(document.content);
   }
 
-  toJSON(options?: { includeParseTokens: boolean, removeIdProperty: boolean }): JSON {
+  toJSON(options?: { includeParseTokens?: boolean, removeIdProperty?: boolean }): JSON {
     return this.rootNode.toJSON(options);
   }
 }

--- a/packages/@atjson/hir/src/hir.ts
+++ b/packages/@atjson/hir/src/hir.ts
@@ -39,7 +39,7 @@ export default class HIR {
     this.rootNode.insertText(document.content);
   }
 
-  toJSON(options?: { includeParseTokens: boolean }): JSON {
+  toJSON(options?: { includeParseTokens: boolean, removeIdProperty: boolean }): JSON {
     return this.rootNode.toJSON(options);
   }
 }


### PR DESCRIPTION
This PR extends the options property that is passed to the toJSON method in the HIR class with `removeIdProperty`. 

When `removeIdProperty` is `true` ids are not included in the response from the toJSON function, allowing us to compare two HIRs for equality 
