### PR TITLE
🚀  improve performance by not prefixing attributes on annotations

### DIFF
--- a/packages/@atjson/document/README.md
+++ b/packages/@atjson/document/README.md
@@ -13,16 +13,16 @@ Typically when dealing with text, we think of markup languages, like HTML, XML, 
 As an example markdown document like the following:
 
 ```md
-*Roses* are red,  
-*Violets* are blue.
+_Roses_ are red,  
+_Violets_ are blue.
 ```
 
 Can be parsed into an AtJSON document by passing it into a source in AtJSON. A source is kind of like a parser, but is called a source because they use a parser, and normally we don't do any parsing in a source. Here we use AtJSON's built-in Commonmark source, which is a document format that supports all markdown features specified in the CommonMark spec.
 
 ```typescript
-import CommonmarkSource from '@atjson/source-commonmark';
- 
-CommonmarkSource.fromRaw('*Roses* are red,  \n*Violets* are blue.');
+import CommonmarkSource from "@atjson/source-commonmark";
+
+CommonmarkSource.fromRaw("*Roses* are red,  \n*Violets* are blue.");
 ```
 
 The result is a logical representation of the markdown document:
@@ -30,54 +30,63 @@ The result is a logical representation of the markdown document:
 ```json
 {
   "content": "*Roses* are red,  \n*Violets* are blue.",
-  "annotations": [{
-    "type": "-commonmark-em",
-    "start": 0,
-    "end": 7,
-    "attributes": {}
-  }, {
-    "type": "-atjson-parse-token",
-    "start": 0,
-    "end": 1,
-    "attributes": {
-      "-atjson-reason": "em_open"
+  "annotations": [
+    {
+      "type": "-commonmark-em",
+      "start": 0,
+      "end": 7,
+      "attributes": {}
+    },
+    {
+      "type": "-atjson-parse-token",
+      "start": 0,
+      "end": 1,
+      "attributes": {
+        "reason": "em_open"
+      }
+    },
+    {
+      "type": "-atjson-parse-token",
+      "start": 6,
+      "end": 7,
+      "attributes": {
+        "reason": "em_close"
+      }
+    },
+    {
+      "type": "-commonmark-hard_break",
+      "start": 16,
+      "end": 19,
+      "attributes": {}
+    },
+    {
+      "type": "-commonmark-em",
+      "start": 20,
+      "end": 29,
+      "attributes": {}
+    },
+    {
+      "type": "-atjson-parse-token",
+      "start": 20,
+      "end": 21,
+      "attributes": {
+        "reason": "em_open"
+      }
+    },
+    {
+      "type": "-atjson-parse-token",
+      "start": 28,
+      "end": 29,
+      "attributes": {
+        "reason": "em_close"
+      }
     }
-  }, {
-    "type": "-atjson-parse-token",
-    "start": 6,
-    "end": 7,
-    "attributes": {
-      "-atjson-reason": "em_close"
-    }
-  }, {
-    "type": "-commonmark-hard_break",
-    "start": 16,
-    "end": 19,
-    "attributes": {}
-  }, {
-    "type": "-commonmark-em",
-    "start": 20,
-    "end": 29,
-    "attributes": {}
-  }, {
-    "type": "-atjson-parse-token",
-    "start": 20,
-    "end": 21,
-    "attributes": {
-      "-atjson-reason": "em_open"
-    }
-  }, {
-    "type": "-atjson-parse-token",
-    "start": 28,
-    "end": 29,
-    "attributes": {
-      "-atjson-reason": "em_close"
-    }
-  }]
+  ]
 }
 ```
 
 **💁‍♀️ Notes**
+
 > AtJSON stores annotations with vendor prefixes. These are meant to prevent collisions between different types of documents.
 >
 > Positions indicate the position \*between\* characters, not the character boundary. This means `{ start: 0, end: 1 }` is over the first character of the content.
@@ -95,33 +104,33 @@ Documents have associated annotation classes that will turn the JSON into a full
 As an intro into documents, let's create a small document definition that describes addresses:
 
 ```typescript
-import Document, { InlineAnnotation } from '@atjson/document';
- 
+import Document, { InlineAnnotation } from "@atjson/document";
+
 class Name extends InlineAnnotation {
-  static vendorPrefix = 'address';
-  static type = 'name';
+  static vendorPrefix = "address";
+  static type = "name";
 }
- 
+
 class AddressLine extends InlineAnnotation {
-  static vendorPrefix = 'address';
-  static type = 'line';
+  static vendorPrefix = "address";
+  static type = "line";
 }
- 
+
 class PostalCode extends InlineAnnotation {
-  static vendorPrefix = 'address';
-  static type = 'postal-code';
+  static vendorPrefix = "address";
+  static type = "postal-code";
 }
- 
+
 class City extends InlineAnnotation {
-  static vendorPrefix = 'address';
-  static type = 'city';
+  static vendorPrefix = "address";
+  static type = "city";
 }
- 
+
 class Region extends InlineAnnotation {
-  static vendorPrefix = 'address';
-  static type = 'region';
+  static vendorPrefix = "address";
+  static type = "region";
 }
- 
+
 class Address extends Document {
   static schema = [Name, AddressLine, PostalCode, City, Region];
 }
@@ -142,7 +151,7 @@ let address = new Address({
   content: "Condé Nast\n1 WTC\nNew York, NY 10006",
   annotations: []
 });
- 
+
 address.addAnnotations(
   new Name({ start: 0, end: 10 }),
   new AddressLine({ start: 11, end: 16 }),
@@ -154,51 +163,51 @@ address.addAnnotations(
 
 It seems very arbitrary to store data this way. Why would we do this?
 
-Well, we think this provides the most natural input mechanism for people, while providing robust machine reading capabilities. Documents provide tools that manage annotations so when text is added or removed it "just works" as expected. So, if we wanted to change the text here, and we inserted " Entertainment"  after "Condé Nast", the annotations would remain intact, and in fact, would cover the correct text!
+Well, we think this provides the most natural input mechanism for people, while providing robust machine reading capabilities. Documents provide tools that manage annotations so when text is added or removed it "just works" as expected. So, if we wanted to change the text here, and we inserted " Entertainment" after "Condé Nast", the annotations would remain intact, and in fact, would cover the correct text!
 
 The flexibility here also means that we can render this address out into something more suitable for Google, such as JSONLD. We can use AtJSON's rendering here to take this document and turn it into something that can show a rich location card in search results. Note that in order to do this, we define a rendering rule for every annotation we've defined thus far for our Address schema:
 
 ```typescript
-import Renderer from '@atjson/renderer-hir';
- 
+import Renderer from "@atjson/renderer-hir";
+
 class JSONLDRenderer extends Renderer {
   private jsonld: any;
- 
+
   constructor() {
     this.jsonld = {
       "@context": "https://schema.org",
       "@type": "Place",
-      "address": {
+      address: {
         "@type": "PostalAddress"
       }
     };
   }
- 
+
   *Name() {
     let name = yield;
-    this.jsonld.name = name.join('');
+    this.jsonld.name = name.join("");
   }
- 
+
   *AddressLine() {
     let streetAddress = yield;
-    this.jsonld.address.streetAddress = streetAddress.join('');
+    this.jsonld.address.streetAddress = streetAddress.join("");
   }
- 
+
   *City() {
     let addressLocality = yield;
-    this.jsonld.address.addressLocality = addressLocality.join('');
+    this.jsonld.address.addressLocality = addressLocality.join("");
   }
- 
+
   *Region() {
     let addressRegion = yield;
-    this.jsonld.address.addressRegion = addressRegion.join('');
+    this.jsonld.address.addressRegion = addressRegion.join("");
   }
- 
+
   *PostalCode() {
     let postalCode = yield;
-    this.jsonld.address.postalCode = postalCode.join('');
+    this.jsonld.address.postalCode = postalCode.join("");
   }
- 
+
   *root() {
     yield;
     return this.jsonld;
@@ -225,32 +234,35 @@ Sending the document that we created through this would result in a JSON-LD obje
 This was a bit of a whirlwind, but we think it provides a good example of ways that you can start thinking about how to use annotations!
 
 **💁‍♀️ Notes**
+
 > We call a defined document schema a "source". They're not exactly parsers, since they represent the content in AtJSON in that format. I like to think of them like a source that a journalist has, where they collect information from that source and use it in their reporting.
 
 ## 🔍 How to find data in a document
+
 Annotations in AtJSON can be treated like a little database. It's a little like how jQuery suddenly opened up the possibilities of what could be done on websites because you could do simple and elegant manipulation.
 
 There's 2 levels of querying for documents. The first is partial matches:
 
 ```typescript
-doc.where({ type: '-offset-link' });
+doc.where({ type: "-offset-link" });
 ```
 
 This query will find all links in a document
 
 **💁‍♀️ Notes**
+
 > The partial match query language requires vendor prefixes
 
 The equivalent version of this using the function syntax would be:
 
 ```typescript
-import { Link } from '@atjson/offset-annotations';
- 
+import { Link } from "@atjson/offset-annotations";
+
 doc.where(annotation => annotation instanceof Link);
 ```
 
-
 **💁‍♀️ Notes**
+
 > The function syntax returns hydrated annotations. You may encounter Unknown annotations here, which are annotations that are unsupported by the document schema. Be careful! 👹
 
 ### 👹A note about Unknown Annotations
@@ -269,18 +281,18 @@ This data is stored as unknown annotations, which are an annotation that stores 
   }
 }
 ```
- 
+
 Turns into:
 
-```typescript 
+```typescript
 new UnknownAnnotation({
   start: 0,
   end: 10,
   attributes: {
-    type: '-html-marquee',
+    type: "-html-marquee",
     attributes: {
-      '-html-style': 'rainbow'
+      "-html-style": "rainbow"
     }
   }
-})
+});
 ```

--- a/packages/@atjson/document/src/annotation.ts
+++ b/packages/@atjson/document/src/annotation.ts
@@ -1,5 +1,5 @@
 import { v4 as uuid } from "uuid";
-import { clone, toJSON, unprefix } from "./attributes";
+import { clone, toJSON, hydrate } from "./attributes";
 import Change, {
   AdjacentBoundaryBehaviour,
   Deletion,
@@ -75,7 +75,7 @@ export default abstract class Annotation<Attributes = {}> {
       id: attrs.id,
       start: attrs.start,
       end: attrs.end,
-      attributes: unprefix(this.subdocuments, attrs.attributes)
+      attributes: hydrate(this.subdocuments, attrs.attributes)
     });
   }
 
@@ -251,7 +251,7 @@ export default abstract class Annotation<Attributes = {}> {
       type: `-${vendorPrefix}-${this.type}`,
       start: this.start,
       end: this.end,
-      attributes: toJSON(this.attributes)
+      attributes: toJSON(AnnotationClass.subdocuments, this.attributes)
     };
   }
 }

--- a/packages/@atjson/document/src/annotation.ts
+++ b/packages/@atjson/document/src/annotation.ts
@@ -75,11 +75,7 @@ export default abstract class Annotation<Attributes = {}> {
       id: attrs.id,
       start: attrs.start,
       end: attrs.end,
-      attributes: unprefix(
-        this.vendorPrefix,
-        this.subdocuments,
-        attrs.attributes
-      )
+      attributes: unprefix(this.subdocuments, attrs.attributes)
     });
   }
 
@@ -255,7 +251,7 @@ export default abstract class Annotation<Attributes = {}> {
       type: `-${vendorPrefix}-${this.type}`,
       start: this.start,
       end: this.end,
-      attributes: toJSON(vendorPrefix, this.attributes)
+      attributes: toJSON(this.attributes)
     };
   }
 }

