### PR TITLE
✨ handle full giphy embeds when converting from HTML

### DIFF
--- a/packages/@atjson/source-html/src/converter/convertSocialEmbeds.ts
+++ b/packages/@atjson/source-html/src/converter/convertSocialEmbeds.ts
@@ -153,7 +153,7 @@ export default function(doc: Document) {
       doc.where({ type: "-html-p" }).as("paragraphs"),
       (iframe, paragraph) => {
         return (
-          iframe.end <= paragraph.start && iframe.start <= paragraph.end + 1
+          iframe.end <= paragraph.start && paragraph.start <= iframe.end + 1
         );
       }
     )

--- a/packages/@atjson/source-html/test/source-html-test.ts
+++ b/packages/@atjson/source-html/test/source-html-test.ts
@@ -850,6 +850,26 @@ describe("@atjson/source-html", () => {
           ]
         });
       });
+
+      test("Giphy embed", () => {
+        let doc = HTMLSource.fromRaw(
+          `<iframe src="https://giphy.com/embed/13CoXDiaCcCoyk" width="480" height="398" frameBorder="0" class="giphy-embed" allowFullScreen></iframe><p><a href="https://giphy.com/gifs/wiggle-shaq-13CoXDiaCcCoyk">via GIPHY</a></p>`
+        ).convertTo(OffsetSource);
+
+        expect(doc.canonical()).toMatchObject({
+          content: "",
+          annotations: [
+            {
+              type: "giphy-embed",
+              start: 0,
+              end: 0,
+              attributes: {
+                url: "https://giphy.com/embed/13CoXDiaCcCoyk"
+              }
+            }
+          ]
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
This correctly identifies the whole HTML chunk and removes the link and paragraph following the embed. When we were implementing smart embedding and a Giphy integration, we found that embedding full iframe embed codes from Giphy weren't being recognized because of the trailing paragraph.

This feature removes the `via Giphy` text that follows the embed and the paragraph / link that follows, resulting in cleaner output