### PR TITLE
🐝: fix consecutive line breaks

### DIFF
--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -1,5 +1,6 @@
 import Document, {
   Annotation,
+  BlockAnnotation,
   ParseAnnotation,
   UnknownAnnotation
 } from "@atjson/document";
@@ -429,8 +430,18 @@ export default class CommonmarkRenderer extends Renderer {
    * A line break in Commonmark can be two white spaces at the end of the line  <--
    * or it can be a backslash at the end of the line\
    */
-  *LineBreak(): Iterable<any> {
-    return "  \n";
+  *LineBreak(_: any, context: Context): Iterable<any> {
+    // Line breaks cannot end markdown block elements or paragraphs
+    if (context.parent instanceof BlockAnnotation && context.next == null) {
+      return "";
+    }
+
+    // MD code and html blocks cannot contain line breaks
+    if (context.parent.type === "code" || context.parent.type === "html") {
+      return "\n";
+    }
+
+    return "\\\n";
   }
 
   /**

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -432,11 +432,13 @@ export default class CommonmarkRenderer extends Renderer {
    */
   *LineBreak(_: any, context: Context): Iterable<any> {
     // Line breaks cannot end markdown block elements or paragraphs
+    // https://spec.commonmark.org/0.29/#example-641
     if (context.parent instanceof BlockAnnotation && context.next == null) {
       return "";
     }
 
     // MD code and html blocks cannot contain line breaks
+    // https://spec.commonmark.org/0.29/#example-637
     if (context.parent.type === "code" || context.parent.type === "html") {
       return "\n";
     }

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -1470,4 +1470,56 @@ After all the lists
       );
     });
   });
+
+  describe("line breaks", () => {
+    test("consecutive line breaks", () => {
+      let document = new OffsetSource({
+        content: "a\n\nb",
+        annotations: [
+          { type: "-offset-line-break", start: 1, end: 2, attributes: {} },
+          { type: "-offset-line-break", start: 2, end: 3, attributes: {} }
+        ]
+      });
+
+      expect(CommonmarkRenderer.render(document)).toEqual("a\\\n\\\nb");
+    });
+
+    test.each([
+      ["paragraph", "a\n\n"],
+      ["blockquote", "> a\n\n"],
+      ["heading", "## a\n"]
+    ])("ending a %s are ignored", (name, output) => {
+      let document = new OffsetSource({
+        content: "a\n",
+        annotations: [
+          {
+            type: `-offset-${name}`,
+            start: 0,
+            end: 2,
+            attributes: { "-offset-level": 2 }
+          },
+          { type: "-offset-line-break", start: 1, end: 2, attributes: {} }
+        ]
+      });
+
+      expect(CommonmarkRenderer.render(document)).toEqual(output);
+    });
+
+    test("in a code block", () => {
+      let document = new OffsetSource({
+        content: "a\nb",
+        annotations: [
+          {
+            type: "-offset-code",
+            start: 0,
+            end: 3,
+            attributes: { "-offset-style": "inline" }
+          },
+          { type: "-offset-line-break", start: 1, end: 2, attributes: {} }
+        ]
+      });
+
+      expect(CommonmarkRenderer.render(document)).toEqual("`a\nb`");
+    });
+  });
 });


### PR DESCRIPTION
This updates the commonmark renderer to use backslash + newline to
represent a line break. This allows for multiple consecutive line breaks
which the old md (space + space + newline) did not.

This also fixes behavior for line breaks ending paragraphs and block
elements, as well as line breaks in code and html blocks.