### PR TITLE
🐞 make "title" optional on Link annotations

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/link.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/link.ts
@@ -2,7 +2,7 @@ import { InlineAnnotation } from '@atjson/document';
 
 export default class Link extends InlineAnnotation<{
   url: string;
-  title: string;
+  title?: string;
 }> {
   static type = 'link';
   static vendorPrefix = 'offset';


### PR DESCRIPTION
This was causing some typing errors when testing the react renderer.