### PR TITLE
Encode HTML entities when rendering to HTML

### DIFF
--- a/packages/@atjson/renderer-html/package.json
+++ b/packages/@atjson/renderer-html/package.json
@@ -16,7 +16,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/renderer-hir": "file:../renderer-hir"
+    "@atjson/renderer-hir": "file:../renderer-hir",
+    "entities": "^2.0.0"
   },
   "devDependencies": {
     "@atjson/document": "file:../document",

--- a/packages/@atjson/renderer-html/src/index.ts
+++ b/packages/@atjson/renderer-html/src/index.ts
@@ -1,5 +1,6 @@
 import { Code, Heading, Image, Link, List } from "@atjson/offset-annotations";
 import Renderer from "@atjson/renderer-hir";
+import * as entities from "entities";
 
 export default class HTMLRenderer extends Renderer {
   /**
@@ -22,7 +23,7 @@ export default class HTMLRenderer extends Renderer {
         } else if (typeof value === "boolean" && value === true) {
           results.push(`${key}`);
         } else if (value != null && value !== false) {
-          results.push(`${key}="${value}"`);
+          results.push(`${key}="${entities.encode(value)}"`);
         }
         return results;
       },
@@ -46,6 +47,10 @@ export default class HTMLRenderer extends Renderer {
     }
 
     return `<${tagName}>${innerHTML.join("")}</${tagName}>`;
+  }
+
+  text(text: string) {
+    return entities.encode(text);
   }
 
   *root() {
@@ -103,7 +108,7 @@ export default class HTMLRenderer extends Renderer {
   *Link(link: Link) {
     return yield* this.$("a", {
       attributes: {
-        href: link.attributes.url,
+        href: encodeURI(link.attributes.url),
         title: link.attributes.title
       }
     });

--- a/packages/@atjson/renderer-html/test/renderer-test.ts
+++ b/packages/@atjson/renderer-html/test/renderer-test.ts
@@ -114,24 +114,65 @@ describe("renderer-html", () => {
     expect(Renderer.render(doc)).toEqual(`<br />`);
   });
 
-  test("link", () => {
-    let doc = new OffsetSource({
-      content: "Hello",
-      annotations: [
-        new Link({
-          start: 0,
-          end: 5,
-          attributes: {
-            url: "https://condenast.com",
-            title: "Condé Nast"
-          }
-        })
-      ]
+  describe("links", () => {
+    test("url / title", () => {
+      let doc = new OffsetSource({
+        content: "Hello",
+        annotations: [
+          new Link({
+            start: 0,
+            end: 5,
+            attributes: {
+              url: "https://condenast.com",
+              title: "Condé Nast"
+            }
+          })
+        ]
+      });
+
+      expect(Renderer.render(doc)).toEqual(
+        `<a href="https://condenast.com" title="Cond&#xE9; Nast">Hello</a>`
+      );
     });
 
-    expect(Renderer.render(doc)).toEqual(
-      `<a href="https://condenast.com" title="Condé Nast">Hello</a>`
-    );
+    test("URL encoding", () => {
+      let doc = new OffsetSource({
+        content: "日本人",
+        annotations: [
+          new Link({
+            start: 0,
+            end: 6,
+            attributes: {
+              url: "https://en.wiktionary.org/wiki/日本人"
+            }
+          })
+        ]
+      });
+
+      expect(Renderer.render(doc)).toEqual(
+        `<a href="https://en.wiktionary.org/wiki/%E6%97%A5%E6%9C%AC%E4%BA%BA">&#x65E5;&#x672C;&#x4EBA;</a>`
+      );
+    });
+
+    test("entity escapes", () => {
+      let doc = new OffsetSource({
+        content: "Test",
+        annotations: [
+          new Link({
+            start: 0,
+            end: 4,
+            attributes: {
+              url: "https://example.com?q=this is a search",
+              title: `"test" <tag>`
+            }
+          })
+        ]
+      });
+
+      expect(Renderer.render(doc)).toEqual(
+        `<a href="https://example.com?q=this%20is%20a%20search" title="&quot;test&quot; &lt;tag&gt;">Test</a>`
+      );
+    });
   });
 
   describe("ordered list", () => {

--- a/packages/@atjson/source-html/test/source-html-test.ts
+++ b/packages/@atjson/source-html/test/source-html-test.ts
@@ -203,9 +203,29 @@ describe("@atjson/source-html", () => {
     });
   });
 
-  test('<a href="https://en.wiktionary.org/wiki/%E6%97%A5%E6%9C%AC%E4%BA%BA"></a>', () => {
+  test("entities in attributes", () => {
     let doc = HTMLSource.fromRaw(
-      '<a href="https://en.wiktionary.org/wiki/%E6%97%A5%E6%9C%AC%E4%BA%BA"></a>'
+      `<a href="https://example.com?q=this%20is%20a%20search" title="&quot;test&quot; &lt;tag&gt;">Test</a>`
+    );
+    expect(doc.canonical()).toMatchObject({
+      content: "Test",
+      annotations: [
+        {
+          type: "a",
+          start: 0,
+          end: 4,
+          attributes: {
+            href: "https://example.com?q=this is a search",
+            title: `"test" <tag>`
+          }
+        }
+      ]
+    });
+  });
+
+  test('<a href="https://en.wiktionary.org/wiki/%E6%97%A5%E6%9C%AC%E4%BA%BA">&#x65E5;&#x672C;&#x4EBA;</a>', () => {
+    let doc = HTMLSource.fromRaw(
+      '<a href="https://en.wiktionary.org/wiki/%E6%97%A5%E6%9C%AC%E4%BA%BA">&#x65E5;&#x672C;&#x4EBA;</a>'
     );
     let hir = new HIR(doc).toJSON();
     expect(hir).toMatchObject({
@@ -217,7 +237,7 @@ describe("@atjson/source-html", () => {
           attributes: {
             href: "https://en.wiktionary.org/wiki/日本人"
           },
-          children: []
+          children: ["日本人"]
         }
       ]
     });


### PR DESCRIPTION
This fixes a bug where we weren't encoding HTML entities or escaping URLs when we were writing a document to HTML.