### PR TITLE
React-renderer: Use React context for component map

### DIFF
--- a/packages/@atjson/renderer-react/src/index.ts
+++ b/packages/@atjson/renderer-react/src/index.ts
@@ -59,8 +59,7 @@ export default class ReactRenderer extends Renderer {
     this.renderSubdocuments(annotation);
 
     const children = yield;
-    // is this enough to uniquely identify?
-    const key = `${annotation.type}-${annotation.start}-${annotation.end}`;
+    const key = `${annotation.id}-${annotation.start}`;
 
     return React.createElement(ReactRendererConsumer, { key }, value => {
       let AnnotationComponent =

--- a/packages/@atjson/renderer-react/src/index.ts
+++ b/packages/@atjson/renderer-react/src/index.ts
@@ -14,28 +14,23 @@ export type AttributesOf<AnnotationClass> = AnnotationClass extends Annotation<
     }
   : never;
 
-export type ComponentMap = {
-  [key: string]: ComponentType<any>;
-};
-
 // assigning this to a var so we can check equality with this (to throw when a
 // user of the library has not wrapped in a provider).
 const EMPTY_COMPONENT_MAP = {};
 
-const ReactRendererContext = React.createContext<ComponentMap>(
-  EMPTY_COMPONENT_MAP
-);
+const ReactRendererContext = React.createContext<{
+  [key: string]: ComponentType<any>;
+}>(EMPTY_COMPONENT_MAP);
 
 export const ReactRendererConsumer = ReactRendererContext.Consumer;
 
-export const ReactRendererProvider: FC<{ value: ComponentMap }> = ({
-  children,
-  value
-}) => {
+export const ReactRendererProvider: FC<{
+  value: { [key: string]: ComponentType<any> };
+}> = ({ children, value }) => {
   return React.createElement(
     ReactRendererConsumer,
     null,
-    (parentComponentMap: ComponentMap) => {
+    (parentComponentMap: { [key: string]: ComponentType<any> }) => {
       const mergedValues = { ...parentComponentMap, ...value };
       return React.createElement(
         ReactRendererContext.Provider,
@@ -80,7 +75,7 @@ export default class ReactRenderer extends Renderer {
 
     return React.createElement(ReactRendererConsumer, {
       key,
-      children: (componentMap: ComponentMap) => {
+      children: (componentMap: { [key: string]: ComponentType<any> }) => {
         if (componentMap === EMPTY_COMPONENT_MAP) {
           throw new Error(
             "Component map is empty. Did you wrap your render call in ReactRendererProvider?"

--- a/packages/@atjson/renderer-react/src/index.ts
+++ b/packages/@atjson/renderer-react/src/index.ts
@@ -18,7 +18,7 @@ export type AttributesOf<AnnotationClass> = AnnotationClass extends Annotation<
 // user of the library has not wrapped in a provider).
 const EMPTY_COMPONENT_MAP = {};
 
-const ReactRendererContext = React.createContext<{
+export const ReactRendererContext = React.createContext<{
   [key: string]: ComponentType<any>;
 }>(EMPTY_COMPONENT_MAP);
 

--- a/packages/@atjson/renderer-react/src/index.ts
+++ b/packages/@atjson/renderer-react/src/index.ts
@@ -75,10 +75,15 @@ export default class ReactRenderer extends Renderer {
     const annotationChildren = yield;
     const key = `${annotation.id}-${annotation.start}`;
 
-    return React.createElement(
-      ReactRendererConsumer,
-      { key },
-      (componentMap: ComponentMap) => {
+    return React.createElement(ReactRendererConsumer, {
+      key,
+      children: (componentMap: ComponentMap) => {
+        if (Object.keys(componentMap).length === 0) {
+          throw new Error(
+            "Component map is empty. Did you wrap your render call in ReactRendererProvider?"
+          );
+        }
+
         let AnnotationComponent =
           componentMap[annotation.type] ||
           componentMap[classify(annotation.type)];
@@ -93,6 +98,6 @@ export default class ReactRenderer extends Renderer {
           return annotationChildren;
         }
       }
-    );
+    });
   }
 }

--- a/packages/@atjson/renderer-react/src/index.ts
+++ b/packages/@atjson/renderer-react/src/index.ts
@@ -1,7 +1,7 @@
 import Document, { Annotation } from "@atjson/document";
 import Renderer, { classify } from "@atjson/renderer-hir";
 import * as React from "react";
-import { ComponentType, ReactElement } from "react";
+import { ComponentType, FC, ReactElement } from "react";
 
 // Make a React-aware AttributesOf for subdocuments rendered into Fragments
 export type AttributesOf<AnnotationClass> = AnnotationClass extends Annotation<
@@ -18,16 +18,19 @@ export type ComponentMap = {
   [key: string]: ComponentType<any>;
 };
 
-const ReactRendererContext = React.createContext<ComponentMap>({});
+// assigning this to a var so we can check equality with this (to throw when a
+// user of the library has not wrapped in a provider).
+const EMPTY_COMPONENT_MAP = {};
+
+const ReactRendererContext = React.createContext<ComponentMap>(
+  EMPTY_COMPONENT_MAP
+);
 
 export const ReactRendererConsumer = ReactRendererContext.Consumer;
 
-export const ReactRendererProvider = ({
+export const ReactRendererProvider: FC<{ value: ComponentMap }> = ({
   children,
   value
-}: {
-  children: React.ReactNode;
-  value: ComponentMap;
 }) => {
   return React.createElement(
     ReactRendererConsumer,
@@ -78,7 +81,7 @@ export default class ReactRenderer extends Renderer {
     return React.createElement(ReactRendererConsumer, {
       key,
       children: (componentMap: ComponentMap) => {
-        if (Object.keys(componentMap).length === 0) {
+        if (componentMap === EMPTY_COMPONENT_MAP) {
           throw new Error(
             "Component map is empty. Did you wrap your render call in ReactRendererProvider?"
           );

--- a/packages/@atjson/renderer-react/test/react-renderer-test.tsx
+++ b/packages/@atjson/renderer-react/test/react-renderer-test.tsx
@@ -192,6 +192,17 @@ describe("ReactRenderer", () => {
     );
   });
 
+  it("errors when no provider present", () => {
+    let document = new OffsetSource({
+      content: "This is bold text",
+      annotations: [new Bold({ start: 8, end: 12 })]
+    });
+
+    expect(() =>
+      ReactDOMServer.renderToStaticMarkup(ReactRenderer.render(document))
+    ).toThrowError(/ReactRendererProvider/);
+  });
+
   describe("Subdocuments", () => {
     it("renders single-level nested subdocuments", () => {
       const subDoc = new CaptionSource({

--- a/packages/@atjson/renderer-react/test/react-renderer-test.tsx
+++ b/packages/@atjson/renderer-react/test/react-renderer-test.tsx
@@ -9,7 +9,7 @@ import OffsetSource, {
   YouTubeEmbed
 } from "@atjson/offset-annotations";
 import * as React from "react";
-import { FC } from "react";
+import { ComponentType, FC } from "react";
 import * as ReactDOMServer from "react-dom/server";
 import ReactRenderer, { AttributesOf, ReactRendererProvider } from "../src";
 
@@ -23,10 +23,6 @@ function renderDocument(
     </ReactRendererProvider>
   );
 }
-
-const RootComponent: FC<{}> = props => {
-  return <article>{props.children}</article>;
-};
 
 const BoldComponent: FC<{}> = props => {
   return <strong>{props.children}</strong>;
@@ -110,8 +106,7 @@ describe("ReactRenderer", () => {
     expect(
       renderDocument(document, {
         Bold: BoldComponent,
-        Italic: ItalicComponent,
-        Root: RootComponent
+        Italic: ItalicComponent
       })
     ).toBe(`This is <strong>bold<em> and </em></strong><em>italic</em> text`);
   });
@@ -148,7 +143,6 @@ describe("ReactRenderer", () => {
       renderDocument(doc, {
         Bold: BoldComponent,
         Italic: ItalicComponent,
-        Root: RootComponent,
         Link: LinkComponent,
         LineBreak: LineBreakComponent,
         YoutubeEmbed: YouTubeEmbedComponent
@@ -182,7 +176,6 @@ describe("ReactRenderer", () => {
 
     expect(
       renderDocument(doc, {
-        Root: RootComponent,
         LineBreak: LineBreakComponent,
         Link: LinkComponent,
         GiphyEmbed: GiphyEmbedComponent
@@ -241,8 +234,7 @@ describe("ReactRenderer", () => {
         renderDocument(doc, {
           Bold: BoldComponent,
           Italic: ItalicComponent,
-          IframeEmbed: IframeComponent,
-          Root: RootComponent
+          IframeEmbed: IframeComponent
         })
       ).toBe(
         `An <strong>embed</strong> with caption (<figure><iframe src="https://foo.bar"></iframe><figcaption><strong>This</strong> is <em>some</em> caption text</figcaption></figure>) and some text following.`
@@ -286,8 +278,7 @@ describe("ReactRenderer", () => {
         renderDocument(doc, {
           Bold: BoldComponent,
           Italic: ItalicComponent,
-          IframeEmbed: IframeComponentWithProvider,
-          Root: RootComponent
+          IframeEmbed: IframeComponentWithProvider
         })
       ).toBe(
         `An <strong>embed</strong> with caption (<figure><iframe src="https://foo.bar"></iframe><figcaption><b>This</b> is <em>some</em> caption text</figcaption></figure>) and some text following.`

--- a/website/docs/react-renderer.md
+++ b/website/docs/react-renderer.md
@@ -2,8 +2,7 @@
 title: React
 ---
 
-atjson has a package for rendering documents into React. The renderer
-gives you complete control how each annotation is renderered.
+atjson has a package for rendering documents into React. The renderer gives you complete control how each annotation is renderered.
 
 ## Getting Started
 
@@ -24,23 +23,141 @@ most comfortable for you.
 
 </Note>
 
+After installation, let's prepare a React component for the renderer to use. Here's a basic React component that we'll use to render `Bold` annotations:
 
 ```ts
-import * as React from 'react';
-import { FC } from 'react';
-import ReactRenderer from '@atjson/renderer-react';
+const BoldComponent: FC<{}> = props => <strong>{props.children}</strong>;
+```
+
+Now let's use that component when rendering an atjson document into React components. The React renderer must be wrapped in the provided `ReactRendererProvider` context component, which is used to provide a map of the components available to the renderer.
+
+```ts
+import * as React from "react";
+import { FC } from "react";
+import ReactRenderer, { ReactRendererProvider } from "@atjson/renderer-react";
 
 export const Story: FC<{ children: Document }> = props => {
-  return ReactRenderer.render(props.children, components);
+  const components = {
+    Bold: BoldComponent
+  };
+
+  return (
+    <ReactRendererProvider value={components}>
+      {ReactRenderer.render(props.children)}
+    </ReactRendererProvider>
+  );
 };
 ```
+
+In the example above, any time the React renderer encounters a `Bold` annotation, it will render it using the `BoldComponent` we've created!
+
+## Using annotation attributes
+
+In the example above, the `BoldComponent` simply wraps the annotation text in an HTML tag, but more complex annotations may have additional attributes that you can use when rendering. The renderer provides any values within an annotation's `attributes` as `props` to the rendering component. Here's an example of a component that renders an `IframeEmbed` annotation, which has many attributes that can affect how it renders.
+
+```ts
+import { IframeEmbed } from "@atjson/offset-annotations";
+
+const IframeComponent: FC<AttributesOf<IframeEmbed>> = props => (
+  <figure>
+    <iframe width={props.width} height={props.height} src={props.url} />
+    <figcaption>{props.caption}</figcaption>
+  </figure>
+);
+```
+
+In this example, all the props provided are attributes that belong to the `IframeEmbed` annotation within a document.
+
+## The component map
+
+The component map is an object whose keys should correlate to the annotation types in your atjson document. The renderer will look for keys that either match the annotation type or the result of calling `classify` on the annotation type (which removes hyphens and capitalizes the words in the type name). For example, you may use either `iframe-embed` or `IframeEmbed` as the key for an `IframeEmbed` annotation.
+
+The value for any given annotation key is the React component you intend to use to render that annotation. If the renderer encounters an annotation with no key present in the map, it simply returns the text for that annotation with no decoration.
+
+Using our previous example components, here's how we'd render a document which contains `Bold` and `IframeEmbed` annotations:
+
+```ts
+import * as React from "react";
+import { FC } from "react";
+import ReactRenderer, { ReactRendererProvider } from "@atjson/renderer-react";
+
+// the component map, using the BoldComponent and IframeComponent from above
+const components = {
+  Bold: BoldComponent,
+  IframeEmbed: IframeComponent
+};
+
+export const Story: FC<{ children: Document }> = props => (
+  <ReactRendererProvider value={components}>
+    {ReactRenderer.render(props.children)}
+  </ReactRendererProvider>
+);
+```
+
+## Alternate contextual rendering
+
+By default, the component map provided to the `ReactRenderer.render` call will be used to render the entire document, including any subdocuments (captions, etc). If, however, you need to change the rendering of a particular annotation within a specific context, for example, to render an alternate `Bold` component when it is nested within a `Caption` annotation, you can utilize the `ReactRendererProvider` within your components to override particular components within your component map for that context. For example:
+
+```ts
+// a contextual caption bold component
+const CaptionBoldComponent = FC<{}> = props => {
+  return <b><{props.children}</b>;
+};
+
+// an iframe component using the contextual override
+const IframeComponent: FC<AttributesOf<IframeEmbed>> = props => {
+  return (
+    <figure>
+      <iframe src={props.url} />
+      <ReactRendererProvider value={{ Bold: CaptionBoldComponent }}>
+        <figcaption>{props.caption}</figcaption>
+      </ReactRendererProvider>
+    </figure>
+  );
+};
+
+// top-level component map
+const components = {
+  IframeEmbed: IframeComponent
+  Bold: BoldComponent
+}
+
+// top-level component render
+<ReactRendererProvider value={components}>
+  {ReactRenderer.render(doc)}
+</ReactRendererProvider>
+```
+
+In this instance, the renderer would call the `CaptionBoldComponent` whenever a `Bold` annotation appears within the iframe caption, but any `Bold` annotation outside of that context would still use the parent-level `BoldComponent`.
+
+**Note:** Nested usages of `ReactRendererProvider` are merged with the parent component map; the renderer does not completely replace the parent component map. You only need to provide a component map for the annotations that you wish to override.
 
 ## API
 
 ### `ReactRenderer.render()`
 
 ```ts
-ReactRenderer.render(document, components);
+ReactRenderer.render(document);
 ```
 
-TK explain render function
+A static rendering function that will walk the provided document, rendering annotations as React components based on the component map provided via the `ReactRendererProvider`.
+
+### `ReactRendererProvider`
+
+```ts
+<ReactRendererProvider value={components}>
+  {...}
+</ReactRendererProvider>
+```
+
+A thin wrapper around React context that provides, via the `value` prop, the map of components `ReactRenderer.render` uses. Nested instances of `ReactRendererProvider` merge the provided component map value with any component maps higher in the component tree.
+
+### `ReactRendererConsumer`
+
+```ts
+<ReactRendererConsumer>
+  { value => ... }
+</ReactRendererConsumer>
+```
+
+The React context consumer whose `value` is the component map.

--- a/website/docs/react-renderer.md
+++ b/website/docs/react-renderer.md
@@ -159,3 +159,7 @@ A thin wrapper around React context that provides, via the `value` prop, the map
 ```
 
 The React context consumer whose `value` is the component map.
+
+### `ReactRendererContext`
+
+The underlying React context used by the renderer.

--- a/website/docs/react-renderer.md
+++ b/website/docs/react-renderer.md
@@ -36,17 +36,15 @@ import * as React from "react";
 import { FC } from "react";
 import ReactRenderer, { ReactRendererProvider } from "@atjson/renderer-react";
 
-export const Story: FC<{ children: Document }> = props => {
-  const components = {
-    Bold: BoldComponent
-  };
-
-  return (
-    <ReactRendererProvider value={components}>
-      {ReactRenderer.render(props.children)}
-    </ReactRendererProvider>
-  );
+const components = {
+  Bold: BoldComponent
 };
+
+export const Story: FC<{ children: Document }> = props => (
+  <ReactRendererProvider value={components}>
+    {ReactRenderer.render(props.children)}
+  </ReactRendererProvider>
+);
 ```
 
 In the example above, any time the React renderer encounters a `Bold` annotation, it will render it using the `BoldComponent` we've created!


### PR DESCRIPTION
There a few things going on here that I'm seeking feedback on before moving forward with this approach.

- The component map is no longer passed directly to the `ReactRenderer.render` function but is instead provided via the newly-added `ReactRendererProvider` that you must wrap the `ReactRenderer.render` call with.
- This also allows you to use this Provider in nested subdocuments, allowing you to change the component map within the render tree. I've added a test to demonstrate usage.
- Providing the component map via context also lets us remove all the `componentLookup` aspects of the `ReactRenderer` class, which I've done.
- The `ReactRendererProvider` is not a direct usage of the React context; instead it's a thin wrapper that allows you to pass to a map that gets merged with its parent, so it's easier to override a subset of components (again, as demonstrated in the test).
- Following up on the discussion from #347, I've changed the root element to just use `React.Fragement`

If everyone's generally in agreement with this direction, I'll tidy it up and update the documentation to reflect the changes. I also have a [separate branch](https://github.com/CondeNast/atjson/compare/react-renderer-context) that just provides a name for the context, allowing the component to make that distinction. Either approach would work, so let's talk about what makes the most sense!