### PR TITLE
🐞 make title optional on markdown link annotations

### DIFF
--- a/packages/@atjson/source-commonmark/src/annotations/link.ts
+++ b/packages/@atjson/source-commonmark/src/annotations/link.ts
@@ -5,6 +5,6 @@ export default class Link extends InlineAnnotation {
   static vendorPrefix = "commonmark";
   attributes!: {
     href: string;
-    title: string;
+    title?: string;
   };
 }


### PR DESCRIPTION
Leaving this required has resulted in difficulty using `Document#equals` between HTML sources and commonmark sources.