### PR TITLE
🐛 don't look for data-ceros-origin-domains when parsing ceros embeds

### DIFF
--- a/packages/@atjson/source-html/src/converter/third-party-embeds.ts
+++ b/packages/@atjson/source-html/src/converter/third-party-embeds.ts
@@ -7,9 +7,7 @@ function isCerosExperienceFrame(a: Annotation<any>) {
 
 function isCerosOriginDomainsScript(a: Annotation<any>) {
   return (
-    a.type === "script" &&
-    a.attributes.dataset &&
-    a.attributes.dataset["ceros-origin-domains"] != null
+    a.type === "script" && a.attributes.src?.indexOf("view.ceros.com") !== -1
   );
 }
 

--- a/packages/@atjson/source-html/test/converter-test.ts
+++ b/packages/@atjson/source-html/test/converter-test.ts
@@ -545,7 +545,7 @@ describe("@atjson/source-html", () => {
       describe("Ceros embeds", () => {
         test("with mobileAspectRatio", () => {
           let doc = HTMLSource.fromRaw(
-            `<div style="position: relative;width: auto;padding: 0 0 50%;height: 0;top: 0;left: 0;bottom: 0;right: 0;margin: 0;border: 0 none" id="experience-test" data-aspectRatio="2.01" data-mobile-aspectRatio="3.2"><iframe allowfullscreen src="//view.ceros.com/ceros-inspire/carousel-3" style="position: absolute;top: 0;left: 0;bottom: 0;right: 0;margin: 0;padding: 0;border: 0 none;height: 1px;width: 1px;min-height: 100%;min-width: 100%" frameborder="0" class="ceros-experience" scrolling="no"></iframe></div><script type="text/javascript" src="//view.ceros.com/scroll-proxy.min.js" data-ceros-origin-domains="view.ceros.com"></script>`
+            `<div style="position: relative;width: auto;padding: 0 0 50%;height: 0;top: 0;left: 0;bottom: 0;right: 0;margin: 0;border: 0 none" id="experience-test" data-aspectRatio="2.01" data-mobile-aspectRatio="3.2"><iframe allowfullscreen src="//view.ceros.com/ceros-inspire/carousel-3" style="position: absolute;top: 0;left: 0;bottom: 0;right: 0;margin: 0;padding: 0;border: 0 none;height: 1px;width: 1px;min-height: 100%;min-width: 100%" frameborder="0" class="ceros-experience" scrolling="no"></iframe></div><script type="text/javascript" src="//view.ceros.com/scroll-proxy.min.js"></script>`
           ).convertTo(OffsetSource);
 
           expect(doc.canonical()).toMatchObject({
@@ -568,7 +568,7 @@ describe("@atjson/source-html", () => {
 
         test("without mobileAspectRatio", () => {
           let doc = HTMLSource.fromRaw(
-            `<div style="position: relative;width: auto;padding: 0 0 50%;height: 0;top: 0;left: 0;bottom: 0;right: 0;margin: 0;border: 0 none" id="experience-test" data-aspectRatio="2"><iframe allowfullscreen src="//view.ceros.com/ceros-inspire/carousel-3" style="position: absolute;top: 0;left: 0;bottom: 0;right: 0;margin: 0;padding: 0;border: 0 none;height: 1px;width: 1px;min-height: 100%;min-width: 100%" frameborder="0" class="ceros-experience" scrolling="no"></iframe></div><script type="text/javascript" src="//view.ceros.com/scroll-proxy.min.js" data-ceros-origin-domains="view.ceros.com"></script>`
+            `<div style="position: relative;width: auto;padding: 0 0 50%;height: 0;top: 0;left: 0;bottom: 0;right: 0;margin: 0;border: 0 none" id="experience-test" data-aspectRatio="2"><iframe allowfullscreen src="//view.ceros.com/ceros-inspire/carousel-3" style="position: absolute;top: 0;left: 0;bottom: 0;right: 0;margin: 0;padding: 0;border: 0 none;height: 1px;width: 1px;min-height: 100%;min-width: 100%" frameborder="0" class="ceros-experience" scrolling="no"></iframe></div><script type="text/javascript" src="//view.ceros.com/scroll-proxy.min.js"></script>`
           ).convertTo(OffsetSource);
 
           expect(doc.canonical()).toMatchObject({


### PR DESCRIPTION
When implementing a paste handler, I was encountering some "unknown" annotations leaking through due to the ceros code not having the `data-ceros-origin-domains` data attribute.

This change relaxes the matching requirements and instead looks for the script to have `view.ceros.com` in the script tag (I know that this is not fully correct, but I think it's ok in this circumstance).