### PR TITLE
🐞 Fix parse5 typings and upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,13 @@
         "@types/markdown-it": "^0.0.4",
         "entities": "^2.0.0",
         "markdown-it": "^8.4.1"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+        }
       }
     },
     "@atjson/source-gdocs-paste": {
@@ -152,6 +159,13 @@
       "requires": {
         "@atjson/offset-annotations": "file:packages/@atjson/offset-annotations",
         "parse5": "^5.0.0"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+          "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ=="
+        }
       }
     },
     "@atjson/source-mobiledoc": {
@@ -168,6 +182,13 @@
         "@types/sax": "^1.0.1",
         "entities": "^2.0.0",
         "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+        }
       }
     },
     "@atjson/source-url": {
@@ -3212,6 +3233,12 @@
       "version": "11.13.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.5.tgz",
       "integrity": "sha512-/OMMBnjVtDuwX1tg2pkYVSqRIDSmNTnvVvmvP/2xiMAAWf4a5+JozrApCrO4WCAILmXVxfNoQ3E+0HJbNpFVGg==",
+      "dev": true
+    },
+    "@types/parse5": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.2.tgz",
+      "integrity": "sha512-BOl+6KDs4ItndUWUFchy3aEqGdHhw0BC4Uu+qoDonN/f0rbUnJbm71Ulj8Tt9jLFRaAxPLKvdS1bBLfx1qXR9g==",
       "dev": true
     },
     "@types/prop-types": {
@@ -12274,7 +12301,8 @@
     "parse5": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "@types/jest": "24.0.11",
     "@types/node": "11.13.5",
+    "@types/parse5": "^5.0.2",
     "@types/q": "1.5.2",
     "@types/react": "16.8.13",
     "@types/react-dom": "16.8.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "paths": {
-      "parse5": ["./node_modules/parse5/lib/index.d.ts"]
+      "parse5": ["./node_modules/@types/parse5/index.d.ts"]
     },
     "removeComments": true,
     "jsx": "react",


### PR DESCRIPTION
The upgrade to parse5 to `^5.0.0` broke the HTML source because of some changes to the API. This was caused by some cached modules in the tests (it ended up getting cleared, and caused tests to fail).