### PR TITLE
🐞: Remove URL import added by mistake

### DIFF
--- a/packages/@atjson/offset-annotations/src/utils/social-urls.ts
+++ b/packages/@atjson/offset-annotations/src/utils/social-urls.ts
@@ -1,4 +1,3 @@
-import { URL } from "url";
 import {
   IframeEmbed,
   FacebookEmbed,


### PR DESCRIPTION
Removes an import added by mistake, a result of code autocompletion + carelessness.