### PR TITLE
🐝: decouple annotation classes in renderer

### DIFF
--- a/packages/@atjson/editor/CHANGELOG.md
+++ b/packages/@atjson/editor/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.21.9-dev.0](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.21.8...@atjson/editor@0.21.9-dev.0) (2019-10-28)
+
+**Note:** Version bump only for package @atjson/editor
+
 ## [0.21.8](https://github.com/CondeNast/atjson/compare/@atjson/editor@0.21.7...@atjson/editor@0.21.8) (2019-10-24)
 
 **Note:** Version bump only for package @atjson/editor

--- a/packages/@atjson/editor/package.json
+++ b/packages/@atjson/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/editor",
-  "version": "0.21.8",
+  "version": "0.21.9-dev.0",
   "description": "AtJSON Editor",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",

--- a/packages/@atjson/offset-inspector/CHANGELOG.md
+++ b/packages/@atjson/offset-inspector/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.21.9-dev.0](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.21.8...@atjson/offset-inspector@0.21.9-dev.0) (2019-10-28)
+
+**Note:** Version bump only for package @atjson/offset-inspector
+
 ## [0.21.8](https://github.com/CondeNast/atjson/compare/@atjson/offset-inspector@0.21.7...@atjson/offset-inspector@0.21.8) (2019-10-24)
 
 **Note:** Version bump only for package @atjson/offset-inspector

--- a/packages/@atjson/offset-inspector/package.json
+++ b/packages/@atjson/offset-inspector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/offset-inspector",
-  "version": "0.21.8",
+  "version": "0.21.9-dev.0",
   "description": "Offset AtJSON Inspector",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",

--- a/packages/@atjson/renderer-commonmark/CHANGELOG.md
+++ b/packages/@atjson/renderer-commonmark/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.21.9-dev.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.21.8...@atjson/renderer-commonmark@0.21.9-dev.0) (2019-10-28)
+
+### 🐛 Fixes
+
+- 🐝 : decouple annotation classes in renderer
+
 ## [0.21.8](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.21.7...@atjson/renderer-commonmark@0.21.8) (2019-10-24)
 
 ### 🐛 Fixes

--- a/packages/@atjson/renderer-commonmark/package.json
+++ b/packages/@atjson/renderer-commonmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/renderer-commonmark",
-  "version": "0.21.8",
+  "version": "0.21.9-dev.0",
   "description": "A brand new TypeScript library.",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -100,7 +100,7 @@ export function* splitDelimiterRuns(
     child &&
     child.start === annotation.start &&
     child.end === annotation.end &&
-    (child instanceof Bold || child instanceof Italic)
+    (isBold(child) || isItalic(child))
   ) {
     return ["", text, ""];
   }
@@ -233,6 +233,22 @@ function getNumberOfRequiredBackticks(text: string) {
   }, 1);
 }
 
+function isBold(annotation?: any) {
+  return annotation && annotation.type === "bold";
+}
+
+function isItalic(annotation?: any) {
+  return annotation && annotation.type === "italic";
+}
+
+function isList(annotation?: any) {
+  return annotation && annotation.type === "list";
+}
+
+function isCode(annotation?: any) {
+  return annotation && annotation.type === "code";
+}
+
 export default class CommonmarkRenderer extends Renderer {
   /**
    * Controls whether HTML entities should be escaped. This
@@ -299,7 +315,7 @@ export default class CommonmarkRenderer extends Renderer {
       if (
         !context.previous &&
         !context.next &&
-        context.parent instanceof Italic &&
+        isItalic(context.parent) &&
         !hasInnerMarkup
       ) {
         return `${before}__${text}__${after}`;
@@ -408,10 +424,10 @@ export default class CommonmarkRenderer extends Renderer {
     } else {
       let markup = state.isItalicized ? "_" : "*";
       let hasWrappingBoldMarkup =
-        !context.previous && !context.next && context.parent instanceof Bold;
+        !context.previous && !context.next && isBold(context.parent);
       let hasAdjacentBoldMarkup =
-        (context.next instanceof Bold && after.length === 0) ||
-        (context.previous instanceof Bold && before.length === 0);
+        (isBold(context.next) && after.length === 0) ||
+        (isBold(context.previous) && before.length === 0);
       let hasAlignedParent =
         context.parent.start === italic.start &&
         context.parent.end === italic.end;
@@ -589,9 +605,9 @@ export default class CommonmarkRenderer extends Renderer {
       delimiter = ".";
 
       if (
-        context.previous instanceof List &&
-        context.previous.attributes.type === "numbered" &&
-        context.previous.attributes.delimiter === "."
+        isList(context.previous) &&
+        context.previous!.attributes.type === "numbered" &&
+        context.previous!.attributes.delimiter === "."
       ) {
         delimiter = ")";
       }
@@ -599,9 +615,9 @@ export default class CommonmarkRenderer extends Renderer {
       delimiter = "-";
 
       if (
-        context.previous instanceof List &&
-        context.previous.attributes.type === "bulleted" &&
-        context.previous.attributes.delimiter === "-"
+        isList(context.previous) &&
+        context.previous!.attributes.type === "bulleted" &&
+        context.previous!.attributes.delimiter === "-"
       ) {
         delimiter = "+";
       }
@@ -612,7 +628,7 @@ export default class CommonmarkRenderer extends Renderer {
 
     // Handle indendation for code blocks that immediately follow a list.
     let hasCodeBlockFollowing =
-      context.next instanceof Code && context.next.attributes.style === "block";
+      isCode(context.next) && context.next!.attributes.style === "block";
     Object.assign(this.state, {
       isList: true,
       type: list.attributes.type,


### PR DESCRIPTION
Currently there is logic in the Commonmark Renderer that checks for specific annotation classes in the rendering logic. We should decouple this, as this means this renderer will only work with specific Sources. Instead, the renderer should expose its own types or interfaces for annotations rather than using the annotation classes from a source directly. This fix resolves the immediate issue instead of fleshing out the aforementioned feature, which can be done at a later date.