### PR TITLE
Paragraph whitespace

### DIFF
--- a/packages/@atjson/renderer-commonmark/CHANGELOG.md
+++ b/packages/@atjson/renderer-commonmark/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.21.14-dev.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.21.13...@atjson/renderer-commonmark@0.21.14-dev.0) (2019-11-22)
+
+### 🐛 Fixes
+
+- 🐞 Encode \u2003 as &emsp;
+- 🐞 Only strip MD-meaningful spaces in paragraphs
+
 ## [0.21.13](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.21.12...@atjson/renderer-commonmark@0.21.13) (2019-11-18)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark

--- a/packages/@atjson/renderer-commonmark/package.json
+++ b/packages/@atjson/renderer-commonmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/renderer-commonmark",
-  "version": "0.21.13",
+  "version": "0.21.14-dev.0",
   "description": "Render atjson documents into commonmark",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -197,7 +197,8 @@ function escapeHtmlEntities(text: string) {
   return text
     .replace(/&([^\s]+);/g, "\\&$1;")
     .replace(/</g, "&lt;")
-    .replace(/\u00A0/gu, "&nbsp;");
+    .replace(/\u00A0/gu, "&nbsp;")
+    .replace(/\u2003/gu, "&emsp;");
 }
 
 function escapeEntities(text: string) {
@@ -208,7 +209,8 @@ function unescapeEntities(text: string) {
   return text
     .replace(/&amp;/gi, "&")
     .replace(/&lt;/gi, "<")
-    .replace(/&nbsp;/gi, "\u00A0");
+    .replace(/&nbsp;/gi, "\u00A0")
+    .replace(/&emsp;/gi, "\u2003");
 }
 
 function escapeAttribute(text: string) {

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -20,6 +20,8 @@ import {
   BEGINNING_WHITESPACE_PUNCTUATION,
   ENDING_WHITESPACE,
   ENDING_WHITESPACE_PUNCTUATION,
+  LEADING_MD_SPACES,
+  TRAILING_MD_SPACES,
   WHITESPACE_PUNCTUATION
 } from "./lib/punctuation";
 export * from "./lib/punctuation";
@@ -635,12 +637,13 @@ export default class CommonmarkRenderer extends Renderer {
     let rawText = yield;
     let text = rawText.join("");
 
-    // Remove leading and trailing newlines from paragraphs
-    // with text in them.
-    // This ensures that paragraphs preceded with tabs or spaces
-    // will not turn into code blocks
+    // If a paragraph has text, remove leading and trailing MD-meaningful
+    // space characters which could be interpreted as indented code blocks
+    // or line breaks
     if (!text.match(/^\s+$/g)) {
-      text = text.replace(/^\s+/g, "").replace(/\s+$/g, "");
+      text = text
+        .replace(LEADING_MD_SPACES, "")
+        .replace(TRAILING_MD_SPACES, "");
     }
 
     // Two newlines in raw text need to be encoded as HTML

--- a/packages/@atjson/renderer-commonmark/src/lib/punctuation.ts
+++ b/packages/@atjson/renderer-commonmark/src/lib/punctuation.ts
@@ -66,3 +66,7 @@ export const ENDING_WHITESPACE_PUNCTUATION = new RegExp(
 );
 export const BEGINNING_WHITESPACE = /^(\s|&nbsp;){1}/;
 export const ENDING_WHITESPACE = /(\s|&nbsp;){1}$/;
+
+export const MD_SPACES = /[ \f\n\r\t\v\u00a0]+/;
+export const LEADING_MD_SPACES = new RegExp(`^${MD_SPACES.source}`, "g");
+export const TRAILING_MD_SPACES = new RegExp(`${MD_SPACES.source}$`, "g");

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -1305,6 +1305,40 @@ After all the lists
     );
   });
 