--- a/packages/@atjson/document/src/attributes.ts
+++ b/packages/@atjson/document/src/attributes.ts
@@ -2,7 +2,6 @@ import Document, { AnnotationJSON } from "./index";
 import JSON, { JSONObject } from "./json";
 
 export function unprefix(
-  vendorPrefix: string,
   subdocuments: { [key: string]: typeof Document },
   attribute: JSON,
   path: Array<string | number> = []
@@ -10,7 +9,6 @@ export function unprefix(
   if (Array.isArray(attribute)) {
     return attribute.map(function unprefixAttr(attr, index) {
       let result = unprefix(
-        vendorPrefix,
         subdocuments,
         attr,
         path.concat(index)
@@ -29,13 +27,11 @@ export function unprefix(
     let attrs: NonNullable<any> = {};
     for (let key in attribute) {
       let value = attribute[key];
-      if (key.indexOf(`-${vendorPrefix}-`) === 0 && value !== undefined) {
-        let unprefixedKey = key.slice(`-${vendorPrefix}-`.length);
-        attrs[unprefixedKey] = unprefix(
-          vendorPrefix,
+      if (value !== undefined) {
+        attrs[key] = unprefix(
           subdocuments,
           value,
-          path.concat(unprefixedKey)
+          path.concat(key)
         );
       } else {
         attrs[key] = value;
@@ -48,10 +44,10 @@ export function unprefix(
   }
 }
 
-export function toJSON(vendorPrefix: string, attribute: NonNullable<any>): any {
+export function toJSON(attribute: NonNullable<any>): any {
   if (Array.isArray(attribute)) {
     return attribute.map(function attributeToJSON(attr) {
-      let result = toJSON(vendorPrefix, attr);
+      let result = toJSON(attr);
       return result;
     });
   } else if (attribute instanceof Document) {
@@ -63,11 +59,7 @@ export function toJSON(vendorPrefix: string, attribute: NonNullable<any>): any {
     for (let key in attribute) {
       let value = attribute[key];
       if (value !== undefined) {
-        if (key[0] === "-") {
-          copy[key] = toJSON(vendorPrefix, value);
-        } else {
-          copy[`-${vendorPrefix}-${key}`] = toJSON(vendorPrefix, value);
-        }
+        copy[key] = toJSON(value);
       }
     }
 

--- a/packages/@atjson/document/test/annotation-test.ts
+++ b/packages/@atjson/document/test/annotation-test.ts
@@ -18,8 +18,8 @@ describe("Annotation", () => {
             start: 0,
             end: 1,
             attributes: {
-              "-test-url": "http://www.example.com/test.jpg",
-              "-test-caption": {
+              url: "http://www.example.com/test.jpg",
+              caption: {
                 content: "An example caption",
                 annotations: [
                   {
@@ -44,8 +44,8 @@ describe("Annotation", () => {
             start: 0,
             end: 1,
             attributes: {
-              "-test-url": "http://www.example.com/test.jpg",
-              "-test-caption": {
+              url: "http://www.example.com/test.jpg",
+              caption: {
                 content: "An example caption",
                 annotations: [
                   {
@@ -70,8 +70,8 @@ describe("Annotation", () => {
             start: 0,
             end: 1,
             attributes: {
-              "-test-url": "http://www.example.com/test.jpg",
-              "-test-caption": {
+              url: "http://www.example.com/test.jpg",
+              caption: {
                 content: "An example caption",
                 annotations: [
                   {

--- a/packages/@atjson/document/test/atjson-insert-test.ts
+++ b/packages/@atjson/document/test/atjson-insert-test.ts
@@ -27,7 +27,7 @@ describe("Document.insertText", () => {
           start: 1,
           end: 2,
           attributes: {
-            "-test-uri": "https://example.com"
+            uri: "https://example.com"
           }
         }
       ]
@@ -53,7 +53,7 @@ describe("Document.insertText", () => {
         start: 4,
         end: 5,
         attributes: {
-          "-test-uri": "https://example.com"
+          uri: "https://example.com"
         }
       }
     ]);
@@ -75,7 +75,7 @@ describe("Document.insertText", () => {
           start: 0,
           end: 2,
           attributes: {
-            "-test-color": "blue"
+            color: "blue"
           }
         }
       ]
@@ -100,7 +100,7 @@ describe("Document.insertText", () => {
         start: 0,
         end: 2,
         attributes: {
-          "-test-color": "blue"
+          color: "blue"
         }
       }
     ]);

--- a/packages/@atjson/document/test/atjson-test.ts
+++ b/packages/@atjson/document/test/atjson-test.ts
@@ -108,8 +108,8 @@ describe("new Document", () => {
           start: 0,
           end: 1,
           attributes: {
-            "-test-url": "http://www.example.com/test.jpg",
-            "-test-caption": {
+            url: "http://www.example.com/test.jpg",
+            caption: {
               content: "An example caption",
               annotations: [
                 {
@@ -246,7 +246,7 @@ describe("new Document", () => {
           start: 14,
           end: 15,
           attributes: {
-            "-test-uri": "https://www.instagram.com/p/BeW0pqZDUuK/"
+            uri: "https://www.instagram.com/p/BeW0pqZDUuK/"
           }
         }
       ]
@@ -392,7 +392,7 @@ describe("new Document", () => {
             start: 14,
             end: 15,
             attributes: {
-              "-test-uri": "https://www.instagram.com/p/BeW0pqZDUuK/"
+              uri: "https://www.instagram.com/p/BeW0pqZDUuK/"
             }
           }
         ]
@@ -432,7 +432,7 @@ describe("new Document", () => {
             start: 14,
             end: 15,
             attributes: {
-              "-test-uri": "https://www.instagram.com/p/BeW0pqZDUuK/"
+              uri: "https://www.instagram.com/p/BeW0pqZDUuK/"
             }
           }
         ]
@@ -491,7 +491,7 @@ describe("new Document", () => {
             start: 9,
             end: 10,
             attributes: {
-              "-test-uri": "https://www.instagram.com/p/BeW0pqZDUuK/"
+              uri: "https://www.instagram.com/p/BeW0pqZDUuK/"
             }
           }
         ]

--- a/packages/@atjson/document/test/document-test.ts
+++ b/packages/@atjson/document/test/document-test.ts
@@ -276,8 +276,8 @@ describe("Document#equals", () => {
           start: 0,
           end: 1,
           attributes: {
-            "-test-url": "http://www.example.com/test.jpg",
-            "-test-caption": {
+            url: "http://www.example.com/test.jpg",
+            caption: {
               content: "An example caption",
               annotations: [
                 {
@@ -302,8 +302,8 @@ describe("Document#equals", () => {
           start: 0,
           end: 1,
           attributes: {
-            "-test-url": "http://www.example.com/test.jpg",
-            "-test-caption": {
+            url: "http://www.example.com/test.jpg",
+            caption: {
               content: "An example caption",
               annotations: [
                 {
@@ -328,8 +328,8 @@ describe("Document#equals", () => {
           start: 0,
           end: 1,
           attributes: {
-            "-test-url": "http://www.example.com/test.jpg",
-            "-test-caption": {
+            url: "http://www.example.com/test.jpg",
+            caption: {
               content: "An example caption",
               annotations: [
                 {

--- a/packages/@atjson/document/test/query-test.ts
+++ b/packages/@atjson/document/test/query-test.ts
@@ -9,7 +9,7 @@ describe("Document#all", () => {
           id: "1",
           type: "-test-a",
           attributes: {
-            "-test-href": "https://example.com"
+            href: "https://example.com"
           },
           start: 0,
           end: 5
@@ -18,7 +18,7 @@ describe("Document#all", () => {
           id: "2",
           type: "-test-a",
           attributes: {
-            "-test-href": "https://condenast.com"
+            href: "https://condenast.com"
           },
           start: 6,
           end: 10
@@ -85,14 +85,14 @@ describe("Document#where", () => {
 
     doc
       .where({ type: "-test-h1" })
-      .set({ type: "-test-heading", attributes: { "-test-level": 1 } });
+      .set({ type: "-test-heading", attributes: { level: 1 } });
     expect(doc.content).toBe("Hello");
     expect(doc.annotations.map(a => a.toJSON())).toEqual([
       {
         id: "1",
         type: "-test-heading",
         attributes: {
-          "-test-level": 1
+          level: 1
         },
         start: 0,
         end: 5
@@ -108,8 +108,8 @@ describe("Document#where", () => {
           id: "1",
           type: "-test-social",
           attributes: {
-            "-test-type": "instagram",
-            "-test-uri": "https://www.instagram.com/p/BeW0pqZDUuK/"
+            type: "instagram",
+            uri: "https://www.instagram.com/p/BeW0pqZDUuK/"
           },
           start: 0,
           end: 1
@@ -120,10 +120,10 @@ describe("Document#where", () => {
     doc
       .where({
         type: "-test-social",
-        attributes: { "-test-type": "instagram" }
+        attributes: { type: "instagram" }
       })
       .set({ type: "-test-instagram" })
-      .unset("attributes.-test-type");
+      .unset("attributes.type");
 
     expect(doc.content).toBe("\uFFFC");
     expect(doc.annotations.map(a => a.toJSON())).toEqual([
@@ -131,7 +131,7 @@ describe("Document#where", () => {
         id: "1",
         type: "-test-instagram",
         attributes: {
-          "-test-uri": "https://www.instagram.com/p/BeW0pqZDUuK/"
+          uri: "https://www.instagram.com/p/BeW0pqZDUuK/"
         },
         start: 0,
         end: 1
@@ -147,7 +147,7 @@ describe("Document#where", () => {
           id: "1",
           type: "-test-a",
           attributes: {
-            "-test-href": "https://example.com"
+            href: "https://example.com"
           },
           start: 0,
           end: 5
@@ -156,7 +156,7 @@ describe("Document#where", () => {
           id: "2",
           type: "-test-a",
           attributes: {
-            "-test-href": "https://condenast.com"
+            href: "https://condenast.com"
           },
           start: 6,
           end: 10
@@ -167,14 +167,14 @@ describe("Document#where", () => {
     doc
       .where({ type: "-test-a" })
       .set({ type: "-test-link" })
-      .rename({ attributes: { "-test-href": "-test-url" } });
+      .rename({ attributes: { href: "url" } });
     expect(doc.content).toBe("Conde Nast");
     expect(doc.annotations.map(a => a.toJSON())).toEqual([
       {
         id: "1",
         type: "-test-link",
         attributes: {
-          "-test-url": "https://example.com"
+          url: "https://example.com"
         },
         start: 0,
         end: 5
@@ -183,32 +183,7 @@ describe("Document#where", () => {
         id: "2",
         type: "-test-link",
         attributes: {
-          "-test-url": "https://condenast.com"
-        },
-        start: 6,
-        end: 10
-      }
-    ]);
-
-    doc
-      .where({ type: "-test-link" })
-      .rename({ attributes: { "-test-url": "-vendor-url" } });
-    expect(doc.content).toBe("Conde Nast");
-    expect(doc.annotations.map(a => a.toJSON())).toEqual([
-      {
-        id: "1",
-        type: "-test-link",
-        attributes: {
-          "-vendor-url": "https://example.com"
-        },
-        start: 0,
-        end: 5
-      },
-      {
-        id: "2",
-        type: "-test-link",
-        attributes: {
-          "-vendor-url": "https://condenast.com"
+          url: "https://condenast.com"
         },
         start: 6,
         end: 10
@@ -224,7 +199,7 @@ describe("Document#where", () => {
           id: "1",
           type: "-test-a",
           attributes: {
-            "-test-href": "http://example.com"
+            href: "http://example.com"
           },
           start: 0,
           end: 5
@@ -240,7 +215,7 @@ describe("Document#where", () => {
         start: anchor.start,
         end: anchor.end,
         attributes: {
-          "-test-url": href.replace("http://", "https://")
+          url: href.replace("http://", "https://")
         }
       });
     });
@@ -251,7 +226,7 @@ describe("Document#where", () => {
         id: "2",
         type: "-test-link",
         attributes: {
-          "-test-url": "https://example.com"
+          url: "https://example.com"
         },
         start: 0,
         end: 5
@@ -288,8 +263,8 @@ describe("Document#where", () => {
           start: 0,
           end: 14,
           attributes: {
-            "-test-class": "language-js",
-            "-test-language": "js"
+            class: "language-js",
+            language: "js"
           }
         },
         {
@@ -298,8 +273,8 @@ describe("Document#where", () => {
           start: 16,
           end: 28,
           attributes: {
-            "-test-class": "language-rb",
-            "-test-language": "rb"
+            class: "language-rb",
+            language: "rb"
           }
         }
       ]
@@ -331,7 +306,7 @@ describe("Document#where", () => {
           remove: [code]
         };
       })
-      .unset("attributes.-test-class");
+      .unset("attributes.class");
 
     expect(doc.content).toBe("string.trim();\nstring.strip");
     expect(doc.annotations.map(a => a.toJSON())).toEqual([
@@ -341,7 +316,7 @@ describe("Document#where", () => {
         start: 0,
         end: 14,
         attributes: {
-          "-test-language": "js"
+          language: "js"
         }
       },
       {
@@ -357,7 +332,7 @@ describe("Document#where", () => {
         start: 16,
         end: 28,
         attributes: {
-          "-test-language": "rb"
+          language: "rb"
         }
       },
       {
@@ -381,8 +356,8 @@ describe("Document#where", () => {
             start: 0,
             end: 14,
             attributes: {
-              "-test-class": "language-js",
-              "-test-language": "js"
+              class: "language-js",
+              language: "js"
             }
           },
           {
@@ -424,8 +399,8 @@ describe("Document#where", () => {
             start: 0,
             end: 14,
             attributes: {
-              "-test-class": "language-js",
-              "-test-language": "js"
+              class: "language-js",
+              language: "js"
             }
           },
           pre: [
@@ -455,9 +430,9 @@ describe("Document#where", () => {
           start: 0,
           end: 12,
           attributes: {
-            "-test-class": "language-js",
-            "-test-language": "js",
-            "-test-textStyle": "pre"
+            class: "language-js",
+            language: "js",
+            textStyle: "pre"
           }
         },
         {
@@ -487,8 +462,8 @@ describe("Document#where", () => {
             start: 0,
             end: 14,
             attributes: {
-              "-test-class": "language-js",
-              "-test-language": "js"
+              class: "language-js",
+              language: "js"
             }
           },
           {
@@ -530,8 +505,8 @@ describe("Document#where", () => {
             start: 0,
             end: 14,
             attributes: {
-              "-test-class": "language-js",
-              "-test-language": "js"
+              class: "language-js",
+              language: "js"
             }
           },
           pre: [
@@ -572,8 +547,8 @@ describe("Document#where", () => {
           start: 0,
           end: 14,
           attributes: {
-            "-test-class": "language-js",
-            "-test-language": "js"
+            class: "language-js",
+            language: "js"
           }
         },
         {
@@ -596,8 +571,8 @@ describe("Document#where", () => {
           start: 30,
           end: 35,
           attributes: {
-            "-test-class": "language-html",
-            "-test-language": "html"
+            class: "language-html",
+            language: "html"
           }
         }
       ]);
@@ -613,8 +588,8 @@ describe("Document#where", () => {
             start: 0,
             end: 14,
             attributes: {
-              "-test-class": "language-js",
-              "-test-language": "js"
+              class: "language-js",
+              language: "js"
             }
           },
           {
@@ -644,7 +619,7 @@ describe("Document#where", () => {
             start: 0,
             end: 14,
             attributes: {
-              "-test-locale": "en-us"
+              locale: "en-us"
             }
           },
           {
@@ -652,7 +627,7 @@ describe("Document#where", () => {
             type: "-test-pre",
             start: 0,
             end: 14,
-            attributes: { "-test-style": "color: red" }
+            attributes: { style: "color: red" }
           }
         ]
       });
@@ -679,8 +654,8 @@ describe("Document#where", () => {
             start: 0,
             end: 14,
             attributes: {
-              "-test-class": "language-js",
-              "-test-language": "js"
+              class: "language-js",
+              language: "js"
             }
           },
           preElements: [
@@ -697,7 +672,7 @@ describe("Document#where", () => {
               start: 0,
               end: 14,
               attributes: {
-                "-test-style": "color: red"
+                style: "color: red"
               }
             }
           ],
@@ -708,7 +683,7 @@ describe("Document#where", () => {
               start: 0,
               end: 14,
               attributes: {
-                "-test-locale": "en-us"
+                locale: "en-us"
               }
             }
           ]
@@ -746,10 +721,10 @@ describe("Document#where", () => {
           start: 7,
           end: 21,
           attributes: {
-            "-test-class": "language-js",
-            "-test-language": "js",
-            "-test-locale": "en-us",
-            "-test-style": "color: red"
+            class: "language-js",
+            language: "js",
+            locale: "en-us",
+            style: "color: red"
           }
         },
         {

--- a/packages/@atjson/hir/test/hir-test.ts
+++ b/packages/@atjson/hir/test/hir-test.ts
@@ -371,8 +371,8 @@ describe("@atjson/hir", () => {
           start: 0,
           end: 1,
           attributes: {
-            "-test-url": "http://www.example.com/test.jpg",
-            "-test-caption": {
+            url: "http://www.example.com/test.jpg",
+            caption: {
               content: "An example caption",
               annotations: [
                 {

--- a/packages/@atjson/renderer-commonmark/performance/fixtures/long-list-of-links.md
+++ b/packages/@atjson/renderer-commonmark/performance/fixtures/long-list-of-links.md
@@ -1,0 +1,421 @@
+Ci dapad cizor bar olita begnejla vohi do li wun guantu pet lupwol eloezo. Ziipdo ho guz veknic eplica mof ecomak lih leopno wiubelu ud suhowaco ficdokeh. **Do ev** Gakcuf razug loznut ci lab uwocok su libginuh fac bossef juutbe ta dilwa. Sut beilagoj ciras esoahez cebawlis seharnic gulwuimu lerici miwocibu jowhe sebrutu mofkawso fofiwoto ra jade. Kad wer sa is fa ro kahahofa esmewa ete ujoco mutu esoem lifiz jo bopirolu se.
+
+Adicwag ubaroz zafukov ijifo nooc lidobla vadosu sesucov ro pejhuf et poaw. Kag pa licomdu tebuf osa ekohepun bibzizun rul gijwi uju ab zaofi ubu incumat vekjicur wogtucusu gulkop uh. Kaihapa wi ra kilozpif babva genuhmi uncefu vuphowvul muj mu noep tu fariv lif mohlubis oce. Izpode vuf iholup cesmegbu gufreni uclu fu aho sizzu edi hunoh wisurif ijohowjo. **Lual lic** Jepo wossakub rivgig **Ka ci**)Puw bo lojkud nusjohvem gurli lu omarotsig otuoh wenemuc tosegug jinob sekoj dotjuvlu aw ge. Wajjugiv dowuwihej pi sog tekaduw wiwbulo tutup de lelzatniv vig weika sezono emce.
+
+*Fueli anom zegoz dah du ebge fakin bu lar cipapo hekfesge lud ofakorob magi iw wog kih. Huit ce suatecu kol egafefhov ezeace iberaruce piphaor wezmout cupcoh vojimra lirori icmu pe mafra. Akowu kucguh cuw ke rebvodu jozgaawa lob ikuhi leke jubeja ovoan wimevna dil ha.*
+
+## **Icmimi wimazabuc durtinfur sowe**
+### [**aniba**](http://elazva.gu/sis)
+**Hivazi za:** If cat jufulot obi vuvom wuaga duniz focaup dolhof ongowwit iza vok musomlud noj fuve denupgu comhoosi usi nahhe awiv kirag cipuhu tinsodiv [Ibdifzeg adhi](http://te.tk/fahsalev). ([**Cade gevwih kak jiwibad**](http://en.hu/pe))
+
+### **[kaha](http://few.ws/uhubouh)**
+Fufdi mow ge ciogafu kiho do lacet ufgubku [Ra nasfordad lar](http://her.lk/ukuj) Babune hutsuci tuhva od vo gusuki bedone kivo za afasgok (**[Sekbama cubanevig ce wogaz](http://dal.nc/ave)**)
+
+### **[Wukur afotas](http://zibo.sa/fiwzegir)**
+**Gu aw:** Zeimwu gegtihev ugudiwsef var wemvida upetauf los undob izigu page afa mo padpaj ohubem dan ho (**[Ci cewi bo lodo nagpafur](http://jug.ve/keploz)**)
+
+### [**Cedjepse gudor**](http://loc.sc/kuvve)
+**Dipolos cijemna:** Gapwod zen mel ifibijo wi abe azovfa ropaf eroga nowo ibo wilzew kef fifvupe em ta ja ipigoucu ezow rol kubu jenura mariwaofo mupazen otkanvot lirfuda tubu kev su pebzab fimgeg aneha ociipu ([**Soz fi emzanviw gehhus escabgu**](http://na.az/tovegpan))
+
+### **Womais itomeovi**
+**Vutomar oku:** Pol zah nagahu fariw cocepep docedezu let nidke no sa po vecbo wit zejcolnaz hol binmokas. Zotuhne cujadce epiga te ceiva junto apile jon havmeba ca memmujgev wajza muc uwikulon silo ilvosveg vase. (**[Is hucacco giv ce ujozoote](http://wiw.tl/me)**)
+
+### [**Nipajofi noz**](http://wapujo.sz/ozfiuce)
+**Efe na:** Pabgiflif mosiif duazlem icso hehipipi rinnatim asu owoibesah pip ketzahvew wesed ogujunvo sipar. Pefibun wimwu jowom kama vunuh jiawahup sabo tig ohaahi fo zepagit osuab adubah zes. ([**Dul kulego ama no hojobiw**](http://nud.gy/upev))
+
+### [**Wehuzho owokej op wufka valos galas uh humnaseh he ju sakidlad eho vibpu. Iwtane feteka mamizni giod az ki cade kiejala zitmob ben nowidar zedam.**](http://zoweza.mh/fipip)
+**Jakeju repu:** Lam ju uceziw pawgafel cehoncah nub tevu masiepa zokbo zolnejluv fu ukjun guh vebiphec ma kulew furu ([**Domwov bo histobmuf azusi fokboklot fiac cenu cuka zaaw vopuw kidwiwa powwej pa guuta vak segin. Bu gascaul latezus to mivnazco totir bed gotri nozcaldo vagjofbi umuliza fewujjo iw.**](http://dij.de/awpotib))
+
+### **[Fiw ko](http://nos.gf/cup)**
+**Utaho nulenfo:** Ke avjier fugi vagufed vugek ci cu sehagi osvucej tih iliguzu ga waugore ca ta suohe te gopze uli uga ategap gino vise fiwuri ni watmenicu vuwnujgi ma lopiaza boras luhukmu ufi kid nincar jettotkul aciwi ce nuzop ira zienbaz if (**[Jahwoijo feawrar jidcasin vabwudfu nuzuv](http://wunu.eg/kimcov)**)
+
+### [**holpiv**](http://roje.se/kejil)
+**Pieca veopout:** Inegi ku sapku ekecag rop ujjonbe je coma bifah dob zehi git pomme ipiziel nuldeses vide maf cenes. Cujalef ib haviduf aniwaz eruzupus serugki sopcim jidtejoj ewjaju ocijo wiar ukupazge jem cewapvib coju kas. ([**Mejaf pafi bodi olu**](http://so.om/te))
+
+### **[lef](http://su.co/gograded)**
+**Puru sijizi:** Buwis ra siwlofu tuzdihoj ha loju veslo unlow vawolcol enevosif se jane dek zasvawej lilolrob vijiuj dorjumfub daojahob ohuseluz ijeedi cu di demga (**[Vabwufde elo veviwe vimelu](http://be.nc/taehvo)**)
+
+### [**destoc**](http://hav.bd/nekpitu)
+**Duktan bistew:** Rud va oza gojawako untotes hufahfib ba pecun okohameb icwu tin ninuwnof lejzidzo coaluso lew higwozi pal hob. Rab gev jehmu nigec narre pu giwludme tenaw gaw cucu jih sovoj ucko fizlevbaw nozuto alanci oza. ([**Fi hofrumem ocahuwa himacojer**](http://wad.sl/zahadow))
+
+### [**Ro zunawofu**](http://imtuzig.bi/zal)
+**Kagaj soskicuj:** Leif acuvuctu po ca mukuma hepi anedoz woakafe puocle murulu kok miusle secne now po tul ujo pimponhun dab anwic fiedu ([**Uhje con wuhuhaoh wowih wufato**](http://ja.je/kuupret))
+
+### [**wa**](http://mevopo.sz/jorucu)
+**Mewka kuc:** Rewedej niwid fifwa nuiwagev ecboun tuwud zivkuwwop wokvijca fudahofew dukuzda pimvu bazlaz sancule igiwi vurahfa deje rajzorvip ezodudu nov vafadidu fuvte filaci fopivol jomibi su mi zawanne kugpu pus it gopvemu aj nipci nubja ak ma apiva iso ni big akgahco ananibat soboja fildevab vob fofciola roz ku ni tuttivboc nab re ejeuja bud rifovizam mog utosic ku pu gow ciuzo ad vefa mapse ([**Da bo mawolde cup bowkezjik**](http://arosidlij.ne/fiudemi))
+
+### [**Do mezi**](http://cu.gf/ho)
+**Lupo wov:** Gebi zikefero po cekajumis girovu wiglave ri asedo epuje ove ret nuzifbam wilcolme okuse. Pag ucibujus kezhaih hur ibele wivi wuhleazo ze biiz sig rijlemug ciflu kuvwajgiv dona ihikovfi hi ub cuvtaew. ([**Ernu isbar loncuwfa buzbud**](http://zidpahep.tr/ne))
+
+### [**Mukwosno eg**](http://sos.ht/ovijet)
+**Faohtu goj:** Amzem zazuge faw zu wu lo jocusar hi ca uscitec opahurmef cim ivacogac secbemeh guz ectutbu hi hucosimem nuvizaaku fitgiah an zuabo badoh fanepo luig far bipe sermupwac haobfiz we ([**Igewiezu paik ujero fa zalcazke**](http://fen.jo/penemu))
+
+### [**ufa**](http://sawa.cl/se)
+**Bawde robu:** Hok am bat hi zikawecu cerip nuw oweaw awivenef toro ofta gu onruj. Hobgifa sev ke bucfid ofbajzu jako do vur badica kobdu udason koca. ([**Te beg cow emkif**](http://fogkegbun.bi/fake))
+
+### **[Ubciv boglicpi](http://zodhoh.de/ato)**
+**Tilheshuv uj:** Wac wowvamiko pegude jelet kakos bow hizga esdikpe ibtos lo dot ineceh folad wan newuha igcijvev (**[Tecniz uwi iwiuk evu ovjum](http://udemevag.ke/ka)**)
+
+### [**zo**](http://evuinitam.sm/hokak)
+**Ajasofa job:** Pav ducgesles tofvu zozuzvo afefiozi tare aziles dupleun cenitji zu zap tevji be. Bokdaoh agcawu oj cah kolev dathedwa siohuhi ujwa hadseig kegak etiaroga bof lati banu wozok gefu. ([**En sesof tadhadego ratouci**](http://zaitzar.cw/vejozup))
+
+### [**somopuc**](http://teididu.lr/epahoju)
+**Zuwbu joroc:** Cuz ridlo jutoocu noco ahmut nej sigo mubig co oceodijo gow sa. Uvaelfa arihan soga mubkoji ufucga di pelbuvom fatujaj daenanu jacbu nunju fisa. [Elofdow cez iji dailuus](http://vewoc.gw/hipa) Le onakub tohdag ([**Cootouk padoje nav watdemi**](http://cigmuz.cm/ike))
+
+### [**Li kefecco**](http://toujo.ge/fofapbob)
+**Huvuke ose:** Cicihwuv puc vek vi vimiv diowe sebeap nobufo caohufa ewo osugu vaferlen api te wiz jelupwim ziw purojad kuh lu ivoabajo nousino juled diawo vokote obbenro [Wevlorre nepefiva esjoap](http://neralbu.dj/adifoar).Bureze jeczakuj zenhemo taw pobaw tucur ire gisek cuwlafu cur hir hezoh wanieju lovguz ifanorus zuttuoza zejevroz nak wubetvu aga guk suced ([**Nu azi dino kufu miles**](http://lot.sd/re))
+
+### [**Wokem jutel**](http://pesaf.dz/dede)
+**Ko gufuru:** Enlorhef evvoc gosvize vovjabve pangoj inu riden bahsac uwhosi ozikozkug imi cebcaad dawarogu reppoil vofbuneh ogmu pifi huk japilvul ehaezohuc re tobco bafi bop supeigu guj pofhi seki siz owmef nuf sevopji idiobikat ([**Efgevi berijdi rislauz vope busnacut**](http://tov.cy/wem))
+
+### [**Vihodzew owiuwu**](http://ot.nz/zebekmez)
+**Ziotonid joici:** Om letsowpeh fepupofoj cawaz nobigiw uwail ew luvzefke un tu luwap suvo apcif jenunur kivaef ke duiniub. Gukkav gigaele lir rucpoce camojanik fa gomu ros hojakeoz vaw mu nikbev ozolo mivoti ve er vif ja. Keoloso hawa ar imu tuemo gup bak betab bokal arauz ke dagidi fak mowa. Ge hugewnof milwehaf fi lologgu harag la pokmuhle onipubef avvas tatca zuzne. (**[Ijgu amivdib zeipi pifmos fu](http://se.me/se)**)
+
+### [**Jike nimbuc wor**](http://fo.im/lolbetat)
+**Mur zan:** Uruder wum ma dezo bagalda hito tomi eranav bu sutjohop wed pu kunupikav enaeje us uwookvop ino jatehe lepu zocilra da cagcovkiz ([**Volojtap teetoimi nudud kuvu fugawar kon**](http://zo.ug/kewkugo))
+
+### [**Dagrimro maho**](http://to.tm/arsiv)
+**Bikubbac suc:** Upi laop kudcic juspu natlis taclo fu si bu etdo naget elo. Evoco occim oduuzce faga vokuw kosnugle edi we guganman acpoaju nenate racureb vuf az. Govefik agopona dom ki rasus rinbugbem kek hame devbi ha rat govum ser. ([**Nagu ec zavbes jinibate foon**](http://baejoze.mp/cubecgu))
+
+### [**evtudta**](http://rotbenol.gs/wikuseb)
+**Hilbuhko sar:** Omcojok fo biip ugiocsi necadam liwweg lubojcus mukico hoal ebeju vow moku zolpasa vaccu zaotegah. Bonla sawug laonhu goeb dalupwub lehe rughate heemhal gi te ba luba wa agmub zig paholsa fufiwudi. [Ope ped vuj newez](http://cic.gov/cuj) Dildi etiropes omganha how kid atejato lis ge genatcol megticad onoke ejecona vil kaddapwuv rejur ativihcu ([**Riw rocur paf hefa**](http://jopel.zm/ta))
+
+### [**moz**](http://utmogij.bq/jockef)
+**Vuidvo pirud:** Juzhi mem horsekof panfa an wubim sib bagig badab wivec tef pohus favrugu za buhagoni lu hi ramugaz ju neh vajom gepsuje mufulil uco tatbavup ti irasagvat sekgop kedduki bigarged piit sotibada ([**Sornewaf asu nub ihkawew**](http://we.nz/miam))
+
+### [**vukohfu**](http://gohuudo.io/ji)
+**Pog lehoh:** Disiome go jojaz elvofebi vu ju peici ofibeti ajput liumro tug guucoro ikeusgo efi uhvanca amisecko nawunhed ketlab nahtezvi ([**Imeuname sa sel riop**](http://fuprios.nf/hoc))
+
+### [**Lezcig edrut**](http://avrapu.ky/jac)
+**Azo otu:** Potbejvo lumnaodu mooju ditahojo rafobe icivowah jur izoke cu zusbesi wajitso ja poezmoh jovasfe ku ga ibi iluis hu cu ilbelfut mit buhhawtok podigac ([**Lozjon erjat ip zi eca**](http://wogcuf.co.uk/iwu))
+
+### [**catpopo**](http://ma.gs/buwweg)
+**Va kago:** Govbic fevoko ataoksic faj noawerem idu wovatno toihaen jugip vopni jim dikgen bun. Zabjorsi disub haapjo vo regcila mu wop no reku tadesu hitu cetaezo nimopte basreesi ra riner vupupedor. Igneszan awopeoca bo pup gi un piz adov kuhno zisudwu at eg vemonop neh zove lavuz liketci higpuja. ([**Mo kib cokoz kaiblof**](http://sasreg.ba/likes))
+
+### [**Puragoj ronmon**](http://muipdal.cv/rozfisunu)
+**Aneke upivupa:** Zasloto gu ado lom baanno totemtez pij *tanuse* Alnuj lewode we sastuto holul nukuk zolupowu fuw isa na fiwinlu tezgube amoge ve fofule pes ralik puwokid mi fanipul pena ot oztudlo boh nu kumip senatzi to ([**Fantufsiz nufek osejonde pig je ge**](http://duv.ag/hidre))
+
+### [**maron**](http://ga.pn/hepaz)
+**Rerna zucruip:** Sem re lafurhe worhom oworufu icvak va jinga vokari birmetu sagdar bi jalu vag emikasen hawiaz etevipi datawa megaruzuh joatco lihebfo ju ditbi zagki otha foffeb vavuwi dog ([**Ledrov zar bucujnaz iwo**](http://mib.ss/surohnit))
+
+### [**Tutza zapnokla**](http://jimzag.cn/mu)
+**Hocleig vuvo:** Ecda egejifino naweol rawluk veisisul omo kaflojeno bapnagon usfaznow ur da val ja nokatefo lo gahlopfor rumti wunhok feplusimo hah mav hipow nafoagi ozbasjiv nuz liuton ruv jum ([**Zi sudba vafi ga vone**](http://fufed.cf/bahuisu))
+
+### [**Enipevoc oz pipome**](http://ziefta.bd/cegved)
+**Zelatij tijhimo:** Netti odto jevevmuw duunaeno tutco doptifzi rolec azkow sabifeb bi rihigoji lus satrafpu eriki no. Ege esise sa be upnamho ra ce ekumacim wur sibcusgin awiikrik dezizaefo biozaon pik cic zik. ([**Ohotuhmi kishawes wirsogid uprotbu zecafvef gefhu**](http://bu.gi/ge))
+
+### [**iva**](http://ku.org/gopiwguz)
+**Afe pawof:** Cih aku opoivi guko vi puzam tewilu vu nosewo obo wi ogzapuru vi zu oh ed lo duze. Lejwe wupuvo dek hiv leruwod tumki imi epowaz rojal ripkaror petnon emavuzi. ([**Wuk edabi jimidik tilad**](http://dawlorre.dj/hosa))
+
+### [**Ho jolaluc**](http://jefmetep.io/oc)
+**Feonuma ce:** Veuvum vimagtan ejaihjij bipigiina mu mogmad asaovoem owaen nagdad ba vinaf los em kusokto hiwowsi tuhbi sirejid acawo zas uhilelak bem leab ga ecinut avoumicom gorege kanzevo gicoat imu si dorpotebo pemeksa zakef udocaja roam ardues bitse rohjanoc bulmumu ridpobvo idigori irajecu ([**Sop mubaz nidaj ecpak dose**](http://jenpef.ar/sanapni))
+
+### [**Cairvah decji**](http://nuh.my/ujiharah)
+**Mungog ila:** Warje zojad zeuvesu jeszego vif eka ciwkejab utzola sen bec buwik jup mu fepmuehe. Rotvoda ew satouru rozoh ori to ruf wosun nowcica neeb zi go ig sabofpo irwoic ucfoliv. ([**Dimaw ham hos cutebasuj so**](http://an.tz/fulevanul))
+
+### [**di**](http://wepzohe.mr/ribefnof)
+**Fug juz:** Dadaezi ijwimun fuh fonme aza kifosvak nadjekec dince bur ejuhi teh netela vi. Emecizgo divophoc rab dut ta obu wobnaiv badet uf dadez lap dijebgew teimizi dumazunow de pe. ([**Tovi wek giz izonuje**](http://giztazik.kn/gaw))
+
+### [**kaj**](http://coomhek.ac/wunagevo)
+**Tu jet:** Vuto pazif ewu dacsac efu giidawac miwa temba rut ur medpok balnadu ineicwo fupno. Juukguv je gadoz gal fa relimilup mi subkip awhejfav ukjalzel vob bab jurpijmu be efeosa ni. ([**Lec ije wem cadi du**](http://orwup.bh/zageb))
+
+### [**Eh lun**](http://mirdot.pr/vubo)
+**Lo woujefud:** Letdakhu jeep cure muhaf otoka ehuja tor wogme iwbozdus wa rubo fe otuwesbi com uceso obawugu wov katiru gekal wiz kijulej vak jekca rotawcem at huumha sazhit zuhjezic faja ot cas ke ([**Pesamol sowuzac lajsacib ze zes**](http://taj.gp/licninin))
+
+### [**Akimjuw vuvas epu**](http://vub.edu/peba)
+**Akomoc za:** Wivhu elpon duhbedriz riz gezvor pozake tum kirwa ipton wiej azetin do sigebnoc panlun kejtof fi nas mujisvem bujab cot ([**Fab ojatopi nejhi la ef sudaif**](http://hocidnu.nu/ve))
+
+### [**nipadni**](http://werfucud.sr/az)
+**Reogi igcec:** Nuf hezhozac zulzi cohkutnu od cevweraz egmibba reclepro itob zosmutte molorda wanoh omeec ib wozadku poef eme pajdohta gebnawaw ilher cicgej jag rolo sedda rec ike idawap viaw jethojpa sek adhaja memiw ilvoeli le hiwi ([**Ohu riwuj sa su**](http://geg.kn/persab))
+
+### [**gol**](http://fasfufmup.cd/jaeb)
+**Umozoba zac:** Wig fuc nifubpom owihasli go ereihnu umiito zev lodojhut uvuhage vuwabzu jah. Oz se zug parulje cegupad hip ded onuka raotoj vozikab jepotkan jow. ([**Noj wow efa wojdevar**](http://muzow.sg/ra))
+
+### [**Ekeekiej ne**](http://zegnawil.tc/bik)
+**Beabso nuh:** Nit ba guomu bi nuratij lokucmog kakpebfuz lahmi luzodar hudod pivpe kinzuh zunvoz ajabus bukebabed ji ifboj ([**Kospiwso ecoek liv mamkufma coduc ozuideof**](http://ditem.mr/acasov))
+
+### [**To duv**](http://zofuk.ai/remiki)
+**Omufa pedo:** Tah jaw kitno tisa zimpo bip zeawi ugkutu edu di tevcazrar rola giboc koiw fek wi wa ca. Zurohcan jolgife luvlun elomeeb zojdifzep dofcar butuaji cem deefukaw jir sogbis dihutov. ([**Guf higriar uhi ograt lovig**](http://heh.at/tapo))
+
+### [**Zacab nufu**](http://so.tk/ija)
+**Ajedo picacobok:** Mi ofova oleram uh saj bac ge kucamini jajofhaf jojejo nic ajaudmo gabulboj mutuc wumjagadu enav oliojjo titas ifuhewmi nisapfej tohod evo fevi rufitor belah ilowzek cid peajecet il ca upehelig ([**Ami wibu ibi jofofo zuzorat majet**](http://hec.it/pekrar))
+
+### [**Toilevi po he debuj zak ase ifaogujoz pik uko dujhiddom nukoz eg ilo kuabuoc wetkamdur wejmu. Ka usuomfo hehjuno mevisnun kufji gucatda hef apowes fikfum afejir zeno dupsuhaz tungule upibeni.**](http://tef.ss/najawi)
+**Gok gehgos:** Tadcefela ahomuho iju agaudi nijihci ho eseaco birhabaz mimugiiw kancok sohacah jircehvak. Cela juden ec osze fuaneba zutnisuwo tesemit zozrapful gu ur iszehre guswipun veheve si upo cubaz takla ninufli. Kozlep vi tan zevodi ut puag ra jioko mid aherhe oz cikap. ([**Ku pigegjen uge fahbi butitavot ic ujgitema tosmohav afladir sesu inwoej adoam uriman vevito bimper negifra gouvila. Bu ven gu ado hezor wijves du go ru lewunod utetor ode sukhuh zur ojibapel.**](http://sigfuwnug.dk/torovutu))
+
+### [**Fo tezhava mosuha hasiv vigouna metre sogosoj nu da bechi ne falgol ifiuffo kog cuhoor detiw. Hescumuz vomedtov wo pocba kozmag ivwo tu todozi aga zauhutob saecda notcak fatojgo beal jevfa jeucehi.**](http://wej.sx/beha)
+**Meje hi:** Ram imarukfem tuj oce cagani feznoafu zevafo opoilo iw ih utjutow ehhuz ikodupar ele fumvizin hodkoh viwiv noni ivwabjag ucfak ([**Iziekejuj dotlosu hoefzuj ju aj lec figubgu puhimdiw geicze nahipok jo gicla ow piipkis zu. Iwo bit vag uvauvebo gave misavhe il nev jusu dieb coej zughaopu tahoop supufkim.**](http://nup.pt/riiwiehi))
+
+### [**Zajub ziapo jiw**](http://esva.gb/kikohgo)
+**Ziluf zuanoko:** Lo ejicukzu ranad jeos ma cupuzzi ji lamoti vikauho jujaw fekcaf ne. Ozicu modesa sohircev hozrases tabetebo cevceme eskej azehi peeg aduwa eda etijurbe. ([**Nep ub vep uri ejsaoge cufohoef**](http://zesnawhil.ch/lertol))
+
+### [**Han pimighu**](http://kobaji.ai/hogooma)
+**Car rujkem:** Te miwmes id hi henal zidpibi ve ofjih poh mubim dulodiki firi tiwci harjontaj li tacaj zuimu ab ([**Nivausa gicsev zemusha wuhez sacso**](http://sujjo.ye/irpiko))
+
+### [**Bopfuz fitub di**](http://il.la/kizi)
+**Roovpic samu:** Pifuszeb ma se obojade boirow leregul wiodukar tin unreg ce zibuj lutmizu se zekar. Do tizoj he cos oce etake vibzaze nojfok du iti zahehu ame boda apkuvga wo. ([**Ugmahu olnu kag tuhifu doca uwe**](http://inevoc.kw/rakelvot))
+
+### [**we**](http://lat.sa/tac)
+**Ge waju:** Balekahoz vavwulej wanluk befedjij ween naz ca iso facnid lavzi jaorcob now dom ha dig man ma ziwotke jo dihdahha ze unapivas zowe weuzi alnu awjan bolaj mujew haj sezgob kiv ipme kud ubka jegvit jina sat zi vuod dip ([**Uledil odizivico golhuhso ni**](http://parhib.ss/huve))
+
+### [**Pojel dodabes hukappiw**](http://buszo.ky/kiwzeruso)
+**Lapru fohfiv:** Nehubniz acepe riwber efvawir vudivo viota cud disoiw es cepaw anceag jucatwig vobiapu caha tok ripbiec libob wepeh rapezo ([**Akcem lesa riwofu mobmok zuti cegguc siki**](http://gemol.gh/sergevaw))
+
+### [**eba**](http://amuilkis.jp/gi)
+**Kahsemem muuba:** Vol zupsop sinifa pipugoku ebulinnom nemcar ji ike iko sopiba vajke lem ume panubcef zisuh. Amora sarbinwa nu goh vulawu nijim miob wupesjo hah washife fekuuma fatebod ceru. ([**Keip lo po saben**](http://faim.uy/or))
+
+### [**uc**](http://ki.su/lopepev)
+**Conmim eki:** As jargicfud ogacen simwaudi we sucfocaz su ahaasa locujit epimoh ra op guwipu tobcildig iwumorta funwuv vohum wuuda kijdu kokut ga ([**Pojac tac ris mijdu**](http://wisuka.mu/cubbazus))
+
+## **Liwuko cer zuvufo mivwa fef mihjuhha**
+### [**inbuwiz**](http://kiuvipe.bo/apta)
+**Unbiw we:** Mazijli sirafi vu nu kuwtowwe gibsa cisuja zekoz pa faluvupu ca laatmas be nufeca janabizu suh mamsian sojeg jeg zupkizmaf jajodece afkumiz ([**Govuij eri ke uce**](http://rikoif.bq/varosnus))
+
+### [**Mahaked wof bozipo**](http://koadme.pe/zumoddo)
+**Daz kepzu:** Ma komnicfi wiguwid cazvi cooksir vuolirol erewgo nalrajcu kanepja fucotrib iscirro zofakjow hesla fehul koc hih du. Tepjoobi kaper zosba kij hoople tu empu zovvafu pesu uzo wu azuvoke dit diekda. ([**Cownib lu libimo pocool ovedu soawi**](http://azasucge.cg/amurapon))
+
+### [**bozuc**](http://rodpo.mc/gewi)
+**Gu recug:** Gid feb feleflif negez log lapod mo siihci vam uvire bik pedu nonzosu pep jak wu saku afmuzu ce ce pi ivuze ac natcujav ve hanne hara muctor ci posacza nur jovhan ([**Akumu cum av gimtetma**](http://en.md/dokamo))
+
+### [**Icaif rorujwu locru usikeoki iroku alfe voh ginegud buet ucu wobuvucim detismod gukta wip hekdarjet julac pe. Awosaaz ogbo wecfete jam job noj us curane girte luke me ba.**](http://ahocig.td/tegpe)
+**Hig tetajsim:** Keh bujedki lomuwo gohiw dejha cepne ed bu duvis atuoffi cop cinimal zumhin selozepu lisbaz eleeja feper ahobif seodiv ohouvicek afgij up zo wij ([**Basuriuj digub dabin ra lasnaf hupkam simuuni bor bodaz hifair nicoz bovfopom wam vol sifeic uhaevozu. Ofuhi gel hawbaneme vag ivejej vom se to sago uwgocpeh hoco gej cuke puzavile.**](http://hirabbes.gf/roruvfu))
+
+### [**Mufgoji fi ubga**](http://puwter.to/hadecmid)
+**Iniepidic maagi:** Zovfaz ru ra foczeswif uno oli kusu na bieb nim bul ogo fof izosune uha gedla popjawru be obuze caf hodsarliw ([**Tu hoti wasnijna giitore ami zebket**](http://tip.mv/lojuv))
+
+### [**Liigo ofooh**](http://ruuf.ac/mos)
+**Jekemu tu:** Dib wur ru riiw isu duwo jah ta dorgiba hiwan hijah sanda el evo ha haub nedi mikhak wikina amri zanruwu ([**Gij hujfofzo noj pefu ho**](http://savacev.by/kir))
+
+### [**az**](http://najvekal.ir/vu)
+**Ce zeves:** Biglepon behe doji nec ijowahke sifa agipokiw li eb siwofca hepapeja wikma he re wof zub pitmoz. Johedi heki ebe eka ciziksu vudedbe ad azu vohbuca elasajju hun awivaf vogan sifidih esete cuk sur. Juum barwoso aneocaku foba pine eka eculozneg vuhiwwoc us koafouji dotkimeka urivifho goit cialli. ([**Ziza cenu ni edi**](http://sekgina.jp/mifule))
+
+### [**ufi**](http://piwelbeh.mo/neh)
+**Vahug fiv:** Saseco fuzfifo jur ic fufe ed behosnen meh neesmu le he ipij gavtoto zinu ohiva. Zom kinpin bowwa na si ju ki cevudvo ta luvzih ju cufiksed sar ji ac gumu nuzwifrop gomijpoz. ([**Ez pi buofesih uze**](http://ogvodli.bz/vicuw))
+
+### [**zustecor**](http://pujuce.tj/rurirehe)
+**Wiv fevuup:** Or nedjaz catohes wop wiekezuk pirefu woigu lap dipi rocod loci cup larvat jickala zudu rohagi op tiwokesaz vi gilzap lumdof liv fihra re eki karouco kemfaus ([**Demja waw uv sum**](http://muab.sd/nojlipit))
+
+### [**To ta adfa**](http://ava.au/kavo)
+**Kegde jimnewpoh:** Ara iwotub sehuzzij bobiaba eh ofedi kuutzo moveve feb zu su kiw hokfo jij cojuzno fu tuve ju silew te la wuzko kupunzi mizuoso kihasaj ([**Zunem ocanra jejapko itu moad kubwejra**](http://cab.mo/za))
+
+## **Vabeleme cajoba**
+### [**weobawen**](http://alaawwok.bm/dosive)
+**Gi toborhi:** Jop vi je envuffi zi oro fo sol da napoze ripdan derum gev viobrim sa na emu vonno ([**Opzap ohhuru odimiek cotzo**](http://luzowga.rs/ijaaja))
+
+### [**Iwikup abgi**](http://dok.ae/fehotukof)
+**Rifgevsom ivudup:** Isjudto jap bet ik mevmusoso cof we ecamine tov hosmup afuvusaw el teihate sovpu nathub daeci vaszew fotep ijoiw eve bibna ma guwjidih ub igepag anu lecti ([**Bec diwun etsop deunamev bo**](http://ozmo.ag/uk))
+
+### [**eb**](http://soketo.bb/welof)
+**Rakge aze:** Co ul owjisi mafjafaw genwuel viidooh duvlel ro duf tu lad zanefji es el kejhibzu pisekug zosju wulgontod rak isa rabricrut ([**Ufuimu pa helocu ket**](http://notko.cz/wijco))
+
+### [**savovohu**](http://tu.vu/diuhan)
+**Guvgakka jicoboig:** Lebem up mob ir nitu vuovuuza keh pomlufos hatlele cowma pes zumu ko kuhvelu anelev zosu en sih sofu ([**Gicifbop kobu rumlawev su**](http://jajligi.co.uk/ulalij))
+
+## **Uzacozih tovateto epdi lecug**
+### **[bar](http://uniojbub.cu/asvucno)**
+**Pac vawab:** Awiboba kowifka keowidak gac ri pinu fiz gu li mim wo vonit ro fesiri tidkuh obe zow du regtu ma te coracag (**[Nuv nulgiv wowbak obun](http://jo.jo/du)**)
+
+### **[it](http://derowdom.sr/olwi)**
+**Mamnopub mip:** Lutir wobzaima ki zasah nota jiwra vajoraw ca roltonaz let ehjawha wiz tigze (**[Feba pihufkar zasaz lofifadi](http://cejvoma.tv/be)**)
+
+### **[jalna](http://urjuj.mt/ata)**
+Limruh asepijek nicig higgave ojhunmu wohhora dac pilzogze abnu vedduhju kiw naki howowluw gubana gir zome lozpe re. Fof tef tovremu huk ce ladurec ireguhjim renug napmezfa ocoulewi icabeace winonkal sevbil. Cugibtuh jivigoh wamzoro cijlolet wokihsar tezzeg wuc nezesuzec lij rogziktis izumih hevlu vosojeva. (**[Fuvaneja upe oja jo](http://wiragoz.mc/lecegu)**)
+
+### [**zubsevar**](http://vaspazhi.ar/salne)
+**Ta gotorite:** Lu bo kam caune parurzim uplerluw ze wi famron uksekib kez ilnak itebauv wazgov joveaf geugsum no cagoazu. Ubipa pitu liaffu ojogem sanjonimu hefni pojwuhpa me isajuco okepuesa fuga regoja ralagbac gibhaefe iwehus vapattu delluwtek. Atileko jek buntoh atiman johisvo elole rerbe onan akwew kifmum ek mabasoved iwlujug miso onimo vasjud. ([**Ceukotu gehe wojhiw ofuga**](http://po.ma/ga))
+
+### [**Duw nafoafi**](http://arhaku.mz/dabfabzi)
+**Ifo lo:** Liga tiw ezaohahu po dewos helokooro vedaba huupake racpi usakes par fov ho eba zaddegku zawejon geke af nof gej jevor varoibo luvje apuvoz ino ([**Vi bo goot bo kelunoc**](http://zemsaom.io/jam))
+
+### [**kampo**](http://asa.cu/itmotuc)
+**To wac:** Juh we vozasaawe dohra evsuvhim eraol burlaeta zapi faw na huofpos pigur fu lo capekace adfi zidadro lin ([**Lacacra soluz sulauzu eluzepto**](http://zuhwoh.kr/pupu))
+
+### [**So siguha**](http://joigisa.br/ta)
+**Fuhilu ufwa:** Usicig geuk tebozozoj enawuvlud wim panunmud odope afkadzij wepfi it oso emiku uwurepapo zerdi oma vugoclu. Utuhuaju dijivdi vohat wonih ogi biroh mucojo efufabju irane evirive fov opate okitog pe vadob ifven. ([**Ka acimu wezah fi fot**](http://su.ni/mecer))
+
+### [**joj**](http://visfusjin.az/cac)
+**Ocup johleeju:** Nebavwim karepcan ijubaput kornu meelake hausoma pizornun icwir lufalada enaze bocizik biano bo dut rad godluvtuk zepitohu zos. Hahnogeb do rompokas nos iv ricaf adi sezizhe buzgul mijhan taka sif motizmu liw ni nif. Cilhi varez im folujes rasgaw sukcokdon ida utgepeh bim nazotet rab cilo. ([**Bappor hig fib depunip**](http://pewof.bj/demosaf))
+
+### [**He bu**](http://pipje.ae/ebkos)
+**Foh socbud:** Jihuj vur jimji wavifkuv jarkaj pacemaf conrezisa epaacefo pofidu nara ocitahuv fadgu dol la cugiwno pe kuzilva gafgari fulkab kem diet cebhi ite ahebemer oru wip miizro liikalo hima ([**Gufnu iz lompu dow lasohle jucku**](http://deb.py/jojadja))
+
+### [**aroero**](http://atogu.by/ziwa)
+**Duzwini imici:** Nupedse nius cuhvabom cuhul kisna fi botitpit urjoj jukburva jos sobe cuento pimi ta tezub dobsihubo badunoz wapho. Lalbo usbitip ogra jad nipooz gawualo delec banaj zuklajeb reipiziw kehet ejeudomif uvbugil decapzum vo. ([**Toftuf muwbibjuh dukeluk um lutgalvaw**](http://odabu.rw/bunki))
+
+### [**kowelu**](http://ba.dj/mokab)
+**Kopu avu:** Osolu suzezu cop hif be nodbi jez vad wietarus ruhofe abopce mokol cidufot daru sekofza jetmeput fuhum bi. Sezham pagiwow bisni liuh awejan gu gigab nuctu ne nazban gu fo tub vicgof vewgohag dino. Gujvuwur lar lounor zu gotfawma ko jaac eh junusgu mog rupo huh necuz hemwo bizrawce zacmodzuv fu amig. ([**Alodalvej kinja varogefon iwejah**](http://zegsis.gi/wirsitwan))
+
+### [**Oko peanwo zaptojno saoneuro zet di doimauv wabkim wagok wes siaje serkib vutuja amlomlu neaki iba zeem rapwe. Getulpif fe ke buzrip bitoc de bokfud va weli uliefu an ebijuzim.**](http://witlemlu.gh/to)
+**Huhjer pas:** Zuczudfos le wiktelro akoejauno idegak azare jiili zemvub pigwakib eceruf jec fip ge ikep kenene mefobozuw zarun vopmi ofija ([**Izujeznat fub owfornej uze pu rok topvivov vouge lemtollok je rojozgo zub ukovedeb eputoc juopput cohsi vo. In noas lo ripkud buc copuwa nehir cosuz hulsuju so ecaeh rujegu.**](http://gavore.an/dug))
+
+### [**Ju pecvehug voz lozemot**](http://bugok.eh/so)
+**Ponepne omi:** Ran muvatiz aba igitizez rag val lo lidejan nen co ga rulzimze fesidhaf pocefa bifa ([**Vouguna tursapbi le garmufpa mo towo ebmej**](http://hogluvkeb.lt/ilu))
+
+### [**Imo ne**](http://tacsog.ls/fefeksu)
+**Di holda:** Galokhi we hutusraj esuhod hoju makhuhew daun kem luluk edaog bibeme uwufed ebnajjo du venabu uf hez voz nikumaw ([**Dedluupi zuhaduki ak kepa zos**](http://bawe.re/ti))
+
+### [**Ogmawdul vapoji tinguipa**](http://ulerubbew.je/hifecirav)
+**Iwicut bonlah:** Dej an iwji ibvazi san egajimlaw vot kateg gu kaw vit bahtirzof vojejsol bigwa wetuw bow ip ke raopiag ([**Ravama kajkit fijhocda cugsuh suvze guslomuc**](http://ocjozu.ba/ju))
+
+### [**Mugzima lihuzli**](http://hezpa.tf/mohgo)
+**Adonoew ni:** Gopacur la zalarlap so dap api zulo vog wermob cah vawosi rof fieke mi ilpociwo ceunvu du jit umu wuuv fi iwi jihjet taw ulihi ([**Bedme gozse fom jeneagi ponav**](http://bifubu.nu/san))
+
+### [**evalofu**](http://gob.ar/pijewula)
+**Ga ikekare:** Hewawfil lacib fe acule erevipwo zalakuuf haguros le kaz so guta piki acarsem jah. Benemrih pac uvaned ezki dulo opeidogil jan ji mozihtiw bav wen rusemu ka leuj dulnobuze. ([**Meliguv efwunru dumobin zup**](http://degbende.ke/dutiube))
+
+### [**Mi anjo**](http://toj.lr/kozrimni)
+**Buw muzibeh:** Jag edkag uzepe ima havri sihi pak ofika fapwa zileico cocnaag detuzeizo mesalgiv. Kepeb si he rade meoj vufe mafa kurufik bu juntidu wufonap fo luvta siwbulhi hascaanu. ([**Tadu gaha cihimo bikwir rumadse**](http://isaafeba.ga/mumloot))
+
+### [**Gosugjo ej**](http://ruwagi.cc/lo)
+**Awuoro edvok:** Ujhi mogu geb vemocbon kime geranu zi tu afireke calof et rul kaji icji ajofak vi fos dunod. Ednuto eko hasri se bocpafef uwote lu coj go wefopiw fozmiud gujacro bupwa kilinabu. ([**Wikrigwu powu newe tizcol jedal moc**](http://zev.mc/rimfih))
+
+### [**busjotke**](http://ti.mh/uli)
+**Barmehte luv:** Duheb fofaf liena efoojol tujer sopto cohislot aphumpim if duzjevre uvuker habas bopwoij jo tejtag ofu sed nu vi mi vepek mubraz ogta ar elzud segef uwiwig kirhojod opcubot fa ul wibtaj reci apcu bupgagras bav cifdenpop zusbarid dabu cu luulfek ([**Nip mehozu te ven jajata**](http://odonedub.mt/bidi))
+
+### [**zunlisni**](http://jehalip.gt/jelbobov)
+**Ozi fiz:** Vob ajagodub lehiki afi das ravva nonuscin nag ivawo kikbuk jijiwe gekras zege gawvoka. Covweosi aw ko zaidu hobav pab sah ira huj ku harro rimesba rizzikun boow ga. ([**Mebjatu gokmum wuab kavlog**](http://hi.sd/bes))
+
+### [**Nu kicezil**](http://geta.fr/zurpi)
+**Mazoc seeji:** Odomak ha cufci ra bewpi bega leuhidat ovmiv bowive murecsi appoka ricekdev sazhuvun lefew mi ebdopu nahi ajgudse ufticfuf kiw itucogwoc caukif milwoldeh rifu ([**Ducuov onamigod mev kerot kicuro**](http://meedo.lu/oskamu))
+
+### [**hol**](http://sin.do/eri)
+**Sarvin pu:** Sapafbe ladtigiw enfe suajep senec vesah vuv titvu tup geb appi kutac zeuf widuhcit no kahser gil zok ric ramsu nok mi uhinu rij tikec zi ([**Hip jimehoc suhuj nuas**](http://pelnon.sd/kow))
+
+### **[Kaorile memag](http://bagiz.so/tefwero)**
+**Tericag bangujdo:** Kedugo kivajad kosrak roj evote map pehat fokpu ud calurzas (**[Isa bogijup ok bipal hecubfut](http://ra.je/fir)**)
+
+### [**Mupnuas covopad**](http://nepe.ki/kivuptij)
+**Tuceg fe:** Fotava lipo fatfe upsomih mup oho isuuvdi loto mutlopaf gikafe inkuktut pakuov esharo wa livom uhka pattam sofucdi lucav covimkor ([**Etosuz bivete cejpudez sime ziawegi**](http://depowilo.cl/jewop))
+
+### [**jonuji**](http://tuur.uz/jubhuj)
+**Ulnit zoape:** Sek tavehono fuv seh ujujo wewitan suvholim ci luneb lu hes tefden ninba tovliza lo naede baupeec ([**Bosifut fiwej zawla elisa**](http://biwep.zw/pok))
+
+### [**Juvopo pasji hodgesrek**](http://kedu.gi/tavniraw)
+**Wudve moma:** Lomuta ule vetjurah kaknozuh afpi vat hu nife tiuhta patcacu onaroj ozvic uhnih zita richicoj. Iwetehabi robe nir fo tovdewo ormi ajof tokgagiv fazepuh ne zuegi ifirob kadkuv lise. Lagrun arasu negcu su zaki baz lima fa inga ulizec ca lak wabbirum zijej af odawuk fi.([**Nava hifka mewlipsep tadat le midga**](http://gugamno.cm/gibein))
+
+### [**Awo ne mafniet**](http://canbud.uy/mogfezfa)
+**Micecpiv medor:** Isizu ni nuzah liha nugbeb ge kasepi if piguh habpatu zadutsim ka caalo tutehe sapam puzi ju ([**Ta saju judefi jafbove jaovi murute**](http://mog.pg/coofafu))
+
+### [**mugiizo**](http://vekipva.tt/ba)
+**Pa pemsikvoj:** Ke jujizpeb ombeohi gufakeuv jar fasfito tal hufuvti giwtase was cipu fu lip balufa jow pajo mumwijwo zi ([**Ud gefhav ifboj kefutena**](http://uguvo.au/du))
+
+### [**feftanep**](http://pacmidbof.nc/ujiwo)
+**Tuduref mevtuvu:** Pu bo nuleupe jiguah ni fepil git veor piftaja kajo mokiri tozroc. Havevoed rasoso gogciot ana we iswesuw ervul ohi ujac te lerceoso uwuudaha raztohjig. ([**Dobo tupufil ri acikise**](http://iv.lb/wo))
+
+### [**jud**](http://mor.vc/sabzag)
+**Ga jomote:** Efibzug sufmuw tupile levlil peba he edigij peg lid povusomo urbi jedufiowe vujdugbe mod uzluac wih dugcede konpijew rol sinetub tacerob mu jak cid aloope avo ([**Zi hakido zuat mi**](http://woj.se/laroj))
+
+### [**fesobo**](http://mo.et/zanovmuf)
+**Nekiid fi:** Izpik ohuow fewripnid bozig peszevfe kimes pic fopinijuj rajbinke wovuk ruhfod no vorwav kud otvibfa luj osoni ane wekera winesse kabwucca fi udrocwec guha lu jareg jas ditiino boppa reebjo ([**Gahwir hiz olo maz cufutu**](http://kukgama.ci/ahucubze))
+
+### [**Moja kandojafi**](http://gisruaw.mv/dauto)
+**Kaupe cebmuzo:** Pevucer taf ev sohmi uwi ciiba rikira godpowis wes si joakaute fulful waeduge tuuloiwi ret ebovijab lem roplik emka nepanofo cuwogka akleluz igo nalelmu levoza rolone cedihe ([**Gunoviho wiune ogi guku miv**](http://gubeg.pr/ow))
+
+### [**cop**](http://nivatja.ps/ric)
+**Puzu woefeb:** Wij gigig oku ri pep rog urevaug pocnaz mawozkuk ufadebu jitot kuc zew ra hona he cu ameiz dimje kovce te putelsov jubnu riezvu cig teumla wezsufruw etvuz howimmu hopiim tegego ti orepewuw cizpa hafakga zaz fopuz gel ap cahjaeki pouvtu fido gas ([**Sijosap ja abuasehop ti**](http://kipanu.edu/himah))
+
+### [**Namak tacnama seslelni**](http://fa.bv/nurkewuw)
+**Behnacul ula:** Cuc heb pufa edajata lihpuif fied nurof mijza jeb apaow hujagat mimsogu paji jadmet kowne zupdu faifiz dojbewuz su rus latisoobu benos egugir rofbi totce ([**Odukapid awesanen caope fativzeg igrohlo gi**](http://hegke.af/raz))
+
+### **[Hop puson](http://tamse.pe/curecta)**
+**Poje bubri:** Foin wut ru edi usiefi kowveiv wekatca ke huinasa wubuco vokev fezfer pubjur behorji hepihva ticcu lufaila god muiti matrotec ca len (**[Dif ihi hige gopivuj lol](http://efu.aq/joamfo)**)
+
+## **Vekaw up fade daw**
+### [besu](http://lovbu.tg/wouc)
+**Ebeneb dad:** Cedis tojte tiah tenwossu wubomdi edopa edelule hafcata jiac soacagas kulneaz himmomi rukubip wigamu zatoh wu. Liaje uf ma bemov cepal savfikli bo ih pakgiwu goefifaz wow bebuwfig ke ivvaf. (**[Fedetle nala keven alilovuh](http://do.gh/leklim)**)
+
+### [**udu**](http://kezame.ac/aw)
+**Hur hibti:** Jakafgi av jac ududurhan ral mic ajuiv zemewba bo vuesu havtag wupos eh. Muli ku ba tokunew jul urelo wevinwud voucuma suwdosval vipe ves ejuiku. ([**Ida fov ifarof javwib**](http://kubfiob.ma/gowru))
+
+### [**Du joda**](http://ij.sh/se)
+**Modod viru:** Zotpuna rop opele se bakoc ipuuhrip dipadebuf toab uca mochu kacjoc fup am no. Kovsep so pi nohojgiw lemewku nezri kaeddoc un paajta bu wedacooru waz cu leuwi fuzanhe. ([**Deif dumev owobug ki si**](http://nafeezo.rs/evlag))
+
+### [**cegovuz**](http://mupi.re/ew)
+**Gajha wugkobbi:** Tu logova gifmud amaliubu bulovmu ramiv wunubat le tej etkog cu otuafa oju zulik koid kor fuw jivci lekuvib iske ek adjoeb jofdob gicepmi vepsuj ([**Ja enipenaf ofkunan nihgito**](http://igu.aq/uva))
+
+### [**Zewwis nova limvukki**](http://hofi.gn/we)
+**Ba ig:** Ceb kobil alipinmi fili sen jop hi numkodi guneskan wog cil we zefazob vetiovu fevda ruz. Mi du nipra feuva un riwupo vodektet ezubotvow zognad fe iceuzo sadodo lehceje gujesku zem cabruw. Nago pohumsiw otevul gej jeg hi cutoluti asahid ekwubeg ed kidi negkev ake vaholzi huc lifmu rina nedig. ([**Uw uke zik zojmecmu vif sosapan**](http://tivejiv.py/noehaawo))
+
+### [**Cofewer jumuluw**](http://ici.cz/danpatcil)
+**Subisbo eg:** Wadlevec guc datcodac untab hipapam pavkoc nonfurto daha puvinvuz enuwazruv bebet covvube henalep ruchejji gi mopo fe kokge fevubisi le netoc oliuropod voubiiw kicu zal han ([**Guvpilu sedionu zuomima rafohe gij**](http://meg.io/unu))
+
+### [**sibsore**](http://uwa.org/detgaw)
+**Ri kib:** Su om zefdef gezsoago hoh zanma ojlug urapivfep gesavti bidmu ewo gehmej ga tega hohitlas jakpezip maaji adiokpin luhcez muviic mamdat bevibnat egweg le awesor ([**Ona de ti ipi**](http://cokraz.mx/mak))
+
+### [**No wasezop lokvu zawakav suwju viwitur okfi kevase pofalcac oha seewabaj hac ahakow bu nusedih. Cuvif vanhom jep ahvo barunof joweccit awsehjad kojibe felfozsub fo soshofeb gaji uj urid vowsojvin.**](http://da.re/lucsep)
+**Kerpu rotru:** Mebon matba se defaom lel nezleg hodij kewiv sed ofufe zowim vat cawim fowear zire leod ([**Izaide cuv ivgor tim venazzah ja han camo pidud koc ob sapugi wilpibpig. Te vawug las ni digvudhom ajbak te apona zavdezsu cew majufu jakbaaha ezrudu doruwe vevu humidub.**](http://fis.ne/rirte))
+
+### [**kez**](http://uhda.pn/niseg)
+**Suwnuwni nago:** Gawaba rabti fofnib tego wunanset li nihuchu hav cinup ijbah nunifaler nadvewuma lun zacvu cijudceh wo farvummob pefi ([**Ruup mawejida hapfi ro**](http://ki.se/do))
+
+### [**ko**](http://mihre.zw/ge)
+**Met jemimin:** Porhivaku fiberu hizuvco bibe ur atdedpu cov lu ikofur cejet wesku gadiz rufiilu tid imualira lilubnon so jut otuof mu setvuz obuni tahula inotiezo ([**Ob re honleoj avo**](http://roravo.sl/pikve))
+
+### [**Zunwupem puwcubni mok**](http://gad.ee/kerhaaw)
+**Teruwu jotuhov:** Ti ziw uleohvo jes ev jir gihiwrub seossup idozgec mu nuov fihi haoleiz ij hovug bunogemo duber ucmon. Fof tu cica ko ibpes fuh ece ridceini nuek mujan upegenbi piefa bo afzis onunu fol useval. ([**Caowon udivrul wudhun gog bifarra jel**](http://iwi.fi/zeew))
+
+### [**Gauci abho lir visope ritdip cuwbero cubura um wilija ackokre do zezo temsodcer lunagku furpab. Zoiv kep igece fannopgef duw jelusduz if fobovris gitokwe petemni bupver viwni muhicibuk das zekujrip.**](http://dob.aw/kaznodiv)
+**Ceparir od:** Cingeon voblowu tefki ukavzo jabvis isonic hotu kiafa ecepeeki hetesjoc feak kipe ogi bucuk rad jocahbim ircivba nuwuk ([**Fiso le tok doadi ugaig biprep inagor sige iseja wivlalo juwu edaruoh rabadieca tunleiza. Femogoce ogzo tesame hakdah suvagvez min afonoamo mu jevido cakmape uwodoj tozcev reraebu sahlufkes jedap fandufaw giki apa.**](http://fadzo.wf/wawa))
+
+### [**Besu uja**](http://dotwarut.eg/dabnufhef)
+**Ke mi:** Wih piz kehna owise vuczekzok samnar zi cakba is huica seovuta wa muaz muvofut hovbin rerez kawewuk ol hic arenesgi litciguf fuh nos uko ofjofag ([**Pawe lugzuleba obnowuw puz defajzaf**](http://kil.us/egoke))
+
+### [**Befag kuhozulo**](http://oku.mh/enedij)
+**Wezubi cozefi:** Ohni tijovhup etuum pedukce bo la sefcol moda azumiw oneah gobhan jebe te pew pamneti mivi picetbir buga dica vo marrimwa ge ko siw ([**Wejgab rigsonsag wulda ah lebi**](http://diknafep.mx/tu))
+
+### [**Masugej ocuh suze punisese sov cewjuzuv cod niejtu ri ekguseh fanam ca bijibe. Dur rab paed la orupikcur ovoru fonezus hihicjoj masug tanul gasezcu zemo nih.**](http://wivosuwe.lu/wun)
+**Sipheogo jerewip:** Moto icajiha sorija cudin log aje lugireno degtosav widgu gi inimur bovmag za namkin vojiz jiuw diwo tu wabfafni wili ilen wivmuk sib jibtadpo jes luzjuzdat jukajev rinker jizufgo jiiju hotves suh lishi vugumo uwoma ([**Gejoho bartimni kejuup volubu tuc purdi uru donih fuh nicag jo bem memijom ve rujgiflin dewipo. Takat decu upu nonelo bifken muffooh narafiava sawota buzu owoijwuh bol cefusib gep gesmo odduani.**](http://pe.bv/epwav))
+
+### [**Om zin**](http://sofnucom.tt/sewega)
+**Beazo nu:** Jaf bo everorpe fijva nes upi naipa koafbeb nozvofu tifla meziina jepi igcuni otuwaoro nawurku wup camaculal ar lijpo vuzhu fiadouzo opo marafasut jalma gej ziftezwot pozdiosi fakzi selehen wiiwezi tisodtaw ([**Mubcizemo ucuohaub zo gimmehnab mudmu**](http://oc.ru/bub))
+
+### [**Ujhe bahe**](http://gi.tt/cikrav)
+**Wimresaz cegsucom:** Keewuila ca hukowi tozpawac hafvow tilokko jumbu fevda koliw awemadpe pec lidsu nod ni. Mem cuoj bes cipahin dapo ohiru hiv aka mies iwwiwit kip ed toh jagzuju ziben itlo sejuoh nuter. ([**Le zossu pemusig veb ribju**](http://locapop.ax/sig))
+
+### [**rupcec**](http://fa.eu/sike)
+**Musomu dafzuj:** Owsomav muztug zimat igac ova lewgovke duggobob tu ta paudo weuk uwuwapked. Pactapsuw teamuz pu mah defonke kipu iwi jozibi el vimaz fivwu tigma av mosadop cot zubij fif rubome. ([**Mu kod oj jaic**](http://go.uz/nodamo))
+
+### [**galihfi**](http://om.bd/sa)
+**Uzroana egifegi:** Segmuome id edha awalo ir rerje sid fu faof omlep zelsoj zalkov var pi ci es hukulakeh vajhibej ri hofosa otha bi egozate sanoj pe fal wen zowfa fu ulwip momlok siwal tipawaj vihgin afe fimjo cimvuju coebovel anwa bup wagrij to tesoit na kamjo puw pajok lib unkiv fapsit fusoc raorilan bijsudus ([**Cipa butlitzoz uncebul gewha**](http://uh.gw/etu))
+
+### [**gileamu**](http://gisba.me/lez)
+**Gi nuluhog:** Sa ki pehijce simuur diwur zuleci nir menas letadvi uhoki nuw ocenu gip ki je wusjatu bupir dafizaw malon nofokso femdawolo wo ewigid mebla ([**Ucuulalal soverbit pi sohesfov**](http://wam.ec/we))
+
+## **Jip pa**
+### [**Ita roscupec**](http://vopduz.pk/jepmu)
+**Afoafodom up:** Akfose hugew hah fiami duwdoz sob cul um tidezu pezji agetonla jupifo zal efubal ko rasu zipimsu lugfi opjetsos ufo wifcif huwco mozetba woh eju hoid kokwuhwo ([**Vanzi gehfufi wifjo we mom**](http://os.sj/af))
+
+### [**Sor jowwed egadiwo hopde**](http://sonbeug.tr/riv)
+**Ledtaksoc tajhowcum:** Kiwuuri efi sifogitat huuhuozu cep zi eduadutab sopudcak amivwak ev vugan pez dozoja saddicog zadmik mad fauh bo opivun fig jezlazi un miluvege gahobsow cih sige hukewo riujfa mezbu caejo guw ondakad ([**Pesso metun bi rescol ifo ned vivuvo**](http://wenrihun.me/da))
+
+### [**docnuki**](http://cifnagi.in/iriticuro)
+**Pa itouh:** Vebu dokjataz kepozejas eksisawa hef papfazub sifjo kobwen vov raw kicicez fasfod kaase neres hejdu jijcabo ki lec jaofome zelsid ([**Bamonu aduoc dowbeseh ujo**](http://rag.es/jibsuz))
+
+### [**Ozejke jopaba**](http://rotluasi.mx/macedupid)
+**Biwil bo:** Non uku me ilaho vad neftejpuc mi wowhenhus sofsegdu hihipecok pewit rod tumajeb wefo za ruano ohu gojajne vabib ezri gaoci zimar ([**Nam veunu rohi cu hobik**](http://biga.sr/wukbobig))
+
+### [**faok**](http://telsoab.ae/nomoba)
+**Cedfe lupo:** Mel tebo omuco hic vetdopse noha bewnizle zakuro guttavsi gahun widi gocutjel revzutal petjorus taku ribanoz om uri fup kahdu upod liler garjalkoz wuit ju zifoza ofbu gof nufo ive inuoti ([**Owtelpim ta uzubu mi**](http://vozcoal.sl/huwze))
+
+### [**mebfe**](http://zod.im/um)
+**Lu ebuacibes:** Bi okiumaer ujfatuka gaadsak hoc kacahaf pirso virubuce jenvaawi nit voz hajkaccov bangipe. Pakof zaj luhsuc riw me beb di tehwecu togfulhu puktu ci cime awocage hegkigiw enja. ([**Fure buhaci kupoz tec**](http://muz.gw/sazehi))
+
+### [**Jami suhdehe**](http://zudfe.re/kig)
+**Ge adi:** Fu keoriut vivi kuk na marar cowu rate wu cepjabad jufe poerzo niwpo gini wopuev bu toumpe. Rim gos wauw tucrurez ote ri ton wosadi oju fioji suv lowzo behcijser vufbunu bu hif. Hucu cof wuclaj ge soujla gakujab ler caefmo ucofubli zovlumsu kil uvwujij. ([**Fe sutwokop cep regwes efude**](http://ug.ky/reog))
+
+### [**fafom**](http://mafoj.gg/melet)
+**Pu zubumo:** Rerkisan kooke upasiwcog va reomu itomas lejo kapbuz ro wigaf ba pa dedioci kapcillu ah jogcig nazlo wu rom jumliwpo giacubul du siprir zuvdejib wametjok ofrugad fo dedgab ercotlu nujiflo ahjakzaw wew mu guczo tiwuce dojubki oges buw luzna tozwifun wietezi nez ze wodem rorlu pezezeb kag lodbecluc ([**Dalud oliziw ihiracte jid**](http://sabde.ao/wallewu))
+
+### [**Od fohzacun**](http://ba.ug/hijaheg)
+**Edi ipobep:** Utaguli sar osbi mo ow ocwiw zid fawow nod hetim fueho awge uzirada moj gaspu vifacuwu darafda zihsowima talsor bifaro pacij ([**Keh zeev jisoj aru se**](http://aczus.su/us))
+
+### [**Bapepcu howha**](http://zopril.sa/cudde)
+**Akojitsig feicuvij:** Ojohusken gewu purilpik hogesin iw uclo huk jalim vag gusut rakcep danrep sewod jimsazhis suag. Veges cemota reg mule aroajsik gocnafo enokief suren tob jujenitik lakob fuknisbam si okvi sehib kedkuti gihsuj. ([**Abi zu dijwavwiz dogih fiehhe**](http://abtudi.bw/jiw))
+
+***
+**Ofuzoca cijom elbel behzimsil voof:**
+
+- [Em ek wadjohob ak joskab jeluhe so](http://daviba.nr/fanlireg)
+- [Dolahi rawmirof cetefioma mi tu ma domritud vijec jiale](http://nifveer.sm/gih)
+- [Kiicri elluno sasu piwlizbo aka gealukus seppuw peod](http://bevo.dk/mudbug)
+

--- a/packages/@atjson/renderer-commonmark/performance/index.js
+++ b/packages/@atjson/renderer-commonmark/performance/index.js
@@ -137,8 +137,7 @@ performance.clearMeasures();
 let fixtures = [
   "alexander-mcqueen.md",
   "lambda-literary-awards.md",
-  "inoa-listings.md", // ~1s
-  "long-list-of-links.md"
+  "inoa-listings.md" // ~1s
 ].map(filename =>
   readFileSync(join(__dirname, "fixtures", filename)).toString()
 );

--- a/packages/@atjson/renderer-commonmark/performance/index.js
+++ b/packages/@atjson/renderer-commonmark/performance/index.js
@@ -137,7 +137,8 @@ performance.clearMeasures();
 let fixtures = [
   "alexander-mcqueen.md",
   "lambda-literary-awards.md",
-  "inoa-listings.md" // ~1s
+  "inoa-listings.md", // ~1s
+  "long-list-of-links.md"
 ].map(filename =>
   readFileSync(join(__dirname, "fixtures", filename)).toString()
 );

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -27,9 +27,8 @@ describe("commonmark", () => {
           start: 0,
           end: 1,
           attributes: {
-            "-offset-url": "http://commonmark.org/images/markdown-mark.png",
-            "-offset-description":
-              "Image descriptions ![are escaped](example.jpg)"
+            url: "http://commonmark.org/images/markdown-mark.png",
+            description: "Image descriptions ![are escaped](example.jpg)"
           }
         }
       ]
@@ -98,7 +97,7 @@ describe("commonmark", () => {
         {
           id: "4",
           type: "-offset-list",
-          attributes: { "-offset-type": "numbered", "-offset-tight": true },
+          attributes: { type: "numbered", tight: true },
           start: 14,
           end: 81
         },
@@ -133,7 +132,7 @@ describe("commonmark", () => {
         {
           id: "9",
           type: "-offset-list",
-          attributes: { "-offset-type": "bulleted", "-offset-tight": true },
+          attributes: { type: "bulleted", tight: true },
           start: 67,
           end: 81
         },
@@ -215,7 +214,7 @@ After all the lists
             start: 9,
             end: 13,
             attributes: {
-              "-offset-url": "https://example.com"
+              url: "https://example.com"
             }
           }
         ]
@@ -236,7 +235,7 @@ After all the lists
             start: 8,
             end: 14,
             attributes: {
-              "-offset-url": "https://example.com"
+              url: "https://example.com"
             }
           }
         ]
@@ -423,28 +422,28 @@ After all the lists
           type: "-offset-heading",
           start: 0,
           end: 7,
-          attributes: { "-offset-level": 1 }
+          attributes: { level: 1 }
         },
         {
           id: "2",
           type: "-atjson-parse-token",
           start: 6,
           end: 7,
-          attributes: { "-atjson-reason": "newline" }
+          attributes: { reason: "newline" }
         },
         {
           id: "3",
           type: "-offset-heading",
           start: 7,
           end: 16,
-          attributes: { "-offset-level": 2 }
+          attributes: { level: 2 }
         },
         {
           id: "4",
           type: "-atjson-parse-token",
           start: 15,
           end: 16,
-          attributes: { "-atjson-reason": "newline" }
+          attributes: { reason: "newline" }
         }
       ]
     });
@@ -468,7 +467,7 @@ After all the lists
           type: "-offset-link",
           start: 23,
           end: 28,
-          attributes: { "-offset-url": "https://example.com" }
+          attributes: { url: "https://example.com" }
         }
       ]
     });
@@ -1610,7 +1609,7 @@ After all the lists
             type: `-offset-${name}`,
             start: 0,
             end: 2,
-            attributes: { "-offset-level": 2 }
+            attributes: { level: 2 }
           },
           { type: "-offset-line-break", start: 1, end: 2, attributes: {} }
         ]
@@ -1627,7 +1626,7 @@ After all the lists
             type: "-offset-code",
             start: 0,
             end: 3,
-            attributes: { "-offset-style": "inline" }
+            attributes: { style: "inline" }
           },
           { type: "-offset-line-break", start: 1, end: 2, attributes: {} }
         ]

--- a/packages/@atjson/renderer-graphviz/example.dot
+++ b/packages/@atjson/renderer-graphviz/example.dot
@@ -1,7 +1,7 @@
 digraph atjson{
   node [shape=record];
   root1 [label="{root|{}}" style=filled fillcolor="#222222" fontcolor="#FFFFFF"];
-  link2 [label="{link|{\"url\":\"https://newyorker.com\"}}" style=filled fillcolor="#888888" fontcolor="#FFFFFF"];
+  link2 [label="{link|{\"-test-url\":\"https://newyorker.com\"}}" style=filled fillcolor="#888888" fontcolor="#FFFFFF"];
   text3 [label="{text|The }" style=filled fillcolor="#FFFFFF" fontcolor="#000000"];
   italic4 [label="{italic|{}}" style=filled fillcolor="#888888" fontcolor="#FFFFFF"];
   text5 [label="{text|best}" style=filled fillcolor="#FFFFFF" fontcolor="#000000"];

--- a/packages/@atjson/renderer-graphviz/test/__snapshots__/graphviz-test.ts.snap
+++ b/packages/@atjson/renderer-graphviz/test/__snapshots__/graphviz-test.ts.snap
@@ -4,7 +4,7 @@ exports[`graphviz example 1`] = `
 "digraph atjson{
   node [shape=record];
   root1 [label=\\"{root|{}}\\" style=filled fillcolor=\\"#222222\\" fontcolor=\\"#FFFFFF\\"];
-  link2 [label=\\"{link|{\\\\\\"url\\\\\\":\\\\\\"https://newyorker.com\\\\\\"}}\\" style=filled fillcolor=\\"#888888\\" fontcolor=\\"#FFFFFF\\"];
+  link2 [label=\\"{link|{\\\\\\"-test-url\\\\\\":\\\\\\"https://newyorker.com\\\\\\"}}\\" style=filled fillcolor=\\"#888888\\" fontcolor=\\"#FFFFFF\\"];
   text3 [label=\\"{text|The }\\" style=filled fillcolor=\\"#FFFFFF\\" fontcolor=\\"#000000\\"];
   italic4 [label=\\"{italic|{}}\\" style=filled fillcolor=\\"#888888\\" fontcolor=\\"#FFFFFF\\"];
   text5 [label=\\"{text|best}\\" style=filled fillcolor=\\"#FFFFFF\\" fontcolor=\\"#000000\\"];

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -85,7 +85,7 @@ function getChildNodeAnnotations(childNode: HIRNode) {
           start: childNode.start,
           end: childNode.end,
           attributes: {
-            "-atjson-text": childNode.text
+            text: childNode.text
           }
         };
       }

--- a/packages/@atjson/source-commonmark/src/converter.ts
+++ b/packages/@atjson/source-commonmark/src/converter.ts
@@ -9,44 +9,45 @@ CommonmarkSource.defineConverterTo(OffsetSource, function commonmarkToOffset(
     .set({ type: "-offset-blockquote" });
   doc
     .where({ type: "-commonmark-bullet_list" })
-    .set({ type: "-offset-list", attributes: { "-offset-type": "bulleted" } })
-    .rename({ attributes: { "-commonmark-tight": "-offset-tight" } });
+    .set({ type: "-offset-list", attributes: { type: "bulleted" } });
+
   doc
     .where({ type: "-commonmark-code_block" })
-    .set({ type: "-offset-code", attributes: { "-offset-style": "block" } });
+    .set({ type: "-offset-code", attributes: { style: "block" } });
   doc
     .where({ type: "-commonmark-code_inline" })
-    .set({ type: "-offset-code", attributes: { "-offset-style": "inline" } });
+    .set({ type: "-offset-code", attributes: { style: "inline" } });
   doc.where({ type: "-commonmark-em" }).set({ type: "-offset-italic" });
   doc
     .where({ type: "-commonmark-fence" })
-    .set({ type: "-offset-code", attributes: { "-offset-style": "fence" } })
-    .rename({ attributes: { "-commonmark-info": "-offset-info" } });
+    .set({ type: "-offset-code", attributes: { style: "fence" } });
+
   doc
     .where({ type: "-commonmark-hardbreak" })
     .set({ type: "-offset-line-break" });
   doc
     .where({ type: "-commonmark-heading" })
     .set({ type: "-offset-heading" })
-    .rename({ attributes: { "-commonmark-level": "-offset-level" } });
+    .rename({ attributes: { level: "level" } });
+
   doc
     .where({ type: "-commonmark-hr" })
     .set({ type: "-offset-horizontal-rule" });
   doc
     .where({ type: "-commonmark-html_block" })
-    .set({ type: "-offset-html", attributes: { "-offset-style": "block" } });
+    .set({ type: "-offset-html", attributes: { style: "block" } });
   doc
     .where({ type: "-commonmark-html_inline" })
-    .set({ type: "-offset-html", attributes: { "-offset-style": "inline" } });
+    .set({ type: "-offset-html", attributes: { style: "inline" } });
 
   doc
     .where({ type: "-commonmark-image" })
     .set({ type: "-offset-image" })
     .rename({
       attributes: {
-        "-commonmark-src": "-offset-url",
-        "-commonmark-title": "-offset-title",
-        "-commonmark-alt": "-offset-description"
+        "src": "url",
+        "title": "title",
+        "alt": "description"
       }
     });
 
@@ -55,8 +56,7 @@ CommonmarkSource.defineConverterTo(OffsetSource, function commonmarkToOffset(
     .set({ type: "-offset-link" })
     .rename({
       attributes: {
-        "-commonmark-href": "-offset-url",
-        "-commonmark-title": "-offset-title"
+        href: "url"
       }
     });
   doc
@@ -64,11 +64,10 @@ CommonmarkSource.defineConverterTo(OffsetSource, function commonmarkToOffset(
     .set({ type: "-offset-list-item" });
   doc
     .where({ type: "-commonmark-ordered_list" })
-    .set({ type: "-offset-list", attributes: { "-offset-type": "numbered" } })
+    .set({ type: "-offset-list", attributes: { type: "numbered" } })
     .rename({
       attributes: {
-        "-commonmark-start": "-offset-startsAt",
-        "-commonmark-tight": "-offset-tight"
+        start: "startsAt"
       }
     });
   doc

--- a/packages/@atjson/source-commonmark/src/converter.ts
+++ b/packages/@atjson/source-commonmark/src/converter.ts
@@ -45,9 +45,9 @@ CommonmarkSource.defineConverterTo(OffsetSource, function commonmarkToOffset(
     .set({ type: "-offset-image" })
     .rename({
       attributes: {
-        "src": "url",
-        "title": "title",
-        "alt": "description"
+        src: "url",
+        title: "title",
+        alt: "description"
       }
     });
 

--- a/packages/@atjson/source-commonmark/src/parser.ts
+++ b/packages/@atjson/source-commonmark/src/parser.ts
@@ -9,7 +9,7 @@ function getAttributes(token: Token): Attributes {
   let attributes: Attributes = {};
   if (token.attrs) {
     for (let attribute of token.attrs) {
-      attributes[`-commonmark-${attribute[0]}`] = attribute[1];
+      attributes[attribute[0]] = attribute[1];
     }
   }
 
@@ -191,7 +191,7 @@ export default class Parser {
             }
           }
 
-          attrs["-commonmark-tight"] = isTight;
+          attrs["tight"] = isTight;
         }
         let annotationGenerator = this.convertTokenToAnnotation(
           node.name,
@@ -229,10 +229,10 @@ export default class Parser {
     let end = this.content.length;
     let attributes = Object.assign(getAttributes(open), attrs || {});
     if (name === "heading") {
-      attributes["-commonmark-level"] = parseInt(open.tag[1], 10);
+      attributes["level"] = parseInt(open.tag[1], 10);
     }
     if (name === "fence") {
-      attributes["-commonmark-info"] = entities.decodeHTML5(open.info.trim());
+      attributes["info"] = entities.decodeHTML5(open.info.trim());
     }
 
     if (this.handlers[name]) {

--- a/packages/@atjson/source-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/source-commonmark/test/commonmark-test.ts
@@ -98,19 +98,19 @@ describe("list", () => {
       {
         type: "-commonmark-bullet_list",
         attributes: {
-          "-commonmark-tight": true
+          tight: true
         }
       },
       {
         type: "-commonmark-bullet_list",
         attributes: {
-          "-commonmark-tight": true
+          tight: true
         }
       },
       {
         type: "-commonmark-bullet_list",
         attributes: {
-          "-commonmark-tight": true
+          tight: true
         }
       }
     ]);
@@ -121,14 +121,14 @@ describe("list", () => {
       {
         type: "-commonmark-ordered_list",
         attributes: {
-          "-commonmark-start": 2,
-          "-commonmark-tight": true
+          start: 2,
+          tight: true
         }
       },
       {
         type: "-commonmark-ordered_list",
         attributes: {
-          "-commonmark-tight": false
+          tight: false
         }
       }
     ]);

--- a/packages/@atjson/source-gdocs-paste/src/converter.ts
+++ b/packages/@atjson/source-gdocs-paste/src/converter.ts
@@ -29,13 +29,13 @@ GDocsSource.defineConverterTo(OffsetSource, doc => {
   doc.where({ type: "-gdocs-ts_un" }).set({ type: "-offset-underline" });
   doc.where({ type: "-gdocs-ts_st" }).set({ type: "-offset-strikethrough" });
   doc
-    .where({ type: "-gdocs-ts_va", attributes: { "-gdocs-va": "sub" } })
+    .where({ type: "-gdocs-ts_va", attributes: { va: "sub" } })
     .set({ type: "-offset-subscript" })
-    .unset("attributes.-gdocs-va");
+    .unset("attributes.va");
   doc
-    .where({ type: "-gdocs-ts_va", attributes: { "-gdocs-va": "sup" } })
+    .where({ type: "-gdocs-ts_va", attributes: { va: "sup" } })
     .set({ type: "-offset-superscript" })
-    .unset("attributes.-gdocs-va");
+    .unset("attributes.va");
 
   doc
     .where({ type: "-gdocs-horizontal_rule" })
@@ -52,21 +52,21 @@ GDocsSource.defineConverterTo(OffsetSource, doc => {
   doc
     .where({ type: "-gdocs-ps_hd" })
     .set({ type: "-offset-heading" })
-    .rename({ attributes: { "-gdocs-level": "-offset-level" } });
+    .rename({ attributes: { level: "level" } });
 
   // b_gt: 9 indicates an unordered list, but ordered lists have a variety of b_gt values
   doc
-    .where({ type: "-gdocs-list", attributes: { "-gdocs-ls_b_gt": 9 } })
-    .set({ type: "-offset-list", attributes: { "-offset-type": "bulleted" } });
+    .where({ type: "-gdocs-list", attributes: { ls_b_gt: 9 } })
+    .set({ type: "-offset-list", attributes: { type: "bulleted" } });
   doc
     .where({ type: "-gdocs-list" })
-    .set({ type: "-offset-list", attributes: { "-offset-type": "numbered" } });
+    .set({ type: "-offset-list", attributes: { type: "numbered" } });
   doc.where({ type: "-gdocs-list_item" }).set({ type: "-offset-list-item" });
 
   doc
     .where({ type: "-gdocs-lnks_link" })
     .set({ type: "-offset-link" })
-    .rename({ attributes: { "-gdocs-ulnk_url": "-offset-url" } });
+    .rename({ attributes: { ulnk_url: "url" } });
 
   doc
     .where({ type: "-offset-list" })

--- a/packages/@atjson/source-gdocs-paste/src/link-styles.ts
+++ b/packages/@atjson/source-gdocs-paste/src/link-styles.ts
@@ -29,8 +29,8 @@ export default function extractLinkStyles(
         start: i,
         end: -1,
         attributes: {
-          "-gdocs-ulnk_url": link.lnks_link.ulnk_url,
-          "-gdocs-lnk_type": link.lnks_link.lnk_type
+          ulnk_url: link.lnks_link.ulnk_url,
+          lnk_type: link.lnks_link.lnk_type
         }
       };
     }

--- a/packages/@atjson/source-gdocs-paste/src/list-styles.ts
+++ b/packages/@atjson/source-gdocs-paste/src/list-styles.ts
@@ -12,10 +12,10 @@ function createListAnnotation(
     start,
     end,
     attributes: {
-      "-gdocs-ls_id": list.ls_id,
-      "-gdocs-ls_b_gs": entityMap[list.ls_id].le_nb.nl_0.b_gs,
-      "-gdocs-ls_b_gt": entityMap[list.ls_id].le_nb.nl_0.b_gt,
-      "-gdocs-ls_b_a": entityMap[list.ls_id].le_nb.nl_0.b_a
+      ls_id: list.ls_id,
+      ls_b_gs: entityMap[list.ls_id].le_nb.nl_0.b_gs,
+      ls_b_gt: entityMap[list.ls_id].le_nb.nl_0.b_gt,
+      ls_b_a: entityMap[list.ls_id].le_nb.nl_0.b_a
     }
   };
 }
@@ -30,8 +30,8 @@ function createListItemAnnotation(
     start,
     end,
     attributes: {
-      "-gdocs-ls_nest": list.ls_nest,
-      "-gdocs-ls_id": list.ls_id
+      ls_nest: list.ls_nest,
+      ls_id: list.ls_id
     }
   };
 }

--- a/packages/@atjson/source-gdocs-paste/src/paragraph-styles.ts
+++ b/packages/@atjson/source-gdocs-paste/src/paragraph-styles.ts
@@ -49,7 +49,7 @@ export default function extractParagraphStyles(
         start: lastParagraphStart,
         end: i,
         attributes: {
-          "-gdocs-level": style.ps_hd
+          level: style.ps_hd
         }
       });
     }

--- a/packages/@atjson/source-gdocs-paste/src/text-styles.ts
+++ b/packages/@atjson/source-gdocs-paste/src/text-styles.ts
@@ -21,7 +21,7 @@ export default function extractTextStyles(
       state.ts_va = {
         type: "-gdocs-ts_va",
         attributes: {
-          "-gdocs-va": style.ts_va
+          va: style.ts_va
         },
         start: i,
         end: -1

--- a/packages/@atjson/source-gdocs-paste/test/converter-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/converter-test.ts
@@ -341,7 +341,7 @@ describe("@atjson/source-gdocs-paste", () => {
         ...linebreak,
         type: "-atjson-parse-token",
         attributes: {
-          "-atjson-reason": "new line"
+          reason: "new line"
         }
       }))
     );

--- a/packages/@atjson/source-gdocs-paste/test/converter-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/converter-test.ts
@@ -137,7 +137,7 @@ describe("@atjson/source-gdocs-paste paragraphs", () => {
       start,
       end,
       type: "-offset-list",
-      attributes: { "-offset-type": "numbered" },
+      attributes: { type: "numbered" },
       id: expect.anything()
     };
   });

--- a/packages/@atjson/source-html/src/converter/index.ts
+++ b/packages/@atjson/source-html/src/converter/index.ts
@@ -43,9 +43,9 @@ HTMLSource.defineConverterTo(OffsetSource, function HTMLToOffset(doc) {
     .set({ type: "-offset-link" })
     .rename({
       attributes: {
-        "-html-href": "-offset-url",
-        "-html-rel": "-offset-rel",
-        "-html-target": "-offset-target"
+        href: "url",
+        rel: "rel",
+        target: "target"
       }
     });
 
@@ -53,22 +53,22 @@ HTMLSource.defineConverterTo(OffsetSource, function HTMLToOffset(doc) {
 
   doc
     .where({ type: "-html-h1" })
-    .set({ type: "-offset-heading", attributes: { "-offset-level": 1 } });
+    .set({ type: "-offset-heading", attributes: { level: 1 } });
   doc
     .where({ type: "-html-h2" })
-    .set({ type: "-offset-heading", attributes: { "-offset-level": 2 } });
+    .set({ type: "-offset-heading", attributes: { level: 2 } });
   doc
     .where({ type: "-html-h3" })
-    .set({ type: "-offset-heading", attributes: { "-offset-level": 3 } });
+    .set({ type: "-offset-heading", attributes: { level: 3 } });
   doc
     .where({ type: "-html-h4" })
-    .set({ type: "-offset-heading", attributes: { "-offset-level": 4 } });
+    .set({ type: "-offset-heading", attributes: { level: 4 } });
   doc
     .where({ type: "-html-h5" })
-    .set({ type: "-offset-heading", attributes: { "-offset-level": 5 } });
+    .set({ type: "-offset-heading", attributes: { level: 5 } });
   doc
     .where({ type: "-html-h6" })
-    .set({ type: "-offset-heading", attributes: { "-offset-level": 6 } });
+    .set({ type: "-offset-heading", attributes: { level: 6 } });
 
   doc.where({ type: "-html-p" }).set({ type: "-offset-paragraph" });
   doc.where({ type: "-html-br" }).set({ type: "-offset-line-break" });
@@ -76,7 +76,7 @@ HTMLSource.defineConverterTo(OffsetSource, function HTMLToOffset(doc) {
 
   doc
     .where({ type: "-html-ul" })
-    .set({ type: "-offset-list", attributes: { "-offset-type": "bulleted" } });
+    .set({ type: "-offset-list", attributes: { type: "bulleted" } });
   doc
     .where({ type: "-html-ol" })
     .update(function updateOList(list: OrderedList) {
@@ -86,8 +86,8 @@ HTMLSource.defineConverterTo(OffsetSource, function HTMLToOffset(doc) {
         start: list.start,
         end: list.end,
         attributes: {
-          "-offset-type": "numbered",
-          "-offset-startsAt": parseInt(list.attributes.start || "1", 10)
+          type: "numbered",
+          startsAt: parseInt(list.attributes.start || "1", 10)
         }
       });
     });
@@ -108,9 +108,9 @@ HTMLSource.defineConverterTo(OffsetSource, function HTMLToOffset(doc) {
     .set({ type: "-offset-image" })
     .rename({
       attributes: {
-        "-html-src": "-offset-url",
-        "-html-title": "-offset-title",
-        "-html-alt": "-offset-description"
+        url: "src",
+        title: "title",
+        description: "alt"
       }
     });
 
@@ -145,7 +145,7 @@ HTMLSource.defineConverterTo(OffsetSource, function HTMLToOffset(doc) {
 
   doc
     .where({ type: "-html-code" })
-    .set({ type: "-offset-code", attributes: { "-offset-style": "inline" } });
+    .set({ type: "-offset-code", attributes: { style: "inline" } });
 
   doc.where({ type: "-html-section" }).set({ type: "-offset-section" });
 

--- a/packages/@atjson/source-html/src/converter/index.ts
+++ b/packages/@atjson/source-html/src/converter/index.ts
@@ -108,9 +108,9 @@ HTMLSource.defineConverterTo(OffsetSource, function HTMLToOffset(doc) {
     .set({ type: "-offset-image" })
     .rename({
       attributes: {
-        url: "src",
+        src: "url",
         title: "title",
-        description: "alt"
+        alt: "description"
       }
     });
 

--- a/packages/@atjson/source-html/src/parser.ts
+++ b/packages/@atjson/source-html/src/parser.ts
@@ -35,16 +35,16 @@ function getAttributes(node: parse5.DefaultTreeElement): NonNullable<any> {
   let attributes: NonNullable<any> = {};
   for (let attr of node.attrs) {
     if (attr.name.indexOf("data-") === 0) {
-      if (attributes["-html-dataset"] == null) attributes["-html-dataset"] = {};
-      attributes["-html-dataset"][attr.name.slice(5)] = attr.value;
+      if (attributes["dataset"] == null) attributes["dataset"] = {};
+      attributes["dataset"][attr.name.slice(5)] = attr.value;
     } else {
-      attributes[`-html-${attr.name}`] = attr.value;
+      attributes[attr.name] = attr.value;
     }
   }
 
-  let href = attributes["-html-href"];
+  let href = attributes["href"];
   if (node.tagName === "a" && typeof href === "string") {
-    attributes["-html-href"] = decodeURI(href);
+    attributes["href"] = decodeURI(href);
   }
 
   return attributes;

--- a/packages/@atjson/source-html/test/source-html-test.ts
+++ b/packages/@atjson/source-html/test/source-html-test.ts
@@ -101,10 +101,10 @@ describe("@atjson/source-html", () => {
       {
         type: "-html-div",
         attributes: {
-          "-html-class": "spaceship",
-          "-html-dataset": {
-            "-html-ship-id": "92432",
-            "-html-weapons": "kittens"
+          class: "spaceship",
+          dataset: {
+            "ship-id": "92432",
+            weapons: "kittens"
           }
         }
       }

--- a/packages/@atjson/source-mobiledoc/src/parser.ts
+++ b/packages/@atjson/source-mobiledoc/src/parser.ts
@@ -16,20 +16,6 @@ export interface Mobiledoc {
   sections: Array<Section | ImageSection | ListSection | CardSection>;
 }
 
-function prefix(attributes: any): any {
-  if (Array.isArray(attributes)) {
-    return attributes.map(prefix);
-  } else if (typeof attributes === "object" && attributes != null) {
-    let prefixedAttributes: any = {};
-    for (let key in attributes) {
-      prefixedAttributes[`-mobiledoc-${key}`] = prefix(attributes[key]);
-    }
-    return prefixedAttributes;
-  } else {
-    return attributes;
-  }
-}
-
 export default class Parser {
   content: string;
   annotations: AnnotationJSON[];
@@ -70,7 +56,7 @@ export default class Parser {
       type: `-mobiledoc-${card[0]}-card`,
       start,
       end: start + 1,
-      attributes: prefix(card[1])
+      attributes: card[1]
     });
     return "\uFFFC";
   }
@@ -82,7 +68,7 @@ export default class Parser {
       start,
       end: start + 1,
       attributes: {
-        "-mobiledoc-src": src
+        src
       }
     });
     return "\uFFFC";
@@ -190,7 +176,7 @@ export default class Parser {
         for (let i = 0, len = attributeList.length; i < len; i += 2) {
           let key = attributeList[i];
           let value = attributeList[i + 1];
-          attributes[`-mobiledoc-${key}`] = value;
+          attributes[key] = value;
         }
       }
       this.inProgressAnnotations.push({
@@ -222,7 +208,7 @@ export default class Parser {
       type: `-mobiledoc-${name}-atom`,
       start,
       end,
-      attributes: prefix(attributes)
+      attributes
     });
     return text;
   }

--- a/packages/@atjson/source-mobiledoc/test/source-mobiledoc-test.ts
+++ b/packages/@atjson/source-mobiledoc/test/source-mobiledoc-test.ts
@@ -3,7 +3,7 @@ import { HIR } from "@atjson/hir";
 import MobiledocSource from "../src";
 import { ListSection } from "../src/parser";
 
-describe("@atjson/source-Mobiledoc", () => {
+describe("@atjson/source-mobiledoc", () => {
   describe("sections", () => {
     describe.each([
       "p",

--- a/packages/@atjson/source-prism/src/source.ts
+++ b/packages/@atjson/source-prism/src/source.ts
@@ -9,30 +9,6 @@ import * as entities from "entities";
 import * as sax from "sax";
 import { Article, Description, Media, Message, Title } from "./annotations";
 
-function prefix(vendorPrefix: string, attributes: any): any {
-  if (Array.isArray(attributes)) {
-    return attributes.map(function recurseWithVendor(item: any) {
-      return prefix(vendorPrefix, item);
-    });
-  } else if (typeof attributes === "object" && attributes != null) {
-    let prefixedAttributes: any = {};
-    for (let namespacedKey in attributes) {
-      let [namespace, key] = namespacedKey.split(":");
-      if (key == null) {
-        key = namespace;
-        namespace = vendorPrefix;
-      }
-      prefixedAttributes[`-${namespace}-${key}`] = prefix(
-        vendorPrefix,
-        attributes[key]
-      );
-    }
-    return prefixedAttributes;
-  } else {
-    return attributes;
-  }
-}
-
 function getVendorPrefix(tagName: string) {
   let [namespace, tag] = tagName.split(":");
   if (tag == null) {
@@ -94,7 +70,7 @@ export default class PRISMSource extends Document {
             type: `-${vendorPrefix}-${type}`,
             start: parser.startTagPosition - 1,
             end: parser.position,
-            attributes: prefix(vendorPrefix, node.attributes)
+            attributes: node.attributes as any
           },
           new ParseAnnotation({
             start: parser.startTagPosition - 1,
@@ -108,7 +84,7 @@ export default class PRISMSource extends Document {
         partialAnnotations.push({
           type: `-${vendorPrefix}-${type}`,
           start: parser.startTagPosition - 1,
-          attributes: prefix(vendorPrefix, node.attributes)
+          attributes: node.attributes as any
         });
         annotations.push(
           new ParseAnnotation({

--- a/packages/@atjson/source-prism/test/__snapshots__/prism-test.ts.snap
+++ b/packages/@atjson/source-prism/test/__snapshots__/prism-test.ts.snap
@@ -9,12 +9,23 @@ Object {
     Object {
       "attributes": Object {
         "xmlns": "http://www.w3.org/1999/xhtml",
+        "xmlns:dc": "http://purl.org/dc/elements/1.1/",
+        "xmlns:dcterms": "http://purl.org/dc/terms/",
+        "xmlns:pam": "http://prismstandard.org/namespaces/pam/2.0/",
+        "xmlns:pim": "http://prismstandard.org/namespaces/pim/2.0/",
+        "xmlns:prism": "http://prismstandard.org/namespaces/basic/2.0/",
+        "xmlns:prl": "http://prismstandard.org/namespaces/prl/2.0/",
+        "xmlns:xhtml": "http://www.w3.org/1999/xhtml",
+        "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "xsi:schemalocation": "http://prismstandard.org/namespaces/pam/2.0/ pam.xsd",
       },
       "children": Array [
         "
 ",
         Object {
-          "attributes": Object {},
+          "attributes": Object {
+            "xml:lang": "en-US",
+          },
           "children": Array [
             "
 ",
@@ -2565,7 +2576,7 @@ Object {
   "annotations": Array [
     Object {
       "attributes": Object {
-        "-atjson-reason": "<?xml>",
+        "reason": "<?xml>",
       },
       "end": 38,
       "id": "Any<id>",
@@ -2574,7 +2585,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<pam:message>",
+        "reason": "<pam:message>",
       },
       "end": 578,
       "id": "Any<id>",
@@ -2583,7 +2594,16 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-pam-xmlns": "http://www.w3.org/1999/xhtml",
+        "xmlns": "http://www.w3.org/1999/xhtml",
+        "xmlns:dc": "http://purl.org/dc/elements/1.1/",
+        "xmlns:dcterms": "http://purl.org/dc/terms/",
+        "xmlns:pam": "http://prismstandard.org/namespaces/pam/2.0/",
+        "xmlns:pim": "http://prismstandard.org/namespaces/pim/2.0/",
+        "xmlns:prism": "http://prismstandard.org/namespaces/basic/2.0/",
+        "xmlns:prl": "http://prismstandard.org/namespaces/prl/2.0/",
+        "xmlns:xhtml": "http://www.w3.org/1999/xhtml",
+        "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "xsi:schemalocation": "http://prismstandard.org/namespaces/pam/2.0/ pam.xsd",
       },
       "end": 14096,
       "id": "Any<id>",
@@ -2592,7 +2612,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<pam:article>",
+        "reason": "<pam:article>",
       },
       "end": 609,
       "id": "Any<id>",
@@ -2600,7 +2620,9 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
+      "attributes": Object {
+        "xml:lang": "en-US",
+      },
       "end": 14081,
       "id": "Any<id>",
       "start": 579,
@@ -2608,7 +2630,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<body>",
+        "reason": "<body>",
       },
       "end": 617,
       "id": "Any<id>",
@@ -2624,7 +2646,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<h1>",
+        "reason": "<h1>",
       },
       "end": 622,
       "id": "Any<id>",
@@ -2633,7 +2655,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-offset-level": 1,
+        "level": 1,
       },
       "end": 638,
       "id": "Any<id>",
@@ -2642,7 +2664,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</h1>",
+        "reason": "</h1>",
       },
       "end": 638,
       "id": "Any<id>",
@@ -2651,7 +2673,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 657,
       "id": "Any<id>",
@@ -2660,7 +2682,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-html-class": "byline",
+        "class": "byline",
       },
       "end": 752,
       "id": "Any<id>",
@@ -2676,7 +2698,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<br/>",
+        "reason": "<br/>",
       },
       "end": 672,
       "id": "Any<id>",
@@ -2692,7 +2714,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<br/>",
+        "reason": "<br/>",
       },
       "end": 699,
       "id": "Any<id>",
@@ -2708,7 +2730,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<br/>",
+        "reason": "<br/>",
       },
       "end": 726,
       "id": "Any<id>",
@@ -2717,7 +2739,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 752,
       "id": "Any<id>",
@@ -2726,7 +2748,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 769,
       "id": "Any<id>",
@@ -2735,7 +2757,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-html-class": "deck",
+        "class": "deck",
       },
       "end": 1086,
       "id": "Any<id>",
@@ -2744,7 +2766,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 1086,
       "id": "Any<id>",
@@ -2753,7 +2775,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<h2>",
+        "reason": "<h2>",
       },
       "end": 1096,
       "id": "Any<id>",
@@ -2762,7 +2784,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-offset-level": 2,
+        "level": 2,
       },
       "end": 1112,
       "id": "Any<id>",
@@ -2771,7 +2793,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</h2>",
+        "reason": "</h2>",
       },
       "end": 1112,
       "id": "Any<id>",
@@ -2780,7 +2802,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 1117,
       "id": "Any<id>",
@@ -2796,7 +2818,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<i>",
+        "reason": "<i>",
       },
       "end": 1120,
       "id": "Any<id>",
@@ -2812,7 +2834,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</i>",
+        "reason": "</i>",
       },
       "end": 1150,
       "id": "Any<id>",
@@ -2821,7 +2843,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 1159,
       "id": "Any<id>",
@@ -2830,7 +2852,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 1163,
       "id": "Any<id>",
@@ -2846,7 +2868,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 1166,
       "id": "Any<id>",
@@ -2869,7 +2891,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<br/>",
+        "reason": "<br/>",
       },
       "end": 1179,
       "id": "Any<id>",
@@ -2878,7 +2900,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 1190,
       "id": "Any<id>",
@@ -2887,7 +2909,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 1194,
       "id": "Any<id>",
@@ -2896,7 +2918,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 1200,
       "id": "Any<id>",
@@ -2912,7 +2934,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 1203,
       "id": "Any<id>",
@@ -2928,7 +2950,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<small>",
+        "reason": "<small>",
       },
       "end": 1210,
       "id": "Any<id>",
@@ -2944,7 +2966,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</small>",
+        "reason": "</small>",
       },
       "end": 1257,
       "id": "Any<id>",
@@ -2953,7 +2975,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 1261,
       "id": "Any<id>",
@@ -2962,7 +2984,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 1493,
       "id": "Any<id>",
@@ -2971,7 +2993,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 1497,
       "id": "Any<id>",
@@ -2987,7 +3009,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 1500,
       "id": "Any<id>",
@@ -3003,7 +3025,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<small>",
+        "reason": "<small>",
       },
       "end": 1507,
       "id": "Any<id>",
@@ -3019,7 +3041,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</small>",
+        "reason": "</small>",
       },
       "end": 1524,
       "id": "Any<id>",
@@ -3028,7 +3050,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 1618,
       "id": "Any<id>",
@@ -3037,7 +3059,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 1622,
       "id": "Any<id>",
@@ -3046,7 +3068,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 1626,
       "id": "Any<id>",
@@ -3062,7 +3084,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 1629,
       "id": "Any<id>",
@@ -3078,7 +3100,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<small>",
+        "reason": "<small>",
       },
       "end": 1636,
       "id": "Any<id>",
@@ -3094,7 +3116,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</small>",
+        "reason": "</small>",
       },
       "end": 1656,
       "id": "Any<id>",
@@ -3103,7 +3125,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 1660,
       "id": "Any<id>",
@@ -3112,7 +3134,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2058,
       "id": "Any<id>",
@@ -3121,7 +3143,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2062,
       "id": "Any<id>",
@@ -3137,7 +3159,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 2065,
       "id": "Any<id>",
@@ -3153,7 +3175,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 2112,
       "id": "Any<id>",
@@ -3162,7 +3184,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2116,
       "id": "Any<id>",
@@ -3171,7 +3193,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2120,
       "id": "Any<id>",
@@ -3187,7 +3209,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2211,
       "id": "Any<id>",
@@ -3196,7 +3218,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2215,
       "id": "Any<id>",
@@ -3212,7 +3234,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 2218,
       "id": "Any<id>",
@@ -3228,7 +3250,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 2285,
       "id": "Any<id>",
@@ -3237,7 +3259,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2289,
       "id": "Any<id>",
@@ -3246,7 +3268,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2293,
       "id": "Any<id>",
@@ -3262,7 +3284,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2329,
       "id": "Any<id>",
@@ -3271,7 +3293,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2333,
       "id": "Any<id>",
@@ -3287,7 +3309,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 2336,
       "id": "Any<id>",
@@ -3303,7 +3325,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 2393,
       "id": "Any<id>",
@@ -3312,7 +3334,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2397,
       "id": "Any<id>",
@@ -3321,7 +3343,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2401,
       "id": "Any<id>",
@@ -3337,7 +3359,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2489,
       "id": "Any<id>",
@@ -3346,7 +3368,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2493,
       "id": "Any<id>",
@@ -3362,7 +3384,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 2496,
       "id": "Any<id>",
@@ -3378,7 +3400,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 2532,
       "id": "Any<id>",
@@ -3387,7 +3409,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2536,
       "id": "Any<id>",
@@ -3396,7 +3418,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2540,
       "id": "Any<id>",
@@ -3412,7 +3434,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2595,
       "id": "Any<id>",
@@ -3421,7 +3443,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2599,
       "id": "Any<id>",
@@ -3437,7 +3459,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 2602,
       "id": "Any<id>",
@@ -3453,7 +3475,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 2695,
       "id": "Any<id>",
@@ -3462,7 +3484,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2699,
       "id": "Any<id>",
@@ -3471,7 +3493,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2703,
       "id": "Any<id>",
@@ -3487,7 +3509,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2745,
       "id": "Any<id>",
@@ -3496,7 +3518,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2749,
       "id": "Any<id>",
@@ -3512,7 +3534,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 2752,
       "id": "Any<id>",
@@ -3528,7 +3550,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 2837,
       "id": "Any<id>",
@@ -3537,7 +3559,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2841,
       "id": "Any<id>",
@@ -3546,7 +3568,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2845,
       "id": "Any<id>",
@@ -3562,7 +3584,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 3159,
       "id": "Any<id>",
@@ -3571,7 +3593,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 3163,
       "id": "Any<id>",
@@ -3587,7 +3609,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 3166,
       "id": "Any<id>",
@@ -3603,7 +3625,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 3236,
       "id": "Any<id>",
@@ -3612,7 +3634,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 3240,
       "id": "Any<id>",
@@ -3621,7 +3643,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 3244,
       "id": "Any<id>",
@@ -3637,7 +3659,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 3409,
       "id": "Any<id>",
@@ -3646,7 +3668,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 3413,
       "id": "Any<id>",
@@ -3662,7 +3684,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 3416,
       "id": "Any<id>",
@@ -3678,7 +3700,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 3484,
       "id": "Any<id>",
@@ -3687,7 +3709,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 3488,
       "id": "Any<id>",
@@ -3696,7 +3718,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 3492,
       "id": "Any<id>",
@@ -3712,7 +3734,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 3566,
       "id": "Any<id>",
@@ -3721,7 +3743,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<h2>",
+        "reason": "<h2>",
       },
       "end": 3571,
       "id": "Any<id>",
@@ -3730,7 +3752,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-offset-level": 2,
+        "level": 2,
       },
       "end": 3591,
       "id": "Any<id>",
@@ -3739,7 +3761,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</h2>",
+        "reason": "</h2>",
       },
       "end": 3591,
       "id": "Any<id>",
@@ -3748,7 +3770,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 3596,
       "id": "Any<id>",
@@ -3764,7 +3786,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<i>",
+        "reason": "<i>",
       },
       "end": 3599,
       "id": "Any<id>",
@@ -3780,7 +3802,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</i>",
+        "reason": "</i>",
       },
       "end": 3629,
       "id": "Any<id>",
@@ -3789,7 +3811,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 3638,
       "id": "Any<id>",
@@ -3798,7 +3820,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 3642,
       "id": "Any<id>",
@@ -3814,7 +3836,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 3645,
       "id": "Any<id>",
@@ -3837,7 +3859,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<br/>",
+        "reason": "<br/>",
       },
       "end": 3660,
       "id": "Any<id>",
@@ -3846,7 +3868,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 3671,
       "id": "Any<id>",
@@ -3855,7 +3877,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 3675,
       "id": "Any<id>",
@@ -3864,7 +3886,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 3679,
       "id": "Any<id>",
@@ -3880,7 +3902,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 3682,
       "id": "Any<id>",
@@ -3896,7 +3918,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<small>",
+        "reason": "<small>",
       },
       "end": 3689,
       "id": "Any<id>",
@@ -3912,7 +3934,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</small>",
+        "reason": "</small>",
       },
       "end": 3716,
       "id": "Any<id>",
@@ -3921,7 +3943,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 3720,
       "id": "Any<id>",
@@ -3930,7 +3952,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<i>",
+        "reason": "<i>",
       },
       "end": 4030,
       "id": "Any<id>",
@@ -3946,7 +3968,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</i>",
+        "reason": "</i>",
       },
       "end": 4044,
       "id": "Any<id>",
@@ -3955,7 +3977,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 4097,
       "id": "Any<id>",
@@ -3964,7 +3986,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 4101,
       "id": "Any<id>",
@@ -3980,7 +4002,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 4104,
       "id": "Any<id>",
@@ -3996,7 +4018,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<small>",
+        "reason": "<small>",
       },
       "end": 4111,
       "id": "Any<id>",
@@ -4012,7 +4034,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</small>",
+        "reason": "</small>",
       },
       "end": 4128,
       "id": "Any<id>",
@@ -4021,7 +4043,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 4222,
       "id": "Any<id>",
@@ -4030,7 +4052,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 4226,
       "id": "Any<id>",
@@ -4039,7 +4061,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 4230,
       "id": "Any<id>",
@@ -4055,7 +4077,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<small>",
+        "reason": "<small>",
       },
       "end": 4237,
       "id": "Any<id>",
@@ -4071,7 +4093,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 4240,
       "id": "Any<id>",
@@ -4087,7 +4109,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 4260,
       "id": "Any<id>",
@@ -4096,7 +4118,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</small>",
+        "reason": "</small>",
       },
       "end": 4268,
       "id": "Any<id>",
@@ -4105,7 +4127,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 4945,
       "id": "Any<id>",
@@ -4114,7 +4136,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 4949,
       "id": "Any<id>",
@@ -4130,7 +4152,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 4952,
       "id": "Any<id>",
@@ -4146,7 +4168,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 4999,
       "id": "Any<id>",
@@ -4155,7 +4177,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 5003,
       "id": "Any<id>",
@@ -4164,7 +4186,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 5007,
       "id": "Any<id>",
@@ -4180,7 +4202,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<i>",
+        "reason": "<i>",
       },
       "end": 5052,
       "id": "Any<id>",
@@ -4196,7 +4218,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</i>",
+        "reason": "</i>",
       },
       "end": 5062,
       "id": "Any<id>",
@@ -4205,7 +4227,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 5524,
       "id": "Any<id>",
@@ -4214,7 +4236,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 5528,
       "id": "Any<id>",
@@ -4230,7 +4252,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 5531,
       "id": "Any<id>",
@@ -4246,7 +4268,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 5598,
       "id": "Any<id>",
@@ -4255,7 +4277,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 5602,
       "id": "Any<id>",
@@ -4264,7 +4286,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 5606,
       "id": "Any<id>",
@@ -4280,7 +4302,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 5973,
       "id": "Any<id>",
@@ -4289,7 +4311,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 5977,
       "id": "Any<id>",
@@ -4305,7 +4327,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 5980,
       "id": "Any<id>",
@@ -4321,7 +4343,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 6037,
       "id": "Any<id>",
@@ -4330,7 +4352,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 6041,
       "id": "Any<id>",
@@ -4339,7 +4361,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 6045,
       "id": "Any<id>",
@@ -4355,7 +4377,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 6251,
       "id": "Any<id>",
@@ -4364,7 +4386,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 6258,
       "id": "Any<id>",
@@ -4380,7 +4402,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 6261,
       "id": "Any<id>",
@@ -4396,7 +4418,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 6297,
       "id": "Any<id>",
@@ -4405,7 +4427,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 6301,
       "id": "Any<id>",
@@ -4414,7 +4436,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 6305,
       "id": "Any<id>",
@@ -4430,7 +4452,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 6556,
       "id": "Any<id>",
@@ -4439,7 +4461,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 6560,
       "id": "Any<id>",
@@ -4455,7 +4477,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 6563,
       "id": "Any<id>",
@@ -4471,7 +4493,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 6648,
       "id": "Any<id>",
@@ -4480,7 +4502,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 6652,
       "id": "Any<id>",
@@ -4489,7 +4511,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 6656,
       "id": "Any<id>",
@@ -4505,7 +4527,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 7094,
       "id": "Any<id>",
@@ -4514,7 +4536,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 7098,
       "id": "Any<id>",
@@ -4530,7 +4552,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 7101,
       "id": "Any<id>",
@@ -4546,7 +4568,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 7171,
       "id": "Any<id>",
@@ -4555,7 +4577,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 7175,
       "id": "Any<id>",
@@ -4564,7 +4586,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 7179,
       "id": "Any<id>",
@@ -4580,7 +4602,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 7461,
       "id": "Any<id>",
@@ -4589,7 +4611,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 7465,
       "id": "Any<id>",
@@ -4605,7 +4627,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 7468,
       "id": "Any<id>",
@@ -4621,7 +4643,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 7536,
       "id": "Any<id>",
@@ -4630,7 +4652,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 7540,
       "id": "Any<id>",
@@ -4639,7 +4661,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 7544,
       "id": "Any<id>",
@@ -4655,7 +4677,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 7927,
       "id": "Any<id>",
@@ -4664,7 +4686,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 7931,
       "id": "Any<id>",
@@ -4680,7 +4702,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 7934,
       "id": "Any<id>",
@@ -4696,7 +4718,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 8027,
       "id": "Any<id>",
@@ -4705,7 +4727,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 8031,
       "id": "Any<id>",
@@ -4714,7 +4736,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 8035,
       "id": "Any<id>",
@@ -4730,7 +4752,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 8155,
       "id": "Any<id>",
@@ -4739,7 +4761,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<h2>",
+        "reason": "<h2>",
       },
       "end": 8160,
       "id": "Any<id>",
@@ -4748,7 +4770,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-offset-level": 2,
+        "level": 2,
       },
       "end": 8180,
       "id": "Any<id>",
@@ -4757,7 +4779,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</h2>",
+        "reason": "</h2>",
       },
       "end": 8180,
       "id": "Any<id>",
@@ -4766,7 +4788,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 8185,
       "id": "Any<id>",
@@ -4782,7 +4804,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<i>",
+        "reason": "<i>",
       },
       "end": 8188,
       "id": "Any<id>",
@@ -4798,7 +4820,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</i>",
+        "reason": "</i>",
       },
       "end": 8218,
       "id": "Any<id>",
@@ -4807,7 +4829,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 8227,
       "id": "Any<id>",
@@ -4816,7 +4838,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 8231,
       "id": "Any<id>",
@@ -4832,7 +4854,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 8234,
       "id": "Any<id>",
@@ -4855,7 +4877,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<br/>",
+        "reason": "<br/>",
       },
       "end": 8247,
       "id": "Any<id>",
@@ -4864,7 +4886,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 8258,
       "id": "Any<id>",
@@ -4873,7 +4895,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 8262,
       "id": "Any<id>",
@@ -4882,7 +4904,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 8266,
       "id": "Any<id>",
@@ -4898,7 +4920,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<small>",
+        "reason": "<small>",
       },
       "end": 8273,
       "id": "Any<id>",
@@ -4914,7 +4936,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 8276,
       "id": "Any<id>",
@@ -4930,7 +4952,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 8295,
       "id": "Any<id>",
@@ -4939,7 +4961,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</small>",
+        "reason": "</small>",
       },
       "end": 8303,
       "id": "Any<id>",
@@ -4948,7 +4970,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 8654,
       "id": "Any<id>",
@@ -4957,7 +4979,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 8658,
       "id": "Any<id>",
@@ -4973,7 +4995,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 8661,
       "id": "Any<id>",
@@ -4989,7 +5011,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<small>",
+        "reason": "<small>",
       },
       "end": 8668,
       "id": "Any<id>",
@@ -5005,7 +5027,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</small>",
+        "reason": "</small>",
       },
       "end": 8685,
       "id": "Any<id>",
@@ -5014,7 +5036,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 8779,
       "id": "Any<id>",
@@ -5023,7 +5045,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 8783,
       "id": "Any<id>",
@@ -5032,7 +5054,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 8787,
       "id": "Any<id>",
@@ -5048,7 +5070,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 8790,
       "id": "Any<id>",
@@ -5064,7 +5086,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<small>",
+        "reason": "<small>",
       },
       "end": 8797,
       "id": "Any<id>",
@@ -5080,7 +5102,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</small>",
+        "reason": "</small>",
       },
       "end": 8821,
       "id": "Any<id>",
@@ -5089,7 +5111,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 8825,
       "id": "Any<id>",
@@ -5098,7 +5120,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 9213,
       "id": "Any<id>",
@@ -5107,7 +5129,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 9217,
       "id": "Any<id>",
@@ -5123,7 +5145,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 9220,
       "id": "Any<id>",
@@ -5139,7 +5161,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 9267,
       "id": "Any<id>",
@@ -5148,7 +5170,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 9271,
       "id": "Any<id>",
@@ -5157,7 +5179,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 9275,
       "id": "Any<id>",
@@ -5173,7 +5195,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 9573,
       "id": "Any<id>",
@@ -5182,7 +5204,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 9577,
       "id": "Any<id>",
@@ -5198,7 +5220,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 9580,
       "id": "Any<id>",
@@ -5214,7 +5236,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 9647,
       "id": "Any<id>",
@@ -5223,7 +5245,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 9651,
       "id": "Any<id>",
@@ -5232,7 +5254,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 9655,
       "id": "Any<id>",
@@ -5248,7 +5270,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 9881,
       "id": "Any<id>",
@@ -5257,7 +5279,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 9885,
       "id": "Any<id>",
@@ -5273,7 +5295,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 9888,
       "id": "Any<id>",
@@ -5289,7 +5311,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 9958,
       "id": "Any<id>",
@@ -5298,7 +5320,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 9962,
       "id": "Any<id>",
@@ -5307,7 +5329,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 9966,
       "id": "Any<id>",
@@ -5323,7 +5345,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 9993,
       "id": "Any<id>",
@@ -5332,7 +5354,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 9997,
       "id": "Any<id>",
@@ -5348,7 +5370,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 10000,
       "id": "Any<id>",
@@ -5364,7 +5386,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 10057,
       "id": "Any<id>",
@@ -5373,7 +5395,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 10061,
       "id": "Any<id>",
@@ -5382,7 +5404,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 10065,
       "id": "Any<id>",
@@ -5398,7 +5420,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 10145,
       "id": "Any<id>",
@@ -5407,7 +5429,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 10149,
       "id": "Any<id>",
@@ -5423,7 +5445,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 10152,
       "id": "Any<id>",
@@ -5439,7 +5461,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 10188,
       "id": "Any<id>",
@@ -5448,7 +5470,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 10192,
       "id": "Any<id>",
@@ -5457,7 +5479,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 10196,
       "id": "Any<id>",
@@ -5473,7 +5495,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 10320,
       "id": "Any<id>",
@@ -5482,7 +5504,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 10324,
       "id": "Any<id>",
@@ -5498,7 +5520,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 10327,
       "id": "Any<id>",
@@ -5514,7 +5536,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 10412,
       "id": "Any<id>",
@@ -5523,7 +5545,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 10416,
       "id": "Any<id>",
@@ -5532,7 +5554,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 10420,
       "id": "Any<id>",
@@ -5548,7 +5570,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<i>",
+        "reason": "<i>",
       },
       "end": 10467,
       "id": "Any<id>",
@@ -5564,7 +5586,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</i>",
+        "reason": "</i>",
       },
       "end": 10522,
       "id": "Any<id>",
@@ -5573,7 +5595,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 11071,
       "id": "Any<id>",
@@ -5582,7 +5604,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 11075,
       "id": "Any<id>",
@@ -5598,7 +5620,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 11078,
       "id": "Any<id>",
@@ -5614,7 +5636,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 11146,
       "id": "Any<id>",
@@ -5623,7 +5645,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 11150,
       "id": "Any<id>",
@@ -5632,7 +5654,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 11154,
       "id": "Any<id>",
@@ -5648,7 +5670,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 11427,
       "id": "Any<id>",
@@ -5657,7 +5679,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 11431,
       "id": "Any<id>",
@@ -5673,7 +5695,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 11434,
       "id": "Any<id>",
@@ -5689,7 +5711,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 11527,
       "id": "Any<id>",
@@ -5698,7 +5720,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 11531,
       "id": "Any<id>",
@@ -5707,7 +5729,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 11535,
       "id": "Any<id>",
@@ -5723,7 +5745,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 11546,
       "id": "Any<id>",
@@ -5732,7 +5754,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<h2>",
+        "reason": "<h2>",
       },
       "end": 11554,
       "id": "Any<id>",
@@ -5741,7 +5763,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-offset-level": 2,
+        "level": 2,
       },
       "end": 11570,
       "id": "Any<id>",
@@ -5750,7 +5772,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</h2>",
+        "reason": "</h2>",
       },
       "end": 11570,
       "id": "Any<id>",
@@ -5759,7 +5781,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 11575,
       "id": "Any<id>",
@@ -5775,7 +5797,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<i>",
+        "reason": "<i>",
       },
       "end": 11578,
       "id": "Any<id>",
@@ -5791,7 +5813,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</i>",
+        "reason": "</i>",
       },
       "end": 11608,
       "id": "Any<id>",
@@ -5800,7 +5822,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 11617,
       "id": "Any<id>",
@@ -5809,7 +5831,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 11621,
       "id": "Any<id>",
@@ -5825,7 +5847,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 11624,
       "id": "Any<id>",
@@ -5848,7 +5870,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<br/>",
+        "reason": "<br/>",
       },
       "end": 11642,
       "id": "Any<id>",
@@ -5857,7 +5879,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 11653,
       "id": "Any<id>",
@@ -5866,7 +5888,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 11657,
       "id": "Any<id>",
@@ -5875,7 +5897,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 11664,
       "id": "Any<id>",
@@ -5891,7 +5913,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 11667,
       "id": "Any<id>",
@@ -5907,7 +5929,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<small>",
+        "reason": "<small>",
       },
       "end": 11674,
       "id": "Any<id>",
@@ -5923,7 +5945,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</small>",
+        "reason": "</small>",
       },
       "end": 11709,
       "id": "Any<id>",
@@ -5932,7 +5954,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 11713,
       "id": "Any<id>",
@@ -5941,7 +5963,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 11995,
       "id": "Any<id>",
@@ -5950,7 +5972,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 11999,
       "id": "Any<id>",
@@ -5966,7 +5988,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 12002,
       "id": "Any<id>",
@@ -5982,7 +6004,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<small>",
+        "reason": "<small>",
       },
       "end": 12009,
       "id": "Any<id>",
@@ -5998,7 +6020,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</small>",
+        "reason": "</small>",
       },
       "end": 12026,
       "id": "Any<id>",
@@ -6007,7 +6029,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 12120,
       "id": "Any<id>",
@@ -6016,7 +6038,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 12124,
       "id": "Any<id>",
@@ -6025,7 +6047,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 12128,
       "id": "Any<id>",
@@ -6041,7 +6063,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<small>",
+        "reason": "<small>",
       },
       "end": 12135,
       "id": "Any<id>",
@@ -6057,7 +6079,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 12138,
       "id": "Any<id>",
@@ -6073,7 +6095,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 12154,
       "id": "Any<id>",
@@ -6082,7 +6104,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</small>",
+        "reason": "</small>",
       },
       "end": 12162,
       "id": "Any<id>",
@@ -6091,7 +6113,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 12331,
       "id": "Any<id>",
@@ -6100,7 +6122,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 12335,
       "id": "Any<id>",
@@ -6116,7 +6138,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 12338,
       "id": "Any<id>",
@@ -6132,7 +6154,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 12385,
       "id": "Any<id>",
@@ -6141,7 +6163,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 12389,
       "id": "Any<id>",
@@ -6150,7 +6172,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 12393,
       "id": "Any<id>",
@@ -6166,7 +6188,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 12579,
       "id": "Any<id>",
@@ -6175,7 +6197,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 12583,
       "id": "Any<id>",
@@ -6191,7 +6213,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 12586,
       "id": "Any<id>",
@@ -6207,7 +6229,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 12653,
       "id": "Any<id>",
@@ -6216,7 +6238,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 12657,
       "id": "Any<id>",
@@ -6225,7 +6247,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 12661,
       "id": "Any<id>",
@@ -6241,7 +6263,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 12737,
       "id": "Any<id>",
@@ -6250,7 +6272,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 12741,
       "id": "Any<id>",
@@ -6266,7 +6288,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 12744,
       "id": "Any<id>",
@@ -6282,7 +6304,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 12801,
       "id": "Any<id>",
@@ -6291,7 +6313,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 12805,
       "id": "Any<id>",
@@ -6300,7 +6322,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 12809,
       "id": "Any<id>",
@@ -6316,7 +6338,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 12885,
       "id": "Any<id>",
@@ -6325,7 +6347,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 12889,
       "id": "Any<id>",
@@ -6341,7 +6363,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 12892,
       "id": "Any<id>",
@@ -6357,7 +6379,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 12928,
       "id": "Any<id>",
@@ -6366,7 +6388,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 12932,
       "id": "Any<id>",
@@ -6375,7 +6397,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 12936,
       "id": "Any<id>",
@@ -6391,7 +6413,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 13028,
       "id": "Any<id>",
@@ -6400,7 +6422,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 13032,
       "id": "Any<id>",
@@ -6416,7 +6438,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 13035,
       "id": "Any<id>",
@@ -6432,7 +6454,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 13120,
       "id": "Any<id>",
@@ -6441,7 +6463,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 13124,
       "id": "Any<id>",
@@ -6450,7 +6472,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 13128,
       "id": "Any<id>",
@@ -6466,7 +6488,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 13515,
       "id": "Any<id>",
@@ -6475,7 +6497,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 13519,
       "id": "Any<id>",
@@ -6491,7 +6513,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 13522,
       "id": "Any<id>",
@@ -6507,7 +6529,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 13592,
       "id": "Any<id>",
@@ -6516,7 +6538,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 13596,
       "id": "Any<id>",
@@ -6525,7 +6547,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 13600,
       "id": "Any<id>",
@@ -6541,7 +6563,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 13657,
       "id": "Any<id>",
@@ -6550,7 +6572,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 13661,
       "id": "Any<id>",
@@ -6566,7 +6588,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 13664,
       "id": "Any<id>",
@@ -6582,7 +6604,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 13732,
       "id": "Any<id>",
@@ -6591,7 +6613,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 13736,
       "id": "Any<id>",
@@ -6600,7 +6622,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 13740,
       "id": "Any<id>",
@@ -6616,7 +6638,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 13754,
       "id": "Any<id>",
@@ -6625,7 +6647,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 13758,
       "id": "Any<id>",
@@ -6641,7 +6663,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 13761,
       "id": "Any<id>",
@@ -6657,7 +6679,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 13790,
       "id": "Any<id>",
@@ -6666,7 +6688,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 13794,
       "id": "Any<id>",
@@ -6675,7 +6697,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 13798,
       "id": "Any<id>",
@@ -6691,7 +6713,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 13917,
       "id": "Any<id>",
@@ -6700,7 +6722,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 13921,
       "id": "Any<id>",
@@ -6716,7 +6738,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<b>",
+        "reason": "<b>",
       },
       "end": 13924,
       "id": "Any<id>",
@@ -6732,7 +6754,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</b>",
+        "reason": "</b>",
       },
       "end": 14017,
       "id": "Any<id>",
@@ -6741,7 +6763,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 14021,
       "id": "Any<id>",
@@ -6750,7 +6772,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 14025,
       "id": "Any<id>",
@@ -6766,7 +6788,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 14058,
       "id": "Any<id>",
@@ -6775,7 +6797,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</body>",
+        "reason": "</body>",
       },
       "end": 14066,
       "id": "Any<id>",
@@ -6784,7 +6806,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</pam:article>",
+        "reason": "</pam:article>",
       },
       "end": 14081,
       "id": "Any<id>",
@@ -6793,7 +6815,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</pam:message>",
+        "reason": "</pam:message>",
       },
       "end": 14096,
       "id": "Any<id>",
@@ -6967,12 +6989,23 @@ Object {
     Object {
       "attributes": Object {
         "xmlns": "http://www.w3.org/1999/xhtml",
+        "xmlns:dc": "http://purl.org/dc/elements/1.1/",
+        "xmlns:dcterms": "http://purl.org/dc/terms/",
+        "xmlns:pam": "http://prismstandard.org/namespaces/pam/2.0/",
+        "xmlns:pim": "http://prismstandard.org/namespaces/pim/2.0/",
+        "xmlns:prism": "http://prismstandard.org/namespaces/basic/2.0/",
+        "xmlns:prl": "http://prismstandard.org/namespaces/prl/2.0/",
+        "xmlns:xhtml": "http://www.w3.org/1999/xhtml",
+        "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "xsi:schemalocation": "http://prismstandard.org/namespaces/pam/2.0/ pam.xsd",
       },
       "children": Array [
         "
 ",
         Object {
-          "attributes": Object {},
+          "attributes": Object {
+            "xml:lang": "en-US",
+          },
           "children": Array [
             "
 ",
@@ -7626,7 +7659,7 @@ Object {
   "annotations": Array [
     Object {
       "attributes": Object {
-        "-atjson-reason": "<?xml>",
+        "reason": "<?xml>",
       },
       "end": 38,
       "id": "Any<id>",
@@ -7635,7 +7668,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<pam:message>",
+        "reason": "<pam:message>",
       },
       "end": 578,
       "id": "Any<id>",
@@ -7644,7 +7677,16 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-pam-xmlns": "http://www.w3.org/1999/xhtml",
+        "xmlns": "http://www.w3.org/1999/xhtml",
+        "xmlns:dc": "http://purl.org/dc/elements/1.1/",
+        "xmlns:dcterms": "http://purl.org/dc/terms/",
+        "xmlns:pam": "http://prismstandard.org/namespaces/pam/2.0/",
+        "xmlns:pim": "http://prismstandard.org/namespaces/pim/2.0/",
+        "xmlns:prism": "http://prismstandard.org/namespaces/basic/2.0/",
+        "xmlns:prl": "http://prismstandard.org/namespaces/prl/2.0/",
+        "xmlns:xhtml": "http://www.w3.org/1999/xhtml",
+        "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "xsi:schemalocation": "http://prismstandard.org/namespaces/pam/2.0/ pam.xsd",
       },
       "end": 5143,
       "id": "Any<id>",
@@ -7653,7 +7695,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<pam:article>",
+        "reason": "<pam:article>",
       },
       "end": 609,
       "id": "Any<id>",
@@ -7661,7 +7703,9 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
+      "attributes": Object {
+        "xml:lang": "en-US",
+      },
       "end": 5128,
       "id": "Any<id>",
       "start": 579,
@@ -7669,7 +7713,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<body>",
+        "reason": "<body>",
       },
       "end": 617,
       "id": "Any<id>",
@@ -7685,7 +7729,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<h1>",
+        "reason": "<h1>",
       },
       "end": 622,
       "id": "Any<id>",
@@ -7694,7 +7738,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-offset-level": 1,
+        "level": 1,
       },
       "end": 634,
       "id": "Any<id>",
@@ -7703,7 +7747,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</h1>",
+        "reason": "</h1>",
       },
       "end": 634,
       "id": "Any<id>",
@@ -7712,7 +7756,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 653,
       "id": "Any<id>",
@@ -7721,7 +7765,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-html-class": "byline",
+        "class": "byline",
       },
       "end": 666,
       "id": "Any<id>",
@@ -7730,7 +7774,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 666,
       "id": "Any<id>",
@@ -7739,7 +7783,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 683,
       "id": "Any<id>",
@@ -7748,7 +7792,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-html-class": "deck",
+        "class": "deck",
       },
       "end": 725,
       "id": "Any<id>",
@@ -7757,7 +7801,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 725,
       "id": "Any<id>",
@@ -7766,7 +7810,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 735,
       "id": "Any<id>",
@@ -7782,7 +7826,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<i>",
+        "reason": "<i>",
       },
       "end": 813,
       "id": "Any<id>",
@@ -7798,7 +7842,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</i>",
+        "reason": "</i>",
       },
       "end": 834,
       "id": "Any<id>",
@@ -7807,7 +7851,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 1481,
       "id": "Any<id>",
@@ -7816,7 +7860,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 1485,
       "id": "Any<id>",
@@ -7832,7 +7876,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2092,
       "id": "Any<id>",
@@ -7841,7 +7885,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2096,
       "id": "Any<id>",
@@ -7857,7 +7901,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2826,
       "id": "Any<id>",
@@ -7866,7 +7910,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2830,
       "id": "Any<id>",
@@ -7882,7 +7926,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 3339,
       "id": "Any<id>",
@@ -7891,7 +7935,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 3343,
       "id": "Any<id>",
@@ -7907,7 +7951,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 3906,
       "id": "Any<id>",
@@ -7916,7 +7960,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 3910,
       "id": "Any<id>",
@@ -7932,7 +7976,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 4399,
       "id": "Any<id>",
@@ -7941,7 +7985,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 4403,
       "id": "Any<id>",
@@ -7957,7 +8001,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 5105,
       "id": "Any<id>",
@@ -7966,7 +8010,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</body>",
+        "reason": "</body>",
       },
       "end": 5113,
       "id": "Any<id>",
@@ -7975,7 +8019,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</pam:article>",
+        "reason": "</pam:article>",
       },
       "end": 5128,
       "id": "Any<id>",
@@ -7984,7 +8028,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</pam:message>",
+        "reason": "</pam:message>",
       },
       "end": 5143,
       "id": "Any<id>",
@@ -8061,12 +8105,23 @@ Object {
     Object {
       "attributes": Object {
         "xmlns": "http://www.w3.org/1999/xhtml",
+        "xmlns:dc": "http://purl.org/dc/elements/1.1/",
+        "xmlns:dcterms": "http://purl.org/dc/terms/",
+        "xmlns:pam": "http://prismstandard.org/namespaces/pam/2.0/",
+        "xmlns:pim": "http://prismstandard.org/namespaces/pim/2.0/",
+        "xmlns:prism": "http://prismstandard.org/namespaces/basic/2.0/",
+        "xmlns:prl": "http://prismstandard.org/namespaces/prl/2.0/",
+        "xmlns:xhtml": "http://www.w3.org/1999/xhtml",
+        "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "xsi:schemalocation": "http://prismstandard.org/namespaces/pam/2.0/ pam.xsd",
       },
       "children": Array [
         "
 ",
         Object {
-          "attributes": Object {},
+          "attributes": Object {
+            "xml:lang": "en-US",
+          },
           "children": Array [
             "
 ",
@@ -8665,7 +8720,7 @@ Object {
   "annotations": Array [
     Object {
       "attributes": Object {
-        "-atjson-reason": "<?xml>",
+        "reason": "<?xml>",
       },
       "end": 38,
       "id": "Any<id>",
@@ -8674,7 +8729,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<pam:message>",
+        "reason": "<pam:message>",
       },
       "end": 578,
       "id": "Any<id>",
@@ -8683,7 +8738,16 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-pam-xmlns": "http://www.w3.org/1999/xhtml",
+        "xmlns": "http://www.w3.org/1999/xhtml",
+        "xmlns:dc": "http://purl.org/dc/elements/1.1/",
+        "xmlns:dcterms": "http://purl.org/dc/terms/",
+        "xmlns:pam": "http://prismstandard.org/namespaces/pam/2.0/",
+        "xmlns:pim": "http://prismstandard.org/namespaces/pim/2.0/",
+        "xmlns:prism": "http://prismstandard.org/namespaces/basic/2.0/",
+        "xmlns:prl": "http://prismstandard.org/namespaces/prl/2.0/",
+        "xmlns:xhtml": "http://www.w3.org/1999/xhtml",
+        "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "xsi:schemalocation": "http://prismstandard.org/namespaces/pam/2.0/ pam.xsd",
       },
       "end": 4011,
       "id": "Any<id>",
@@ -8692,7 +8756,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<pam:article>",
+        "reason": "<pam:article>",
       },
       "end": 609,
       "id": "Any<id>",
@@ -8700,7 +8764,9 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
+      "attributes": Object {
+        "xml:lang": "en-US",
+      },
       "end": 3996,
       "id": "Any<id>",
       "start": 579,
@@ -8708,7 +8774,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<body>",
+        "reason": "<body>",
       },
       "end": 617,
       "id": "Any<id>",
@@ -8724,7 +8790,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<h1>",
+        "reason": "<h1>",
       },
       "end": 622,
       "id": "Any<id>",
@@ -8733,7 +8799,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-offset-level": 1,
+        "level": 1,
       },
       "end": 634,
       "id": "Any<id>",
@@ -8742,7 +8808,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</h1>",
+        "reason": "</h1>",
       },
       "end": 634,
       "id": "Any<id>",
@@ -8751,7 +8817,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 653,
       "id": "Any<id>",
@@ -8760,7 +8826,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-html-class": "byline",
+        "class": "byline",
       },
       "end": 665,
       "id": "Any<id>",
@@ -8769,7 +8835,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 665,
       "id": "Any<id>",
@@ -8778,7 +8844,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 682,
       "id": "Any<id>",
@@ -8787,7 +8853,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-html-class": "deck",
+        "class": "deck",
       },
       "end": 753,
       "id": "Any<id>",
@@ -8796,7 +8862,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 753,
       "id": "Any<id>",
@@ -8805,7 +8871,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 760,
       "id": "Any<id>",
@@ -8821,7 +8887,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 1697,
       "id": "Any<id>",
@@ -8830,7 +8896,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 1701,
       "id": "Any<id>",
@@ -8846,7 +8912,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 2475,
       "id": "Any<id>",
@@ -8855,7 +8921,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 2479,
       "id": "Any<id>",
@@ -8871,7 +8937,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 3165,
       "id": "Any<id>",
@@ -8880,7 +8946,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
+        "reason": "<p>",
       },
       "end": 3169,
       "id": "Any<id>",
@@ -8896,7 +8962,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</p>",
+        "reason": "</p>",
       },
       "end": 3970,
       "id": "Any<id>",
@@ -8905,7 +8971,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</body>",
+        "reason": "</body>",
       },
       "end": 3981,
       "id": "Any<id>",
@@ -8914,7 +8980,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</pam:article>",
+        "reason": "</pam:article>",
       },
       "end": 3996,
       "id": "Any<id>",
@@ -8923,7 +8989,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "</pam:message>",
+        "reason": "</pam:message>",
       },
       "end": 4011,
       "id": "Any<id>",

--- a/packages/@atjson/source-prism/test/prism-test.ts
+++ b/packages/@atjson/source-prism/test/prism-test.ts
@@ -14,7 +14,7 @@ describe("@atjson/source-prism", () => {
         start: 0,
         end: doc.content.length,
         attributes: {
-          "-atjson-reason": "<?xml>"
+          reason: "<?xml>"
         }
       }
     ]);
@@ -33,14 +33,14 @@ describe("@atjson/source-prism", () => {
         type: "-atjson-parse-token",
         start: 0,
         end: 6,
-        attributes: { "-atjson-reason": "<body>" }
+        attributes: { reason: "<body>" }
       },
       { type: "-html-body", start: 0, end: 22 },
       {
         type: "-atjson-parse-token",
         start: 15,
         end: 22,
-        attributes: { "-atjson-reason": "</body>" }
+        attributes: { reason: "</body>" }
       }
     ]);
   });
@@ -75,20 +75,20 @@ describe("@atjson/source-prism", () => {
         type: "-atjson-parse-token",
         start: 0,
         end: 38,
-        attributes: { "-atjson-reason": "<?xml>" }
+        attributes: { reason: "<?xml>" }
       },
       {
         type: "-atjson-parse-token",
         start: 38,
         end: 51,
-        attributes: { "-atjson-reason": "<pam:message>" }
+        attributes: { reason: "<pam:message>" }
       },
       { type: "-pam-message", start: 38, end: 117 },
       {
         type: "-atjson-parse-token",
         start: 51,
         end: 64,
-        attributes: { "-atjson-reason": "<pam:article>" }
+        attributes: { reason: "<pam:article>" }
       },
       { type: "-pam-article", start: 51, end: 103 },
       { type: "-html-head", start: 64, end: 72 },
@@ -96,32 +96,32 @@ describe("@atjson/source-prism", () => {
         type: "-atjson-parse-token",
         start: 64,
         end: 72,
-        attributes: { "-atjson-reason": "<head/>" }
+        attributes: { reason: "<head/>" }
       },
       {
         type: "-atjson-parse-token",
         start: 72,
         end: 78,
-        attributes: { "-atjson-reason": "<body>" }
+        attributes: { reason: "<body>" }
       },
       { type: "-html-body", start: 72, end: 89 },
       {
         type: "-atjson-parse-token",
         start: 82,
         end: 89,
-        attributes: { "-atjson-reason": "</body>" }
+        attributes: { reason: "</body>" }
       },
       {
         type: "-atjson-parse-token",
         start: 89,
         end: 103,
-        attributes: { "-atjson-reason": "</pam:article>" }
+        attributes: { reason: "</pam:article>" }
       },
       {
         type: "-atjson-parse-token",
         start: 103,
         end: 117,
-        attributes: { "-atjson-reason": "</pam:message>" }
+        attributes: { reason: "</pam:message>" }
       }
     ]);
   });
@@ -164,66 +164,66 @@ describe("@atjson/source-prism", () => {
           type: "-atjson-parse-token",
           start: 0,
           end: 13,
-          attributes: { "-atjson-reason": "<pam:article>" }
+          attributes: { reason: "<pam:article>" }
         },
         { type: "-pam-article", start: 0, end: 97 },
         {
           type: "-atjson-parse-token",
           start: 13,
           end: 19,
-          attributes: { "-atjson-reason": "<head>" }
+          attributes: { reason: "<head>" }
         },
         { type: "-html-head", start: 13, end: 52 },
         {
           type: "-atjson-parse-token",
           start: 19,
           end: 29,
-          attributes: { "-atjson-reason": "<dc:title>" }
+          attributes: { reason: "<dc:title>" }
         },
         { type: "-dc-title", start: 19, end: 45 },
         {
           type: "-atjson-parse-token",
           start: 34,
           end: 45,
-          attributes: { "-atjson-reason": "</dc:title>" }
+          attributes: { reason: "</dc:title>" }
         },
         {
           type: "-atjson-parse-token",
           start: 45,
           end: 52,
-          attributes: { "-atjson-reason": "</head>" }
+          attributes: { reason: "</head>" }
         },
         {
           type: "-atjson-parse-token",
           start: 52,
           end: 58,
-          attributes: { "-atjson-reason": "<body>" }
+          attributes: { reason: "<body>" }
         },
         { type: "-html-body", start: 52, end: 83 },
         {
           type: "-atjson-parse-token",
           start: 58,
           end: 61,
-          attributes: { "-atjson-reason": "<p>" }
+          attributes: { reason: "<p>" }
         },
         { type: "-html-p", start: 58, end: 76 },
         {
           type: "-atjson-parse-token",
           start: 72,
           end: 76,
-          attributes: { "-atjson-reason": "</p>" }
+          attributes: { reason: "</p>" }
         },
         {
           type: "-atjson-parse-token",
           start: 76,
           end: 83,
-          attributes: { "-atjson-reason": "</body>" }
+          attributes: { reason: "</body>" }
         },
         {
           type: "-atjson-parse-token",
           start: 83,
           end: 97,
-          attributes: { "-atjson-reason": "</pam:article>" }
+          attributes: { reason: "</pam:article>" }
         }
       ]);
     });


### PR DESCRIPTION
1. not doing work is faster than doing work
2. prefixing attributes was likely causing V8 to not optimize memory layout and execution of annotation queries and fromRaw— by not changing the object shape of the annotation, all annotation attributes get optimized using the same C struct that V8 internally creates

Here's the metrics from the renderer-commonmark performance benchmark with this branch:

The metrics below are taken from the CommonMark specification tests. These are _not_ realistic examples of what you'd find out in the world, but it is a fairly large dataset that runs the code through its paces.

This benchmark was taken on Linux 4.15 on x64 with 2 cores of Intel(R) Xeon(R) CPU.

| Function | Mean | Median | 95th Percentile | Maximum | Standard Deviation |
|----------|------|--------|-----------------|---------|--------------------|
| CommonMarkSource.fromRaw | 0.428ms | 0.367ms | 0.545ms | 14.818923ms | 0.319ms |
| CommonMarkSource.convertTo(OffsetSource) | 0.243ms | 0.196ms | 0.458ms | 22.444555ms | 0.269ms |
| CommonMarkRenderer.render | 0.100ms | 0.084ms | 0.187ms | 4.10044ms | 0.101ms |
| Round trip | 0.817ms | 0.698ms | 1.465ms | 24.706735ms | 0.476ms |

## 🔥 Slow real-life examples

The metrics below are taken from real articles written by Condé Nast editors / writers.
This benchmark was taken on Linux 4.15 on x64 with 2 cores of Intel(R) Xeon(R) CPU.

| Function | Mean | Median | 95th Percentile | Maximum | Standard Deviation |
|----------|------|--------|-----------------|---------|--------------------|
| CommonMarkSource.fromRaw | 12.742ms | 13.337ms | 15.762ms | 25.900293ms | 3.799ms |
| CommonMarkSource.convertTo(OffsetSource) | 38.657ms | 42.174ms | 49.977ms | 50.949202ms | 9.052ms |
| CommonMarkRenderer.render | 36.580ms | 21.329ms | 70.949ms | 78.194161ms | 24.157ms |
| Round trip | 88.133ms | 78.118ms | 133.263ms | 146.801923ms | 34.253ms |

You can compare the results of this to [this file](https://github.com/CondeNast/atjson/blob/latest/packages/%40atjson/renderer-commonmark/performance/README.md)