### PR TITLE
🐛 use ES2018 for modules output because nullish coalescing and optional chaining is breaking upstream webpack builds

### DIFF
--- a/packages/@atjson/document/tsconfig.modules.json
+++ b/packages/@atjson/document/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/hir/tsconfig.modules.json
+++ b/packages/@atjson/hir/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/offset-annotations/tsconfig.modules.json
+++ b/packages/@atjson/offset-annotations/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/renderer-commonmark/tsconfig.modules.json
+++ b/packages/@atjson/renderer-commonmark/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/renderer-graphviz/tsconfig.modules.json
+++ b/packages/@atjson/renderer-graphviz/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/renderer-hir/tsconfig.modules.json
+++ b/packages/@atjson/renderer-hir/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/renderer-html/tsconfig.modules.json
+++ b/packages/@atjson/renderer-html/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/renderer-plain-text/tsconfig.modules.json
+++ b/packages/@atjson/renderer-plain-text/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/renderer-react/tsconfig.modules.json
+++ b/packages/@atjson/renderer-react/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/renderer-webcomponent/tsconfig.modules.json
+++ b/packages/@atjson/renderer-webcomponent/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/source-commonmark/tsconfig.modules.json
+++ b/packages/@atjson/source-commonmark/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/source-gdocs-paste/tsconfig.modules.json
+++ b/packages/@atjson/source-gdocs-paste/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/source-html/tsconfig.modules.json
+++ b/packages/@atjson/source-html/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/source-mobiledoc/tsconfig.modules.json
+++ b/packages/@atjson/source-mobiledoc/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/source-prism/tsconfig.modules.json
+++ b/packages/@atjson/source-prism/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }

--- a/packages/@atjson/source-url/tsconfig.modules.json
+++ b/packages/@atjson/source-url/tsconfig.modules.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "./dist/modules",
     "module": "esnext",
-    "target": "esnext"
+    "target": "ES2018"
   }
 }


### PR DESCRIPTION
Before:
```js
"data-aspectRatio": embed.attributes.aspectRatio?.toString(),
"data-mobile-aspectRatio": embed.attributes.mobileAspectRatio?.toString()
```

After:

```js
 "data-aspectRatio": (_a = embed.attributes.aspectRatio) === null || _a === void 0 ? void 0 : _a.toString(),
 "data-mobile-aspectRatio": (_b = embed.attributes.mobileAspectRatio) === null || _b === void 0 ? void 0 : _b.toString()
```