### PR TITLE
🐞 `clone` and `toJSON` coerced `undefined` values into `null`

### DIFF
--- a/packages/@atjson/document/src/attributes.ts
+++ b/packages/@atjson/document/src/attributes.ts
@@ -22,7 +22,7 @@ export function unprefix(
       content: string;
       annotations: AnnotationJSON[];
     };
-    return new subdocuments[(path.join("."))](serializedDocument);
+    return new subdocuments[path.join(".")](serializedDocument);
   } else if (attribute == null) {
     return null;
   } else if (typeof attribute === "object") {
@@ -92,7 +92,9 @@ export function clone(attribute: any): NonNullable<any> {
     let copy: NonNullable<any> = {};
     for (let i = 0, len = keys.length; i < len; i++) {
       let key = keys[i];
-      copy[key] = clone(attribute[key]);
+      if (attribute[key] !== undefined) {
+        copy[key] = clone(attribute[key]);
+      }
     }
     return copy;
   } else {

--- a/packages/@atjson/document/test/annotation-test.ts
+++ b/packages/@atjson/document/test/annotation-test.ts
@@ -1,4 +1,5 @@
-import TestSource, { Bold } from "./test-source";
+import TestSource, { Anchor, Bold } from "./test-source";
+
 describe("Annotation", () => {
   describe("equals", () => {
     test("annotations are properly compared for equality", () => {
@@ -96,6 +97,34 @@ describe("Annotation", () => {
           unequalRightHandSideTestDoc.annotations[0]
         )
       ).toBe(false);
+    });
+  });
+
+  describe("clone", () => {
+    test("undefined attributes", () => {
+      let link = new Anchor({
+        start: 0,
+        end: 1,
+        attributes: {
+          href: "https://www.example.com",
+          target: undefined
+        }
+      });
+
+      expect(link.equals(link.clone())).toBe(true);
+    });
+
+    test("null attributes", () => {
+      let link = new Anchor({
+        start: 0,
+        end: 1,
+        attributes: {
+          href: "https://www.example.com",
+          target: null
+        }
+      });
+
+      expect(link.equals(link.clone())).toBe(true);
     });
   });
 });

--- a/packages/@atjson/document/test/test-source.ts
+++ b/packages/@atjson/document/test/test-source.ts
@@ -8,6 +8,7 @@ import Document, {
 
 export class Anchor extends InlineAnnotation<{
   href: string;
+  target?: string | null;
 }> {
   static vendorPrefix = "test";
   static type = "a";

--- a/packages/@atjson/source-prism/test/__snapshots__/prism-test.ts.snap
+++ b/packages/@atjson/source-prism/test/__snapshots__/prism-test.ts.snap
@@ -8,24 +8,13 @@ Object {
 ",
     Object {
       "attributes": Object {
-        "-xmlns-dc": null,
-        "-xmlns-dcterms": null,
-        "-xmlns-pam": null,
-        "-xmlns-pim": null,
-        "-xmlns-prism": null,
-        "-xmlns-prl": null,
-        "-xmlns-xhtml": null,
-        "-xmlns-xsi": null,
-        "-xsi-schemalocation": null,
         "xmlns": "http://www.w3.org/1999/xhtml",
       },
       "children": Array [
         "
 ",
         Object {
-          "attributes": Object {
-            "-xml-lang": null,
-          },
+          "attributes": Object {},
           "children": Array [
             "
 ",
@@ -6972,24 +6961,13 @@ Object {
 ",
     Object {
       "attributes": Object {
-        "-xmlns-dc": null,
-        "-xmlns-dcterms": null,
-        "-xmlns-pam": null,
-        "-xmlns-pim": null,
-        "-xmlns-prism": null,
-        "-xmlns-prl": null,
-        "-xmlns-xhtml": null,
-        "-xmlns-xsi": null,
-        "-xsi-schemalocation": null,
         "xmlns": "http://www.w3.org/1999/xhtml",
       },
       "children": Array [
         "
 ",
         Object {
-          "attributes": Object {
-            "-xml-lang": null,
-          },
+          "attributes": Object {},
           "children": Array [
             "
 ",
@@ -8072,24 +8050,13 @@ Object {
 ",
     Object {
       "attributes": Object {
-        "-xmlns-dc": null,
-        "-xmlns-dcterms": null,
-        "-xmlns-pam": null,
-        "-xmlns-pim": null,
-        "-xmlns-prism": null,
-        "-xmlns-prl": null,
-        "-xmlns-xhtml": null,
-        "-xmlns-xsi": null,
-        "-xsi-schemalocation": null,
         "xmlns": "http://www.w3.org/1999/xhtml",
       },
       "children": Array [
         "
 ",
         Object {
-          "attributes": Object {
-            "-xml-lang": null,
-          },
+          "attributes": Object {},
           "children": Array [
             "
 ",


### PR DESCRIPTION
This removes undefined values from the JSON when cloning or calling toJSON, which fixes equal-ness between annotations.

This is the _real_ fix for HTML & Markdown sources not creating equivalent annotations.