### PR TITLE
fix: protocol-relative iframes were throwing errors when being converted

### DIFF
--- a/packages/@atjson/source-html/src/converter/video-embeds.ts
+++ b/packages/@atjson/source-html/src/converter/video-embeds.ts
@@ -86,7 +86,11 @@ export default function(doc: Document) {
       return covers(paragraph[0], link);
     })
     .update(function convertVimeoVideos({ video, paragraph, links }) {
-      let url = VideoURLs.identify(new URL(video.attributes.src));
+      let src = video.attributes.src;
+      if (src?.indexOf("//") === 0) {
+        src = `https:${src}`;
+      }
+      let url = VideoURLs.identify(new URL(src));
       assert(
         url,
         `The Vimeo embed ${video.attributes.src} was definitely defined in our queries, but was not identified.`
@@ -167,7 +171,11 @@ export default function(doc: Document) {
     });
 
   doc.where(isIframe).update(function convertIdentifiedVideos(iframe) {
-    let url = VideoURLs.identify(new URL(iframe.attributes.src));
+    let src = iframe.attributes.src;
+    if (src?.indexOf("//") === 0) {
+      src = `https:${src}`;
+    }
+    let url = VideoURLs.identify(new URL(src));
     if (url) {
       let width = getSize(iframe, "width");
       let height = getSize(iframe, "height");

--- a/packages/@atjson/source-html/test/converter-test.ts
+++ b/packages/@atjson/source-html/test/converter-test.ts
@@ -402,6 +402,28 @@ describe("@atjson/source-html", () => {
       });
     });
 
+    test("protocol-relative iframe embeds", () => {
+      let doc = HTMLSource.fromRaw(
+        `<iframe src="//example.com"
+            scrolling="no" frameborder="0"
+            allowTransparency="true" allow="encrypted-media"></iframe>`
+      )
+        .convertTo(OffsetSource)
+        .canonical();
+
+      expect(doc).toMatchObject({
+        content: "",
+        annotations: [
+          {
+            type: "iframe-embed",
+            attributes: {
+              url: "//example.com"
+            }
+          }
+        ]
+      });
+    });
+
     describe("social embeds", () => {
       test("Facebook iframe embed", () => {
         let doc = HTMLSource.fromRaw(


### PR DESCRIPTION
We have received some reports of iframes being pasted into our rich text editor that were failing to show up because of a protocol-relative URL.

This change fixes that issue and adds tests for them.