### PR TITLE
🚀 Use a more performant uuid library

### DIFF
--- a/__mocks__/uuid-random.js
+++ b/__mocks__/uuid-random.js
@@ -1,0 +1,3 @@
+module.exports = function uuid() {
+  return "Any<id>";
+};

--- a/__mocks__/uuid.js
+++ b/__mocks__/uuid.js
@@ -1,5 +1,0 @@
-module.exports = {
-  v4() {
-    return 'Any<id>';
-  }
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,16 +15,11 @@
     "@atjson/document": {
       "version": "file:packages/@atjson/document",
       "requires": {
-        "@types/uuid": "^3.4.4",
-        "uuid": "^3.3.2"
+        "uuid-random": "^1.3.0"
       }
     },
     "@atjson/hir": {
-      "version": "file:packages/@atjson/hir",
-      "requires": {
-        "@types/uuid": "^3.4.4",
-        "uuid": "^3.3.2"
-      }
+      "version": "file:packages/@atjson/hir"
     },
     "@atjson/offset-annotations": {
       "version": "file:packages/@atjson/offset-annotations"
@@ -3064,21 +3059,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
-    },
-    "@types/uuid": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.6.tgz",
-      "integrity": "sha512-cCdlC/1kGEZdEglzOieLDYBxHsvEOIg7kp/2FYyVR9Pxakq+Qf/inL3RKQ+PA8gOlI/NnL+fXmQH12nwcGzsHw==",
-      "requires": {
-        "@types/node": "*"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.12.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
-          "integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA=="
-        }
-      }
     },
     "@types/yargs": {
       "version": "13.0.3",
@@ -15688,7 +15668,13 @@
     "uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "dev": true
+    },
+    "uuid-random": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/uuid-random/-/uuid-random-1.3.0.tgz",
+      "integrity": "sha512-FSIlv8RFRPOjcHeDYStV7u6aJRfp+THrcWkbAJpw51JCyQLDxsFz+4dHgTYP8hSpZeSMXBpb/1qrK4bodXpSRA=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@types/q": "1.5.2",
     "@types/react": "16.9.17",
     "@types/react-dom": "16.9.4",
-    "@types/uuid": "3.4.6",
     "@typescript-eslint/eslint-plugin": "2.16.0",
     "@typescript-eslint/parser": "2.16.0",
     "chance": "1.1.4",
@@ -46,7 +45,7 @@
     "ts-loader": "6.2.0",
     "ttest": "2.1.1",
     "typescript": "3.7.4",
-    "uuid": "3.3.3"
+    "uuid-random": "1.3.0"
   },
   "optionalDependencies": {
     "puppeteer": "2.0.0",

--- a/packages/@atjson/document/package.json
+++ b/packages/@atjson/document/package.json
@@ -10,7 +10,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/uuid": "^3.4.4",
-    "uuid": "^3.3.2"
+    "uuid-random": "^1.3.0"
   }
 }

--- a/packages/@atjson/document/src/annotation.ts
+++ b/packages/@atjson/document/src/annotation.ts
@@ -1,4 +1,4 @@
-import { v4 as uuid } from "uuid";
+import * as uuid from "uuid-random";
 import { clone, toJSON, unprefix } from "./attributes";
 import Change, {
   AdjacentBoundaryBehaviour,

--- a/packages/@atjson/hir/package.json
+++ b/packages/@atjson/hir/package.json
@@ -14,10 +14,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "@types/uuid": "^3.4.4",
-    "uuid": "^3.3.2"
-  },
   "devDependencies": {
     "@atjson/document": "file:../document"
   },


### PR DESCRIPTION
I was seeing some minor garbage collections that I tracked down to allocations in node-uuid. Swapping out this library for uuid-random which has better benchmarks improved performance reliably in the degenerate markdown cases.