### PR TITLE
remove call to `where` and add bulk annotation deletion

### DIFF
--- a/packages/@atjson/document/src/collection.ts
+++ b/packages/@atjson/document/src/collection.ts
@@ -257,12 +257,8 @@ export default class AnnotationCollection extends Collection {
   }
 
   remove() {
-    return this.update(annotation => {
-      this.document.removeAnnotation(annotation);
-      return {
-        remove: [annotation]
-      };
-    });
+    this.document.removeAnnotations(this.annotations);
+    this.annotations = [];
   }
 }
 

--- a/packages/@atjson/document/src/collection.ts
+++ b/packages/@atjson/document/src/collection.ts
@@ -1,8 +1,7 @@
 import Document, {
   Annotation,
   AnnotationJSON,
-  AnnotationConstructor,
-  UnknownAnnotation
+  AnnotationConstructor
 } from "./index";
 import Join from "./join";
 

--- a/packages/@atjson/document/src/collection.ts
+++ b/packages/@atjson/document/src/collection.ts
@@ -97,7 +97,9 @@ export class Collection {
         let vendorPrefix = annotationClass.vendorPrefix;
         if (
           filter.type === `-${vendorPrefix}-${a.type}` ||
-          (a instanceof UnknownAnnotation && a.attributes.type === filter.type)
+          (a.type === "unknown" &&
+            vendorPrefix === "atjson" &&
+            a.attributes.type === filter.type)
         ) {
           annotations.push(a);
         }

--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -294,6 +294,7 @@ export default class Document {
     }
 
     this.annotations = keptAnnotations;
+    this.triggerChange();
   }
 
   replaceAnnotation(

--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -274,6 +274,28 @@ export default class Document {
     }
   }
 
+  removeAnnotations(annotations: Array<Annotation<any>>) {
+    if (annotations.length < 10) {
+      for (let annotation of annotations) {
+        this.removeAnnotation(annotation);
+      }
+    }
+
+    let sortedAnnotationsToRemove = annotations.sort(compareAnnotations);
+    let docAnnotations = this.annotations.sort(compareAnnotations);
+
+    let keptAnnotations = [];
+    for (let annotation of docAnnotations) {
+      if (annotation === sortedAnnotationsToRemove[0]) {
+        sortedAnnotationsToRemove.shift();
+      } else {
+        keptAnnotations.push(annotation);
+      }
+    }
+
+    this.annotations = keptAnnotations;
+  }
+
   replaceAnnotation(
     annotation: Annotation<any>,
     ...newAnnotations: Array<AnnotationJSON | Annotation<any>>
@@ -615,13 +637,16 @@ export default class Document {
 
   canonical() {
     let canonicalDoc = this.clone();
-    let ranges: Array<{ start: number; end: number }> = [];
+    let parseTokensToDelete: Array<Annotation> = [];
 
-    canonicalDoc.where({ type: "-atjson-parse-token" }).update(a => {
-      ranges.push({ start: a.start, end: a.end });
-    });
-    canonicalDoc.deleteTextRanges(ranges);
-    canonicalDoc.where({ type: "-atjson-parse-token" }).remove();
+    for (let annotation of canonicalDoc.annotations) {
+      if (annotation instanceof ParseAnnotation) {
+        parseTokensToDelete.push(annotation);
+      }
+    }
+
+    canonicalDoc.removeAnnotations(parseTokensToDelete);
+    canonicalDoc.deleteTextRanges(parseTokensToDelete);
 
     canonicalDoc.annotations.sort(compareAnnotations);
 

--- a/packages/@atjson/document/test/document-test.ts
+++ b/packages/@atjson/document/test/document-test.ts
@@ -75,6 +75,42 @@ describe("Document#deleteTextRanges", () => {
   });
 });
 
+describe("Document#removeAnnotations", () => {
+  test("removes annotations", () => {
+    let parseAnnotations = [
+      new ParseAnnotation({ start: 3, end: 4 }),
+      new ParseAnnotation({ start: 17, end: 18 }),
+      new ParseAnnotation({ start: 11, end: 12 }),
+      new ParseAnnotation({ start: 15, end: 16 }),
+      new ParseAnnotation({ start: 7, end: 8 }),
+      new ParseAnnotation({ start: 1, end: 2 }),
+      new ParseAnnotation({ start: 21, end: 22 }),
+      new ParseAnnotation({ start: 23, end: 24 }),
+      new ParseAnnotation({ start: 19, end: 20 }),
+      new ParseAnnotation({ start: 13, end: 14 }),
+      new ParseAnnotation({ start: 5, end: 6 }),
+      new ParseAnnotation({ start: 9, end: 10 })
+    ];
+    let testDoc = new TestSource({
+      content: "a b c d e f g h i j k l m n o p q r s t u v w x y z",
+      annotations: [
+        ...parseAnnotations,
+        new Paragraph({ start: 0, end: 13 }),
+        new Bold({ start: 0, end: 12 })
+      ]
+    });
+
+    testDoc.removeAnnotations(parseAnnotations);
+
+    expect(testDoc).toMatchObject({
+      annotations: [
+        { type: "bold", start: 0, end: 12 },
+        { type: "paragraph", start: 0, end: 13 }
+      ]
+    });
+  });
+});
+
 describe("Document#canonical", () => {
   test("parse tokens are properly removed", () => {
     let testDoc = new TestSource({

--- a/performance/document-canonical-perf.js
+++ b/performance/document-canonical-perf.js
@@ -439,9 +439,11 @@ let document = CommonMarkSource.fromRaw(longDocumentFixture);
 
 document._old_canonical = function() {
   let canonicalDoc = this.clone();
+  let ranges = [];
   canonicalDoc.where({ type: "-atjson-parse-token" }).update(a => {
-    canonicalDoc.deleteText(a.start, a.end);
+    ranges.push({ start: a.start, end: a.end });
   });
+  canonicalDoc.deleteTextRanges(ranges);
   canonicalDoc.where({ type: "-atjson-parse-token" }).remove();
 
   canonicalDoc.annotations.sort(compareAnnotations);
@@ -449,12 +451,17 @@ document._old_canonical = function() {
   return canonicalDoc;
 };
 
-tests.add("old Document#canonical", function() {
+tests.add("warmup", function() {
+  document.canonical();
   document._old_canonical();
 });
 
 tests.add("alt Document#canonical", function() {
   document.canonical();
+});
+
+tests.add("old Document#canonical", function() {
+  document._old_canonical();
 });
 
 tests.run({ async: true });


### PR DESCRIPTION
This should further improve the performance of `canonical`, including in some cases that weren't particularly affected by the previous change