### PR TITLE
✨ add support for sizing and alignment for giphy embeds

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/giphy-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/giphy-embed.ts
@@ -1,6 +1,9 @@
 import { IframeEmbed, without } from "./iframe-embed";
 
-export class GiphyEmbed extends IframeEmbed {
+export class GiphyEmbed extends IframeEmbed<{
+  align?: string;
+  size?: string;
+}> {
   static type = "giphy-embed";
   static vendorPrefix = "offset";
 

--- a/packages/@atjson/offset-annotations/src/annotations/iframe-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/iframe-embed.ts
@@ -11,13 +11,15 @@ export function without<T>(array: T[], value: T): T[] {
   }, result);
 }
 
-export class IframeEmbed extends ObjectAnnotation<{
-  url: string;
-  width?: string;
-  height?: string;
-  caption?: CaptionSource;
-  sandbox?: string;
-}> {
+export class IframeEmbed<AdditionalAttributes = {}> extends ObjectAnnotation<
+  {
+    url: string;
+    width?: string;
+    height?: string;
+    caption?: CaptionSource;
+    sandbox?: string;
+  } & AdditionalAttributes
+> {
   static type = "iframe-embed";
   static vendorPrefix = "offset";
   static subdocuments = { caption: CaptionSource };


### PR DESCRIPTION
The natural size of the embed is stored as width / height on the annotation and the alignment and size indicates how it should should display on the site.

We're adding support to align Giphy embeds for our editors. We'd like to extend this to video embeds as well at some point, which will allow our editors to embed full-bleed videos into stories.