### PR TITLE
Hotfix/paste issues

### DIFF
--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -22,6 +22,7 @@ import {
   ENDING_WHITESPACE_PUNCTUATION,
   LEADING_MD_SPACES,
   TRAILING_MD_SPACES,
+  UNMATCHED_TRAILING_ESCAPE_SEQUENCES,
   WHITESPACE_PUNCTUATION
 } from "./lib/punctuation";
 export * from "./lib/punctuation";
@@ -78,6 +79,7 @@ function getPreviousChar(doc: Document, end: number) {
 
   for (let a of doc.annotations) {
     if (isCoveredNonParseAnnotation(a)) {
+      console.log("hit!", a);
       return "";
     }
   }
@@ -110,6 +112,7 @@ function getNextChar(doc: Document, start: number) {
 
   for (let a of doc.annotations) {
     if (isCoveredNonParseAnnotation(a)) {
+      console.log("hit!", a);
       return "";
     }
   }
@@ -158,6 +161,12 @@ export function* splitDelimiterRuns(
     if (match[2]) {
       end -= match[2].length;
     } else if (match[3]) {
+      // never include single backslash as last character as this would escape
+      // the delimiter
+      if (match[3].match(UNMATCHED_TRAILING_ESCAPE_SEQUENCES)) {
+        end -= 1;
+        break;
+      }
       let nextChar = getNextChar(context.document, annotation.end);
       if (
         end === text.length &&

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -79,7 +79,6 @@ function getPreviousChar(doc: Document, end: number) {
 
   for (let a of doc.annotations) {
     if (isCoveredNonParseAnnotation(a)) {
-      console.log("hit!", a);
       return "";
     }
   }
@@ -112,7 +111,6 @@ function getNextChar(doc: Document, start: number) {
 
   for (let a of doc.annotations) {
     if (isCoveredNonParseAnnotation(a)) {
-      console.log("hit!", a);
       return "";
     }
   }

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -156,12 +156,12 @@ export function* splitDelimiterRuns(
   while (end > start) {
     match = text.slice(0, end).match(ENDING_WHITESPACE_PUNCTUATION);
     if (!match) break;
-    if (match[2]) {
-      end -= match[2].length;
-    } else if (match[3]) {
+    if (match[4]) {
+      end -= match[4].length;
+    } else if (match[5]) {
       // never include single backslash as last character as this would escape
       // the delimiter
-      if (match[3].match(UNMATCHED_TRAILING_ESCAPE_SEQUENCES)) {
+      if (match[5].match(UNMATCHED_TRAILING_ESCAPE_SEQUENCES)) {
         end -= 1;
         break;
       }
@@ -171,7 +171,7 @@ export function* splitDelimiterRuns(
         nextChar &&
         !nextChar.match(WHITESPACE_PUNCTUATION)
       ) {
-        end -= match[3].length;
+        end -= match[5].length;
       } else {
         break;
       }

--- a/packages/@atjson/renderer-commonmark/src/lib/punctuation.ts
+++ b/packages/@atjson/renderer-commonmark/src/lib/punctuation.ts
@@ -67,3 +67,5 @@ export const ENDING_WHITESPACE = /(\s|&nbsp;){1}$/;
 export const MD_SPACES = /[ \f\n\r\t\v\u00a0]+/;
 export const LEADING_MD_SPACES = new RegExp(`^${MD_SPACES.source}`, "g");
 export const TRAILING_MD_SPACES = new RegExp(`${MD_SPACES.source}$`, "g");
+
+export const UNMATCHED_TRAILING_ESCAPE_SEQUENCES = /(\\\\)*\\$/;

--- a/packages/@atjson/renderer-commonmark/src/lib/punctuation.ts
+++ b/packages/@atjson/renderer-commonmark/src/lib/punctuation.ts
@@ -53,13 +53,13 @@ export const MD_PUNCTUATION = new RegExp(
 
 // Whitespace or (possibly escaped) Ascii punctuation or Unicode punctuation
 export const WHITESPACE_PUNCTUATION = new RegExp(
-  `((\\s|&nbsp;){1}|(\\\\?${MD_PUNCTUATION.source}))`
+  `((\\\\\\n|\\s|&nbsp;){1}|(\\\\?${MD_PUNCTUATION.source}))`
 );
 export const BEGINNING_WHITESPACE_PUNCTUATION = new RegExp(
   `^${WHITESPACE_PUNCTUATION.source}`
 );
 export const ENDING_WHITESPACE_PUNCTUATION = new RegExp(
-  `${WHITESPACE_PUNCTUATION.source}$`
+  `(^|[^\\\\])(\\\\\\\\)*${WHITESPACE_PUNCTUATION.source}$`
 );
 export const BEGINNING_WHITESPACE = /^(\s|&nbsp;){1}/;
 export const ENDING_WHITESPACE = /(\s|&nbsp;){1}$/;
@@ -68,4 +68,4 @@ export const MD_SPACES = /[ \f\n\r\t\v\u00a0]+/;
 export const LEADING_MD_SPACES = new RegExp(`^${MD_SPACES.source}`, "g");
 export const TRAILING_MD_SPACES = new RegExp(`${MD_SPACES.source}$`, "g");
 
-export const UNMATCHED_TRAILING_ESCAPE_SEQUENCES = /(\\\\)*\\$/;
+export const UNMATCHED_TRAILING_ESCAPE_SEQUENCES = /^(\\\\)*\\$/;

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -762,6 +762,60 @@ After all the lists
         );
       });
 
+      test("delimiters with newline in the inner boundary", () => {
+        let document = new OffsetSource({
+          content: "bold\na",
+          annotations: [
+            {
+              type: "-offset-bold",
+              start: 0,
+              end: 5,
+              attributes: {}
+            },
+            {
+              type: "-atjson-parse-token",
+              start: 4,
+              end: 5,
+              attributes: {}
+            },
+            {
+              type: "-offset-line-break",
+              start: 4,
+              end: 5,
+              attributes: {}
+            }
+          ]
+        });
+        expect(CommonmarkRenderer.render(document)).toBe("**bold**\\\na");
+      });
+
+      test.only("delimiters with backslash in the inner boundary", () => {
+        let document = new OffsetSource({
+          content: "bold\\\na",
+          annotations: [
+            {
+              type: "-offset-bold",
+              start: 0,
+              end: 6,
+              attributes: {}
+            },
+            {
+              type: "-atjson-parse-token",
+              start: 5,
+              end: 6,
+              attributes: {}
+            },
+            {
+              type: "-offset-line-break",
+              start: 5,
+              end: 6,
+              attributes: {}
+            }
+          ]
+        });
+        expect(CommonmarkRenderer.render(document)).toBe("**bold\\\\**\\\na");
+      });
+
       // *[menu.as](https://menu.as/)*\n\n\n\n__Missoni Partners with Donghia__\n\n
       test("delimiters wrapping links are not parsed as punctuation at paragraph boundaries", () => {
         let md =

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -816,6 +816,21 @@ After all the lists
         expect(CommonmarkRenderer.render(document)).toBe("**bold\\\\**\\\na");
       });
 
+      test("delimiters with multiple backslash and newline in the inner boundary", () => {
+        let document = new OffsetSource({
+          content: "bold\\\\\na",
+          annotations: [
+            {
+              type: "-offset-bold",
+              start: 0,
+              end: 7,
+              attributes: {}
+            }
+          ]
+        });
+        expect(CommonmarkRenderer.render(document)).toBe("**bold\\\\\\\\**\na");
+      });
+
       // *[menu.as](https://menu.as/)*\n\n\n\n__Missoni Partners with Donghia__\n\n
       test("delimiters wrapping links are not parsed as punctuation at paragraph boundaries", () => {
         let md =

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -789,7 +789,7 @@ After all the lists
         expect(CommonmarkRenderer.render(document)).toBe("**bold**\\\na");
       });
 
-      test.only("delimiters with backslash in the inner boundary", () => {
+      test("delimiters with backslash in the inner boundary", () => {
         let document = new OffsetSource({
           content: "bold\\\na",
           annotations: [

--- a/packages/@atjson/source-gdocs-paste/test/converter-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/converter-test.ts
@@ -302,3 +302,48 @@ describe("@atjson/source-gdocs-paste paragraphs", () => {
     expect(listItems.toJSON()).toMatchObject(LIST_ITEMS);
   });
 });
+
+describe("@atjson/source-gdocs-paste", () => {
+  let atjson: OffsetSource;
+
+  const LINEBREAKS = [
+    [4, 5],
+    [6, 7],
+    [11, 12],
+    [13, 14],
+    [18, 19]
+  ].map(([start, end]) => {
+    return {
+      start,
+      end,
+      type: "-offset-line-break",
+      attributes: {}
+    };
+  });
+
+  beforeAll(() => {
+    // https://docs.google.com/document/d/e/2PACX-1vSty31WXqvhSHwPxJD1QpWdeW7RbZhqJUFW8DVLbxVj9BacHVQdlKoBt0NWCAKBgqXHFgbZJdBfoyUP/pub
+    let fixturePath = path.join(__dirname, "fixtures", "line-breaks.json");
+    let rawJSON = JSON.parse(fs.readFileSync(fixturePath).toString());
+    let gdocs = GDocsSource.fromRaw(rawJSON);
+    atjson = gdocs.convertTo(OffsetSource);
+  });
+
+  it("has correct line breaks", () => {
+    let linebreaks = atjson.where({ type: "-offset-line-break" });
+    expect(linebreaks.toJSON()).toMatchObject(LINEBREAKS);
+  });
+
+  it("has correct parse tokens", () => {
+    let parseTokens = atjson.where({ type: "-atjson-parse-token" });
+    expect(parseTokens.toJSON()).toMatchObject(
+      LINEBREAKS.map(linebreak => ({
+        ...linebreak,
+        type: "-atjson-parse-token",
+        attributes: {
+          "-atjson-reason": "new line"
+        }
+      }))
+    );
+  });
+});

--- a/packages/@atjson/source-gdocs-paste/test/fixtures/line-breaks.json
+++ b/packages/@atjson/source-gdocs-paste/test/fixtures/line-breaks.json
@@ -1,0 +1,833 @@
+{
+  "resolved": {
+    "dsl_spacers": "Test\na\nTest\n \nTest\n",
+    "dsl_styleslices": [
+      {
+        "stsl_type": "autogen",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "cell",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "column_sector",
+        "stsl_leading": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous",
+          "css_mb": null,
+          "css_mh": null,
+          "css_mf": null,
+          "css_ml": null,
+          "css_mr": null,
+          "css_mt": null,
+          "css_fi": null,
+          "css_hi": null,
+          "css_epfi": null,
+          "css_ephi": null,
+          "css_fpfi": null,
+          "css_fphi": null,
+          "css_ufphf": null,
+          "css_pnsi": null
+        },
+        "stsl_leadingType": "column_sector",
+        "stsl_trailing": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous",
+          "css_mb": null,
+          "css_mh": null,
+          "css_mf": null,
+          "css_ml": null,
+          "css_mr": null,
+          "css_mt": null,
+          "css_fi": null,
+          "css_hi": null,
+          "css_epfi": null,
+          "css_ephi": null,
+          "css_fpfi": null,
+          "css_fphi": null,
+          "css_ufphf": null,
+          "css_pnsi": null
+        },
+        "stsl_trailingType": "column_sector",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "comment",
+        "stsl_styles": [
+          {
+            "cs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "date_time",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "document",
+        "stsl_leading": {
+          "ds_b": {
+            "bg_c": null
+          },
+          "ds_fi": null,
+          "ds_hi": null,
+          "ds_epfi": null,
+          "ds_ephi": null,
+          "ds_uephf": false,
+          "ds_fpfi": null,
+          "ds_fphi": null,
+          "ds_ufphf": false,
+          "ds_pnsi": 1,
+          "ds_mb": 72,
+          "ds_ml": 72,
+          "ds_mr": 72,
+          "ds_mt": 72,
+          "ds_ph": 792,
+          "ds_pw": 612,
+          "ds_rtd": "",
+          "ds_mh": 36,
+          "ds_mf": 36,
+          "ds_ulhfl": false
+        },
+        "stsl_leadingType": "document",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation_function",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "footnote",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "headings",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "horizontal_rule",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "ignore_spellcheck",
+        "stsl_styles": [
+          {
+            "isc_osh": null
+          }
+        ]
+      },
+      {
+        "stsl_type": "import_warnings",
+        "stsl_styles": [
+          {
+            "iws_iwids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "language",
+        "stsl_trailing": {
+          "lgs_l": "en"
+        },
+        "stsl_trailingType": "language",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "link",
+        "stsl_styles": [
+          {
+            "lnks_link": null
+          }
+        ]
+      },
+      {
+        "stsl_type": "list",
+        "stsl_styles": [
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "named_range",
+        "stsl_styles": [
+          {
+            "nrs_ei": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "paragraph",
+        "stsl_styles": [
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 0,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 0,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 0,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 0,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 0,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "row",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "suppress_feature",
+        "stsl_styles": [
+          {
+            "sfs_sst": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "tbl",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "text",
+        "stsl_styles": [
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          }
+        ]
+      }
+    ],
+    "dsl_metastyleslices": [
+      {
+        "stsl_type": "autocorrect",
+        "stsl_styles": [
+          {
+            "ac_ot": null,
+            "ac_ct": null,
+            "ac_type": null,
+            "ac_sm": {
+              "asm_s": 0,
+              "asm_rl": 0
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "composing_decoration",
+        "stsl_styles": [
+          {
+            "cd_u": false,
+            "cd_bgc": {
+              "clr_type": 0,
+              "hclr_color": null
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "composing_region",
+        "stsl_styles": [
+          {
+            "cr_c": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "draft_comment",
+        "stsl_styles": [
+          {
+            "dcs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "ignore_word",
+        "stsl_styles": [
+          {
+            "iwos_i": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "revision_diff",
+        "stsl_styles": [
+          {
+            "revdiff_dt": 0,
+            "revdiff_a": "",
+            "revdiff_aid": ""
+          }
+        ]
+      },
+      {
+        "stsl_type": "smart_todo",
+        "stsl_styles": [
+          {
+            "sts_cid": null,
+            "sts_ot": null,
+            "sts_ac": null,
+            "sts_hi": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_pa": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_dm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "spellcheck",
+        "stsl_styles": [
+          {
+            "sc_ow": null,
+            "sc_sl": null,
+            "sc_sugg": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sc_sm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_corrections",
+        "stsl_styles": [
+          {
+            "vcs_c": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_dotted_span",
+        "stsl_styles": [
+          {
+            "vdss_p": null
+          }
+        ]
+      }
+    ],
+    "dsl_suggestedinsertions": {
+      "sgsl_sugg": [[]]
+    },
+    "dsl_suggesteddeletions": {
+      "sgsl_sugg": [[]]
+    },
+    "dsl_entitypositionmap": {},
+    "dsl_entitymap": {},
+    "dsl_entitytypemap": {},
+    "dsl_relateddocslices": {}
+  },
+  "autotext_content": {}
+}


### PR DESCRIPTION
Fixes two issues surfaced in GDocs paste > Offset > rendering MD:
1.) Converting GDocs > Offset, there was a bug in generating Linebreaks 
when newline characters where separated by a single character in the 
GDocs document (ex `a\nb\nc`).

We were relying on a complicated regex which looked for:
  1. a line start or non-newline character
  2. a single newline
  3. a line end or non-newline character
This regex would work except when the matches would overlap, which is
when the non-newline character in 3. would be the non-newline character
in 1. of a subsequent match. In those cases, the next match would be
missed.

It is far simpler just to keep track of which newlines we identify as
part of paragraph boundaries and then just skip them when identifying
linebreaks.

2.) Rendering to Commonmark, there was a bug in `splitDelimiterRuns` if,
for example, a Bold annotation ended with a Linebreak annotation. 

A recent change to Google Docs makes this occur more often: a bold 
that ends a line may have the newline character included in the bold.  
When this happens, we create a Linebreak annotation nested within the 
Bold. This results in the Bold ending with a backslash + newline. In this 
case, we were moving the newline out of the Bold but not the backslash,
since this is a punctuation character which is allowed to be on the inner 
boundary of a delimiter run if the outer boundary is a whitespace 
character, like a newline. However, since the backslash is not escaped, 
it will function to escape the delimiter, resulting in bad markdown. The 
fix is to always move unescaped backslashes out.
