### PR TITLE
Just say no to Unknown-Unknowns!

### DIFF
--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -900,7 +900,10 @@ After all the lists
           ]
         });
 
-        expect(CommonmarkRenderer.render(document)).toBe("*a*.b");
+        // preserved here for correct behaviour in case we decide not to throw,
+        // or to implement an `ignoreUnknown` flag or similar.
+        //expect(CommonmarkRenderer.render(document)).toBe("*a*.b");
+        expect(() => CommonmarkRenderer.render(document)).toThrow();
       });
 
       // This is a weird case in that it results in asymmetric parens, but is probably the

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -902,7 +902,7 @@ After all the lists
 
         // preserved here for correct behaviour in case we decide not to throw,
         // or to implement an `ignoreUnknown` flag or similar.
-        //expect(CommonmarkRenderer.render(document)).toBe("*a*.b");
+        // expect(CommonmarkRenderer.render(document)).toBe("*a*.b");
         expect(() => CommonmarkRenderer.render(document)).toThrow();
       });
 

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -144,6 +144,7 @@ function normalizeChildNode(childNode: HIRNode) {
     return textAnnotationFromNode(childNode);
   } else if (childNode.annotation instanceof UnknownAnnotation) {
     // FIXME This is not helpful debugging information, but I'm not sure the best way to surface more detail.
+    // eslint-disable-next-line no-console
     console.debug(
       "Encountered unknown annotation in render:",
       childNode.annotation
@@ -202,11 +203,11 @@ export default class Renderer {
     if (generator) {
       return yield* generator.call(this, annotation, context);
     } else {
-      // tslint:disable-next-line:no-console
+      // eslint-disable-next-line no-console
       console.warn(
         `[${this.constructor.name}]: No handler present for annotations of type ${annotation.type}. Possibly important information has been dropped.`
       );
-      // tslint:disable-next-line:no-console
+      // eslint-disable-next-line no-console
       console.debug("Unsupported annotation:", annotation);
       return yield;
     }

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -140,7 +140,7 @@ function compile(
  * are some use cases that would benefit from supporting UnknownAnnotations.
  */
 function normalizeChildNode(childNode: HIRNode) {
-  if (childNode.annotation instanceof TextAnnotation) {
+  if (isTextAnnotation(childNode.annotation)) {
     return textAnnotationFromNode(childNode);
   } else if (childNode.annotation instanceof UnknownAnnotation) {
     // FIXME This is not helpful debugging information, but I'm not sure the best way to surface more detail.

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -1,4 +1,8 @@
-import Document, { Annotation, AnnotationJSON } from "@atjson/document";
+import Document, {
+  Annotation,
+  AnnotationJSON,
+  UnknownAnnotation
+} from "@atjson/document";
 import { HIR, HIRNode, TextAnnotation } from "@atjson/hir";
 
 interface Mapping {
@@ -69,32 +73,6 @@ function isTextAnnotation(a: Annotation<any>): a is TextAnnotation {
   );
 }
 
-function getChildNodeAnnotations(childNode: HIRNode) {
-  if (isTextAnnotation(childNode.annotation)) {
-    return {
-      type: "text",
-      start: childNode.start,
-      end: childNode.end,
-      attributes: {
-        text: childNode.text
-      },
-      toJSON(): object {
-        return {
-          id: "Any<id>",
-          type: "-atjson-text",
-          start: childNode.start,
-          end: childNode.end,
-          attributes: {
-            "-atjson-text": childNode.text
-          }
-        };
-      }
-    };
-  } else {
-    return childNode.annotation;
-  }
-}
-
 function compile(
   renderer: Renderer,
   node: HIRNode,
@@ -102,8 +80,7 @@ function compile(
 ): any {
   let annotation = node.annotation;
   let childNodes = node.children();
-
-  let childAnnotations = childNodes.map(getChildNodeAnnotations);
+  let childAnnotations = childNodes.map(normalizeChildNode);
   let generator: Iterator<void, any, any[]>;
 
   if (context.parent == null) {
@@ -146,6 +123,61 @@ function compile(
   ).value;
 }
 
+/**
+ * This normalizes the child node (from the HIR) to ensure that we only attempt
+ * to render _known_ annotations, and converts text nodes (leaf nodes in the HIR)
+ * to have the same shape as 'normal' annotations.
+ *
+ * Usually, a document that contains `UnknownAnnotations` hasn't been fully
+ * converted, and if we didn't throw here, we would simply silently fail to
+ * render the document properly.
+ *
+ * It may be that in the future, we'll add a check that converters *must* convert
+ * all annotations (and there is a WIP change to make all converters renderers,
+ * which would have the same effect in conjunction with this change). In that case,
+ * it would be impossible to have a document that has UnknownAnnotations. At
+ * the time of writing, though, we haven't made a determination because there
+ * are some use cases that would benefit from supporting UnknownAnnotations.
+ */
+function normalizeChildNode(childNode: HIRNode) {
+  if (childNode.annotation instanceof TextAnnotation) {
+    return textAnnotationFromNode(childNode);
+  } else if (childNode.annotation instanceof UnknownAnnotation) {
+    // FIXME This is not helpful debugging information, but I'm not sure the best way to surface more detail.
+    console.debug(
+      "Encountered unknown annotation in render:",
+      childNode.annotation
+    );
+    throw new Error(
+      "Cannot render an unknown annotation. Ensure all annotations are converted or removed before attempting to render."
+    );
+  } else {
+    return childNode.annotation;
+  }
+}
+
+function textAnnotationFromNode(childNode: HIRNode): Annotation {
+  return {
+    type: "text",
+    start: childNode.start,
+    end: childNode.end,
+    attributes: {
+      text: childNode.text
+    },
+    toJSON(): object {
+      return {
+        id: "Any<id>",
+        type: "-atjson-text",
+        start: childNode.start,
+        end: childNode.end,
+        attributes: {
+          "-atjson-text": childNode.text
+        }
+      };
+    }
+  };
+}
+
 export default class Renderer {
   static render<T extends typeof Renderer>(
     this: T,
@@ -169,8 +201,15 @@ export default class Renderer {
       (this as any)[classify(annotation.type)];
     if (generator) {
       return yield* generator.call(this, annotation, context);
+    } else {
+      // tslint:disable-next-line:no-console
+      console.warn(
+        `No renderer was provided for annotations of type ${annotation.type} in the renderer ${this.constructor.name}. Possibly important information has been dropped.`
+      );
+      // tslint:disable-next-line:no-console
+      console.debug("Unsupported annotation:", annotation);
+      return yield;
     }
-    return yield;
   }
 
   *root(): Iterator<void, any, any[]> {

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -156,7 +156,7 @@ function normalizeChildNode(childNode: HIRNode) {
   }
 }
 
-function textAnnotationFromNode(childNode: HIRNode): Annotation {
+function textAnnotationFromNode(childNode: HIRNode) {
   return {
     type: "text",
     start: childNode.start,
@@ -203,9 +203,7 @@ export default class Renderer {
       return yield* generator.call(this, annotation, context);
     } else {
       // tslint:disable-next-line:no-console
-      console.warn(
-        `No renderer was provided for annotations of type ${annotation.type} in the renderer ${this.constructor.name}. Possibly important information has been dropped.`
-      );
+      console.warn(`[${this.constructor.name}]: No handler present for annotations of type ${annotation.type}. Possibly important information has been dropped.`);
       // tslint:disable-next-line:no-console
       console.debug("Unsupported annotation:", annotation);
       return yield;

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -203,7 +203,9 @@ export default class Renderer {
       return yield* generator.call(this, annotation, context);
     } else {
       // tslint:disable-next-line:no-console
-      console.warn(`[${this.constructor.name}]: No handler present for annotations of type ${annotation.type}. Possibly important information has been dropped.`);
+      console.warn(
+        `[${this.constructor.name}]: No handler present for annotations of type ${annotation.type}. Possibly important information has been dropped.`
+      );
       // tslint:disable-next-line:no-console
       console.debug("Unsupported annotation:", annotation);
       return yield;

--- a/packages/@atjson/renderer-plain-text/src/index.ts
+++ b/packages/@atjson/renderer-plain-text/src/index.ts
@@ -1,6 +1,14 @@
+import Document from "@atjson/document";
+import Annotation from "@atjson/annotation";
 import Renderer from "@atjson/renderer-hir";
 
 export default class PlainTextRenderer extends Renderer {
+  constructor(_document: Document,  ..._args: any[]) {
+    _document.where((annotation: Annotation) => annotation.type !== 'parse-token')
+             .remove();
+    super(_document, _args);
+  }
+
   *root(): Iterator<void, string, string[]> {
     let text = yield;
     return text.join("");

--- a/packages/@atjson/renderer-plain-text/src/index.ts
+++ b/packages/@atjson/renderer-plain-text/src/index.ts
@@ -1,5 +1,4 @@
-import Document from "@atjson/document";
-import Annotation from "@atjson/annotation";
+import Document, { Annotation } from "@atjson/document";
 import Renderer from "@atjson/renderer-hir";
 
 export default class PlainTextRenderer extends Renderer {

--- a/packages/@atjson/renderer-plain-text/src/index.ts
+++ b/packages/@atjson/renderer-plain-text/src/index.ts
@@ -2,10 +2,11 @@ import Document, { Annotation } from "@atjson/document";
 import Renderer from "@atjson/renderer-hir";
 
 export default class PlainTextRenderer extends Renderer {
-  constructor(_document: Document,  ..._args: any[]) {
-    _document.where((annotation: Annotation) => annotation.type !== 'parse-token')
-             .remove();
-    super(_document, _args);
+  constructor(document: Document, ...args: any[]) {
+    document
+      .where((annotation: Annotation) => annotation.type !== "parse-token")
+      .remove();
+    super(document, args);
   }
 
   *root(): Iterator<void, string, string[]> {

--- a/packages/@atjson/source-url/src/converter.ts
+++ b/packages/@atjson/source-url/src/converter.ts
@@ -23,6 +23,10 @@ URLSource.defineConverterTo(OffsetSource, doc => {
             }
           })
         );
+      } else {
+        // If we've found a URL Annotation that doesn't match a SocialURL
+        // pattern, remove it for our purposes here.
+        doc.removeAnnotation(annotation);
       }
     });
 


### PR DESCRIPTION
This adds checks to the HIR Renderer to ensure that rendering fails with UnknownAnnotations present in the document. In the event that any _known_ annotations are present in the document and not handled in a given renderer, a warning will be thrown on the debug console.

I've added tslint ignores for the console lines; I'm not sure this is the best thing to do, but I'm not sure any other way to surface the relevant warnings. I can't think of any environment where `console` is absent, but maybe we should add a guard around that, just in case?