### PR TITLE
🐝 fix cases where a full HTML document is passed to source-html

### DIFF
--- a/packages/@atjson/source-html/test/source-html-test.ts
+++ b/packages/@atjson/source-html/test/source-html-test.ts
@@ -332,4 +332,68 @@ describe("@atjson/source-html", () => {
       ]
     });
   });
+
+  test('<!DOCTYPE html><html lang="en"><body>Hello</body></html>', () => {
+    let doc = HTMLSource.fromRaw(
+      '<!DOCTYPE html><html lang="en"><body>Hello</body></html>'
+    );
+
+    expect([...doc.where({ type: "-html-body" })]).toMatchObject([
+      {
+        start: 31,
+        end: 49
+      }
+    ]);
+    expect(doc.content).toEqual(
+      '<!DOCTYPE html><html lang="en"><body>Hello</body></html>'
+    );
+
+    let canonical = doc.canonical();
+    expect(canonical.content).toEqual("Hello");
+    expect(canonical.annotations).toMatchObject([
+      {
+        type: "body",
+        start: 0,
+        end: 5
+      },
+      {
+        type: "html",
+        start: 0,
+        end: 5,
+        attributes: {
+          lang: "en"
+        }
+      }
+    ]);
+  });
+
+  test('<html lang="en"><body>Hello</body></html>', () => {
+    let doc = HTMLSource.fromRaw('<html lang="en"><body>Hello</body></html>');
+
+    expect([...doc.where({ type: "-html-body" })]).toMatchObject([
+      {
+        start: 16,
+        end: 34
+      }
+    ]);
+    expect(doc.content).toEqual('<html lang="en"><body>Hello</body></html>');
+
+    let canonical = doc.canonical();
+    expect(canonical.content).toEqual("Hello");
+    expect(canonical.annotations).toMatchObject([
+      {
+        type: "body",
+        start: 0,
+        end: 5
+      },
+      {
+        type: "html",
+        start: 0,
+        end: 5,
+        attributes: {
+          lang: "en"
+        }
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
This changes the code path for source-html by always going through a full HTML document parse, resulting in quirks-mode for document fragments. The change shouldn't change any behavior, but it allows atjson to ingest full HTML pages.