### PR TITLE
Compile everything to ES5

### DIFF
--- a/packages/@atjson/document/tsconfig.modules.json
+++ b/packages/@atjson/document/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/hir/tsconfig.modules.json
+++ b/packages/@atjson/hir/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/offset-annotations/src/annotations/paragraph.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/paragraph.ts
@@ -5,6 +5,6 @@ export class Paragraph extends BlockAnnotation {
   static vendorPrefix = "offset";
 
   get rank() {
-    return (super.rank * 3) / 2;
+    return 15;
   }
 }

--- a/packages/@atjson/offset-annotations/tsconfig.modules.json
+++ b/packages/@atjson/offset-annotations/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/renderer-commonmark/tsconfig.modules.json
+++ b/packages/@atjson/renderer-commonmark/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/renderer-graphviz/tsconfig.modules.json
+++ b/packages/@atjson/renderer-graphviz/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/renderer-hir/tsconfig.modules.json
+++ b/packages/@atjson/renderer-hir/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/renderer-html/tsconfig.modules.json
+++ b/packages/@atjson/renderer-html/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/renderer-plain-text/tsconfig.modules.json
+++ b/packages/@atjson/renderer-plain-text/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/renderer-react/tsconfig.modules.json
+++ b/packages/@atjson/renderer-react/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/renderer-webcomponent/tsconfig.modules.json
+++ b/packages/@atjson/renderer-webcomponent/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/source-commonmark/src/annotations/paragraph.ts
+++ b/packages/@atjson/source-commonmark/src/annotations/paragraph.ts
@@ -5,6 +5,6 @@ export class Paragraph extends BlockAnnotation {
   static type = "paragraph";
 
   get rank() {
-    return (super.rank * 3) / 2;
+    return 15;
   }
 }

--- a/packages/@atjson/source-commonmark/tsconfig.modules.json
+++ b/packages/@atjson/source-commonmark/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/source-gdocs-paste/tsconfig.modules.json
+++ b/packages/@atjson/source-gdocs-paste/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/source-html/src/annotations/p.ts
+++ b/packages/@atjson/source-html/src/annotations/p.ts
@@ -8,6 +8,6 @@ export class Paragraph extends BlockAnnotation<GlobalAttributes> {
   static type = "p";
 
   get rank() {
-    return (super.rank * 3) / 2;
+    return 15;
   }
 }

--- a/packages/@atjson/source-html/tsconfig.modules.json
+++ b/packages/@atjson/source-html/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/source-mobiledoc/src/annotations/paragraph.ts
+++ b/packages/@atjson/source-mobiledoc/src/annotations/paragraph.ts
@@ -5,6 +5,6 @@ export class Paragraph extends BlockAnnotation {
   static type = "p";
 
   get rank() {
-    return (super.rank * 3) / 2;
+    return 15;
   }
 }

--- a/packages/@atjson/source-mobiledoc/tsconfig.modules.json
+++ b/packages/@atjson/source-mobiledoc/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/source-prism/tsconfig.modules.json
+++ b/packages/@atjson/source-prism/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/packages/@atjson/source-url/tsconfig.json
+++ b/packages/@atjson/source-url/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "lib": ["dom", "dom.iterable", "es6"],
     "outDir": "./dist/commonjs",
     "rootDir": "./src"
   },

--- a/packages/@atjson/source-url/tsconfig.modules.json
+++ b/packages/@atjson/source-url/tsconfig.modules.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
-    "module": "esnext",
-    "target": "ES2018"
+    "module": "ES6",
+    "target": "ES5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "jsx": "react",
     "skipLibCheck": true,
     "strict": true,
-    "target": "ES6"
+    "target": "ES5"
   },
   "exclude": ["node_modules", "dist", "public", "test"]
 }


### PR DESCRIPTION
In trying to implement some custom annotations, I came up against the dreaded `Class constructor ... cannot be invoked without 'new'` error when trying to subclass the `BlockAnnotation`. After beating my head against the wall trying all kinds of different Babel / webpack configs and a number of discussions with @tim-evans, I think this is the way forward to ensure the widest range of compatibility for the library generally, and it will conveniently fix the issues I'm coming up against when creating custom annotations.

Please discuss and let me know if you think this is a bad idea or if you have concerns with this approach!