### PR TITLE
🐞Always entity-escape emspaces

### DIFF
--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -202,7 +202,10 @@ function escapeHtmlEntities(text: string) {
 }
 
 function escapeEntities(text: string) {
-  return text.replace(/&([^\s]+);/g, "\\&$1;").replace(/\u00A0/gu, "&nbsp;");
+  return text
+    .replace(/&([^\s]+);/g, "\\&$1;")
+    .replace(/\u00A0/gu, "&nbsp;")
+    .replace(/\u2003/gu, "&emsp;");
 }
 
 function unescapeEntities(text: string) {

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -687,6 +687,17 @@ After all the lists
         let doc = new OffsetSource({ content: entity, annotations: [] });
         expect(CommonmarkRenderer.render(doc)).toBe("\\" + entity);
       });
+
+      test.each([
+        ["&emsp;", "\u2003"],
+        ["&nbsp;", "\u00a0"]
+      ])("%s", (entity, unicode) => {
+        let doc = new OffsetSource({ content: unicode, annotations: [] });
+        expect(CommonmarkRenderer.render(doc)).toBe(entity);
+        expect(
+          CommonmarkRenderer.render(doc, { escapeHtmlEntities: false })
+        ).toBe(entity);
+      });
     });
 
     describe(`don't escapeHtmlEntities`, () => {


### PR DESCRIPTION
Update the Commonmark renderer to always entity-escape unicode emspace characters. This is necessary since many md parsers will drop unicode whitespace characters. We previously added this encoding only when the `escapeHtmlEntities` flag was set on the renderer, but this should be done in any case, like we are doing with non-breaking spaces.