### PR TITLE
Fix annotation defs

### DIFF
--- a/packages/@atjson/hir/src/annotations/text.ts
+++ b/packages/@atjson/hir/src/annotations/text.ts
@@ -1,11 +1,10 @@
 import { Annotation } from "@atjson/document";
 
-export default class TextAnnotation extends Annotation {
+export default class TextAnnotation extends Annotation<{
+  text: string;
+}> {
   static vendorPrefix = "atjson";
   static type = "text";
-  attributes!: {
-    text: string;
-  };
 
   get rank() {
     return Infinity;

--- a/packages/@atjson/hir/src/hir-node.ts
+++ b/packages/@atjson/hir/src/hir-node.ts
@@ -134,7 +134,7 @@ export default class HIRNode {
     let annotation = new Text({
       start: this.start,
       end: this.end,
-      attributes: {}
+      attributes: { text }
     });
     let node = new HIRNode({
       type: annotation.type,

--- a/packages/@atjson/renderer-graphviz/test/graphviz-test.ts
+++ b/packages/@atjson/renderer-graphviz/test/graphviz-test.ts
@@ -13,12 +13,11 @@ class Italic extends InlineAnnotation {
   static type = "italic";
 }
 
-class Link extends InlineAnnotation {
+class Link extends InlineAnnotation<{
+  url: string;
+}> {
   static vendorPrefix = "test";
   static type = "link";
-  attributes!: {
-    url: string;
-  };
 }
 
 class TestSource extends Document {

--- a/packages/@atjson/source-commonmark/src/annotations/bullet_list.ts
+++ b/packages/@atjson/source-commonmark/src/annotations/bullet_list.ts
@@ -1,9 +1,8 @@
 import { BlockAnnotation } from "@atjson/document";
 
-export default class BulletList extends BlockAnnotation {
+export default class BulletList extends BlockAnnotation<{
+  tight: boolean;
+}> {
   static type = "bullet_list";
   static vendorPrefix = "commonmark";
-  attributes!: {
-    tight: boolean;
-  };
 }

--- a/packages/@atjson/source-commonmark/src/annotations/fence.ts
+++ b/packages/@atjson/source-commonmark/src/annotations/fence.ts
@@ -1,9 +1,8 @@
 import { BlockAnnotation } from "@atjson/document";
 
-export default class Fence extends BlockAnnotation {
+export default class Fence extends BlockAnnotation<{
+  info: string;
+}> {
   static type = "fence";
   static vendorPrefix = "commonmark";
-  attributes!: {
-    info: string;
-  };
 }

--- a/packages/@atjson/source-commonmark/src/annotations/heading.ts
+++ b/packages/@atjson/source-commonmark/src/annotations/heading.ts
@@ -1,9 +1,8 @@
 import { BlockAnnotation } from "@atjson/document";
 
-export default class Heading extends BlockAnnotation {
+export default class Heading extends BlockAnnotation<{
+  level: number;
+}> {
   static type = "heading";
   static vendorPrefix = "commonmark";
-  attributes!: {
-    level: number;
-  };
 }

--- a/packages/@atjson/source-commonmark/src/annotations/image.ts
+++ b/packages/@atjson/source-commonmark/src/annotations/image.ts
@@ -1,11 +1,10 @@
 import { ObjectAnnotation } from "@atjson/document";
 
-export default class Image extends ObjectAnnotation {
+export default class Image extends ObjectAnnotation<{
+  alt?: string;
+  src: string;
+  title?: string;
+}> {
   static type = "image";
   static vendorPrefix = "commonmark";
-  attributes!: {
-    alt: string;
-    src: string;
-    title: string;
-  };
 }

--- a/packages/@atjson/source-commonmark/src/annotations/link.ts
+++ b/packages/@atjson/source-commonmark/src/annotations/link.ts
@@ -1,10 +1,9 @@
 import { InlineAnnotation } from "@atjson/document";
 
-export default class Link extends InlineAnnotation {
+export default class Link extends InlineAnnotation<{
+  href: string;
+  title?: string;
+}> {
   static type = "link";
   static vendorPrefix = "commonmark";
-  attributes!: {
-    href: string;
-    title?: string;
-  };
 }

--- a/packages/@atjson/source-commonmark/src/annotations/ordered_list.ts
+++ b/packages/@atjson/source-commonmark/src/annotations/ordered_list.ts
@@ -1,10 +1,9 @@
 import { BlockAnnotation } from "@atjson/document";
 
-export default class OrderedList extends BlockAnnotation {
+export default class OrderedList extends BlockAnnotation<{
+  start: number;
+  tight: boolean;
+}> {
   static type = "ordered_list";
   static vendorPrefix = "commonmark";
-  attributes!: {
-    start: number;
-    tight: boolean;
-  };
 }

--- a/packages/@atjson/source-gdocs-paste/src/annotations/heading.ts
+++ b/packages/@atjson/source-gdocs-paste/src/annotations/heading.ts
@@ -1,9 +1,8 @@
 import { BlockAnnotation } from "@atjson/document";
 
-export default class Heading extends BlockAnnotation {
+export default class Heading extends BlockAnnotation<{
+  level: 1 | 2 | 3 | 4 | 5 | 6 | 100 | 101;
+}> {
   static vendorPrefix = "gdocs";
   static type = "ps_hd";
-  attributes!: {
-    level: 1 | 2 | 3 | 4 | 5 | 6 | 100 | 101;
-  };
 }

--- a/packages/@atjson/source-gdocs-paste/src/annotations/link.ts
+++ b/packages/@atjson/source-gdocs-paste/src/annotations/link.ts
@@ -1,10 +1,9 @@
 import { InlineAnnotation } from "@atjson/document";
 
-export default class Link extends InlineAnnotation {
+export default class Link extends InlineAnnotation<{
+  ulnk_url: string;
+  lnk_type: number;
+}> {
   static vendorPrefix = "gdocs";
   static type = "lnks_link";
-  attributes!: {
-    ulnk_url: string;
-    lnk_type: number;
-  };
 }

--- a/packages/@atjson/source-gdocs-paste/src/annotations/list-item.ts
+++ b/packages/@atjson/source-gdocs-paste/src/annotations/list-item.ts
@@ -1,10 +1,9 @@
 import { BlockAnnotation } from "@atjson/document";
 
-export default class ListItem extends BlockAnnotation {
+export default class ListItem extends BlockAnnotation<{
+  ls_id: string;
+  ls_nest: number;
+}> {
   static vendorPrefix = "gdocs";
   static type = "list_item";
-  attributes!: {
-    ls_id: string;
-    ls_nest: number;
-  };
 }

--- a/packages/@atjson/source-gdocs-paste/src/annotations/list.ts
+++ b/packages/@atjson/source-gdocs-paste/src/annotations/list.ts
@@ -1,12 +1,11 @@
 import { BlockAnnotation } from "@atjson/document";
 
-export default class List extends BlockAnnotation {
+export default class List extends BlockAnnotation<{
+  ls_id: string;
+  ls_b_gs: string;
+  ls_b_gt: number;
+  ls_b_a: number;
+}> {
   static vendorPrefix = "gdocs";
   static type = "list";
-  attributes!: {
-    ls_id: string;
-    ls_b_gs: string;
-    ls_b_gt: number;
-    ls_b_a: number;
-  };
 }

--- a/packages/@atjson/source-gdocs-paste/src/annotations/vertical-adjust.ts
+++ b/packages/@atjson/source-gdocs-paste/src/annotations/vertical-adjust.ts
@@ -1,9 +1,9 @@
 import { InlineAnnotation } from "@atjson/document";
 
-export default class VerticalAdjust extends InlineAnnotation {
+export default class VerticalAdjust extends InlineAnnotation<{
+  // Vertical adjust: subscript / superscript
+  va: "sub" | "sup";
+}> {
   static vendorPrefix = "gdocs";
-  static type = "ts_va"; // Text style: underline
-  attributes!: {
-    va: "sub" | "sup"; // Vertical adjust: subscript / superscript
-  };
+  static type = "ts_va"; // Text style: vertical adjust
 }

--- a/packages/@atjson/source-mobiledoc/README.md
+++ b/packages/@atjson/source-mobiledoc/README.md
@@ -10,28 +10,28 @@ Mobiledoc's format is represented using HTML tags for built-in elements, which c
 
 All markup and sections provided by Mobiledoc have corresponding annotations. These annotations are:
 
-| Name          | Annotation type |
-|---------------|-----------------|
-| Links         | `-mobiledoc-a`  |
-| Pull Quote    | `-mobiledoc-aside` |
-|               | `-mobiledoc-pull-quote` |
-| Headings      | `-mobiledoc-h1` |
-|               | `-mobiledoc-h2` |
-|               | `-mobiledoc-h3` |
-|               | `-mobiledoc-h4` |
-|               | `-mobiledoc-h5` |
-|               | `-mobiledoc-h6` |
-| Image         | `-mobiledoc-img` |
-| Italic        | `-mobiledoc-em` |
-| List Item     | `-mobiledoc-li` |
-| Numbered List | `-mobiledoc-ol` |
-| Bulleted List | `-mobiledoc-ol` |
-| Paragraph     | `-mobiledoc-p` |
-| Strike-through | `-mobiledoc-s` |
-| Bold          | `-mobiledoc-strong` |
-| Subscript     | `-mobiledoc-sub` |
-| Superscript   | `-mobiledoc-sup` |
-| Underline     | `-mobiledoc-u` |
+| Name           | Annotation type         |
+| -------------- | ----------------------- |
+| Links          | `-mobiledoc-a`          |
+| Pull Quote     | `-mobiledoc-aside`      |
+|                | `-mobiledoc-pull-quote` |
+| Headings       | `-mobiledoc-h1`         |
+|                | `-mobiledoc-h2`         |
+|                | `-mobiledoc-h3`         |
+|                | `-mobiledoc-h4`         |
+|                | `-mobiledoc-h5`         |
+|                | `-mobiledoc-h6`         |
+| Image          | `-mobiledoc-img`        |
+| Italic         | `-mobiledoc-em`         |
+| List Item      | `-mobiledoc-li`         |
+| Numbered List  | `-mobiledoc-ol`         |
+| Bulleted List  | `-mobiledoc-ol`         |
+| Paragraph      | `-mobiledoc-p`          |
+| Strike-through | `-mobiledoc-s`          |
+| Bold           | `-mobiledoc-strong`     |
+| Subscript      | `-mobiledoc-sub`        |
+| Superscript    | `-mobiledoc-sup`        |
+| Underline      | `-mobiledoc-u`          |
 
 💁‍♀️ If you are a developer using Mobiledoc and have made custom extensions to Mobiledoc to support more sections or other types of markup, the bits of code that you'll need are the following:
 
@@ -69,14 +69,13 @@ If there's a photo card in Mobiledoc, with `id`, `size`, and `caption` propertie
 ```ts annotations/photo-card.ts
 import { ObjectAnnotation } from '@atjson/document';
 
-export default PhotoCard extends ObjectAnnotation {
+export default PhotoCard extends ObjectAnnotation<{
+  id: string;
+  size: 'small' | 'medium' | 'large';
+  caption?: string;
+}> {
   static vendorPrefix = 'mobiledoc';
   static type = 'photo-card';
-  attributes!: {
-    id: string;
-    size: 'small' | 'medium' | 'large';
-    caption?: string;
-  };
 }
 ```
 
@@ -98,12 +97,11 @@ Let's go through the exercise of adding a mention atom that works like Twitter h
 ```ts annotations/mention-atom.ts
 import { InlineAnnotation } from '@atjson/document';
 
-export default MentionAtom extends InlineAnnotation {
+export default MentionAtom extends InlineAnnotation<{
+  id: string;
+}> {
   static vendorPrefix = 'mobiledoc';
   static type = 'mention-atom';
-  attributes!: {
-    id: string;
-  };
 }
 ```
 
@@ -116,15 +114,14 @@ export default MyMobiledocSource extends MobiledocSource {
 }
 ```
 
-### 🤷‍♀️ What is a Mobiledoc? 
+### 🤷‍♀️ What is a Mobiledoc?
 
 Mobiledoc is a JSON representation of a document with a few notable bits. The format is a compressed tree view of a document, where metadata about the document is _mostly_ stored apart from the contents.
-
 
 Mobiledoc's storage format is most similar to AtJSON's heirarchical intermediate representation (hir), which shows a derived form of AtJSON's text + annotations model.
 
 [Read up more on the format itself](https://github.com/bustle/mobiledoc-kit/blob/master/MOBILEDOC.md).
 
-
 #### 📚 Read More
+
 - http://bustle.github.io/mobiledoc-kit/demo/docs/

--- a/packages/@atjson/source-mobiledoc/src/annotations/anchor.ts
+++ b/packages/@atjson/source-mobiledoc/src/annotations/anchor.ts
@@ -1,11 +1,10 @@
 import { InlineAnnotation } from "@atjson/document";
 
-export default class Anchor extends InlineAnnotation {
+export default class Anchor extends InlineAnnotation<{
+  href: string;
+  target?: string;
+  rel?: string;
+}> {
   static vendorPrefix = "mobiledoc";
   static type = "a";
-  attributes!: {
-    href: string;
-    target: string;
-    rel: string;
-  };
 }

--- a/packages/@atjson/source-mobiledoc/src/annotations/image.ts
+++ b/packages/@atjson/source-mobiledoc/src/annotations/image.ts
@@ -1,9 +1,8 @@
 import { ObjectAnnotation } from "@atjson/document";
 
-export default class Image extends ObjectAnnotation {
+export default class Image extends ObjectAnnotation<{
+  src: string;
+}> {
   static vendorPrefix = "mobiledoc";
   static type = "img";
-  attributes!: {
-    src: string;
-  };
 }

--- a/packages/@atjson/source-mobiledoc/src/annotations/ordered-list.ts
+++ b/packages/@atjson/source-mobiledoc/src/annotations/ordered-list.ts
@@ -1,9 +1,8 @@
 import { BlockAnnotation } from "@atjson/document";
 
-export default class OrderedList extends BlockAnnotation {
+export default class OrderedList extends BlockAnnotation<{
+  starts: string;
+}> {
   static vendorPrefix = "mobiledoc";
   static type = "ol";
-  attributes!: {
-    starts: string;
-  };
 }

--- a/packages/@atjson/source-mobiledoc/test/source-mobiledoc-test.ts
+++ b/packages/@atjson/source-mobiledoc/test/source-mobiledoc-test.ts
@@ -243,12 +243,11 @@ describe("@atjson/source-Mobiledoc", () => {
   });
 
   test("atom", () => {
-    class Mention extends InlineAnnotation {
+    class Mention extends InlineAnnotation<{
+      id: number;
+    }> {
       static vendorPrefix = "mobiledoc";
       static type = "mention-atom";
-      attributes!: {
-        id: number;
-      };
     }
 
     class MentionSource extends MobiledocSource {
@@ -285,13 +284,12 @@ describe("@atjson/source-Mobiledoc", () => {
   });
 
   test("card", () => {
-    class Gallery extends InlineAnnotation {
+    class Gallery extends InlineAnnotation<{
+      style: "mosaic" | "slideshow" | "list";
+      ids: number[];
+    }> {
       static vendorPrefix = "mobiledoc";
       static type = "gallery-card";
-      attributes!: {
-        style: "mosaic" | "slideshow" | "list";
-        ids: number[];
-      };
     }
 
     class GallerySource extends MobiledocSource {

--- a/website/docs/mobiledoc-source.md
+++ b/website/docs/mobiledoc-source.md
@@ -20,28 +20,28 @@ npm install --save @atjson/source-mobiledoc
 
 All markup and sections provided by Mobiledoc have corresponding annotations. These annotations are:
 
-| Name          | Annotation type |
-|---------------|-----------------|
-| Links         | `-mobiledoc-a`  |
-| Pull Quote    | `-mobiledoc-aside` |
-|               | `-mobiledoc-pull-quote` |
-| Headings      | `-mobiledoc-h1` |
-|               | `-mobiledoc-h2` |
-|               | `-mobiledoc-h3` |
-|               | `-mobiledoc-h4` |
-|               | `-mobiledoc-h5` |
-|               | `-mobiledoc-h6` |
-| Image         | `-mobiledoc-img` |
-| Italic        | `-mobiledoc-em` |
-| List Item     | `-mobiledoc-li` |
-| Numbered List | `-mobiledoc-ol` |
-| Bulleted List | `-mobiledoc-ol` |
-| Paragraph     | `-mobiledoc-p` |
-| Strike-through | `-mobiledoc-s` |
-| Bold          | `-mobiledoc-strong` |
-| Subscript     | `-mobiledoc-sub` |
-| Superscript   | `-mobiledoc-sup` |
-| Underline     | `-mobiledoc-u` |
+| Name           | Annotation type         |
+| -------------- | ----------------------- |
+| Links          | `-mobiledoc-a`          |
+| Pull Quote     | `-mobiledoc-aside`      |
+|                | `-mobiledoc-pull-quote` |
+| Headings       | `-mobiledoc-h1`         |
+|                | `-mobiledoc-h2`         |
+|                | `-mobiledoc-h3`         |
+|                | `-mobiledoc-h4`         |
+|                | `-mobiledoc-h5`         |
+|                | `-mobiledoc-h6`         |
+| Image          | `-mobiledoc-img`        |
+| Italic         | `-mobiledoc-em`         |
+| List Item      | `-mobiledoc-li`         |
+| Numbered List  | `-mobiledoc-ol`         |
+| Bulleted List  | `-mobiledoc-ol`         |
+| Paragraph      | `-mobiledoc-p`          |
+| Strike-through | `-mobiledoc-s`          |
+| Bold           | `-mobiledoc-strong`     |
+| Subscript      | `-mobiledoc-sub`        |
+| Superscript    | `-mobiledoc-sup`        |
+| Underline      | `-mobiledoc-u`          |
 
 If you are a developer using Mobiledoc and have made custom extensions to Mobiledoc to support more sections or other types of markup, the bits of code that you'll need are the following:
 
@@ -107,12 +107,11 @@ Let's go through the exercise of adding a mention atom that works like Twitter h
 ```ts
 import { InlineAnnotation } from '@atjson/document';
 
-export default MentionAtom extends InlineAnnotation {
+export default MentionAtom extends InlineAnnotation<{
+  id: string;
+}> {
   static vendorPrefix = 'mobiledoc';
   static type = 'mention-atom';
-  attributes!: {
-    id: string;
-  };
 }
 ```
 
@@ -125,7 +124,7 @@ export default MyMobiledocSource extends MobiledocSource {
 }
 ```
 
-## What is a Mobiledoc? 
+## What is a Mobiledoc?
 
 Mobiledoc is a JSON representation of a document with a few notable bits. The format is a compressed tree view of a document, where metadata about the document is _mostly_ stored apart from the contents.
 
@@ -133,6 +132,6 @@ Mobiledoc's storage format is most similar to AtJSON's heirarchical intermediate
 
 [Read up more on the format itself](https://github.com/bustle/mobiledoc-kit/blob/master/MOBILEDOC.md).
 
-
 ### Read More
+
 - http://bustle.github.io/mobiledoc-kit/demo/docs/


### PR DESCRIPTION
This PR fixes #232 by adding type definitions to annotations or by moving them from `attributes!` to the generic interface on the annotation itself.