+  test("emspaces are encoded", () => {
+    let document = new OffsetSource({
+      content: "\u2003\u2003\u2003\u2003Hello \n    This is my text",
+      annotations: [
+        {
+          id: "1",
+          type: "-offset-paragraph",
+          start: 0,
+          end: 11,
+          attributes: {}
+        },
+        {
+          id: "2",
+          type: "-offset-paragraph",
+          start: 11,
+          end: 30,
+          attributes: {}
+        }
+      ]
+    });
+
+    let markdown = CommonmarkRenderer.render(document);
+
+    expect(markdown).toBe(
+      "&emsp;&emsp;&emsp;&emsp;Hello\n\nThis is my text\n\n"
+    );
+    // Make sure we're not generating code in the round-trip
+    expect(markdown).toEqual(
+      CommonmarkRenderer.render(
+        CommonmarkSource.fromRaw(markdown).convertTo(OffsetSource)
+      )
+    );
+  });
+
   describe("escape sequences", () => {
     describe("numbers", () => {
       test.each(["5.8 million", "in 2016.", "2.0", "$280,000."])(
@@ -1545,7 +1579,7 @@ After all the lists
       });
 
       expect(CommonmarkRenderer.render(document)).toEqual(
-        "Normal text, \u2003Indented text\nMore text, \u2003\u2003\u2003Also indented"
+        "Normal text, &emsp;Indented text\nMore text, &emsp;&emsp;&emsp;Also indented"
       );
     });
   });

--- a/packages/@atjson/source-commonmark/CHANGELOG.md
+++ b/packages/@atjson/source-commonmark/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.21.13-dev.0](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.21.12...@atjson/source-commonmark@0.21.13-dev.0) (2019-11-22)
+
+### 🐛 Fixes
+
+- 🐞 Encode \u2003 as &emsp;
+
 ## [0.21.12](https://github.com/CondeNast/atjson/compare/@atjson/source-commonmark@0.21.11...@atjson/source-commonmark@0.21.12) (2019-11-18)
 
 **Note:** Version bump only for package @atjson/source-commonmark

--- a/packages/@atjson/source-commonmark/package.json
+++ b/packages/@atjson/source-commonmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/source-commonmark",
-  "version": "0.21.12",
+  "version": "0.21.13-dev.0",
   "description": "Create atjson documents from CommonMark.",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",

--- a/packages/@atjson/source-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/source-commonmark/test/commonmark-test.ts
@@ -15,7 +15,7 @@ describe("whitespace", () => {
 
   describe("non-breaking spaces", () => {
     test("html entities are converted to unicode characters", () => {
-      let doc = CommonMarkSource.fromRaw("1\n\n&#8239;\n\n&nbsp;\n\n2");
+      let doc = CommonMarkSource.fromRaw("1\n\n&#8239;\n\n&nbsp;&emsp;\n\n2");
       let hir = new HIR(doc);
       expect(hir.toJSON()).toMatchObject({
         type: "root",
@@ -34,7 +34,7 @@ describe("whitespace", () => {
           {
             type: "paragraph",
             attributes: {},
-            children: ["\u00A0"]
+            children: ["\u00A0\u2003"]
           },
           {
             type: "paragraph",


### PR DESCRIPTION
This PR updates the Commonmark renderer to support documents containing unicode emspaces (`\u2003`). There are two relevant changes:
When rendering Paragraphs, we were stripping all leading and trailing whitespace characters from their text to prevent the possibility of these characters being interpreted as markdown symbols, as leading spaces might be interpreted as an indented code block and trailing spaces might be interpreted as a line break. We were being overzealous in this stripping, as MD only considers certain whitespace characters as meaningful in this way. We obtained a narrower set of characters to strip by considering the chars which are matched by `[\s]`, `[ \f\n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]`, and checking which of these are meaningful to markdown.
Secondly, we need to encode unicode whitespace characters as html entities in the rendered output, as otherwise many markdown parsers (including Markdown-it) will ignore them. This PR does that for emspace characters only, but other unicode whitespace characters can be added as needed in subsequent PRs. 