### PR TITLE
fix: leading whitespace trim

### DIFF
--- a/packages/@atjson/source-html/src/parser.ts
+++ b/packages/@atjson/source-html/src/parser.ts
@@ -60,7 +60,7 @@ export default class Parser {
   private offset: number;
 
   constructor(html: string) {
-    this.html = html;
+    this.html = html.trim();
     this.content = "";
     this.annotations = [];
     this.offset = 0;
@@ -68,7 +68,7 @@ export default class Parser {
     // By using `parse` all the time,
     // we can handle `<!DOCTYPE html>` declarations
     // and HTML fragments cleanly.
-    let tree = parse5.parse(html, { sourceCodeLocationInfo: true });
+    let tree = parse5.parse(this.html, { sourceCodeLocationInfo: true });
 
     if (isDocumentFragment(tree) || isDocument(tree)) {
       this.walk(tree.childNodes);

--- a/packages/@atjson/source-html/src/parser.ts
+++ b/packages/@atjson/source-html/src/parser.ts
@@ -1,6 +1,8 @@
 import { AnnotationJSON, ParseAnnotation } from "@atjson/document";
 import * as parse5 from "parse5";
 
+const LEADING_WHITESPACE = /^\s+/;
+
 function isElement(
   node: parse5.DefaultTreeNode
 ): node is parse5.DefaultTreeElement {
@@ -60,8 +62,10 @@ export default class Parser {
   private offset: number;
 
   constructor(html: string) {
-    this.html = html.trim();
-    this.content = "";
+    this.html = html;
+    let leadingWhitespace = html.match(LEADING_WHITESPACE);
+
+    this.content = leadingWhitespace ? leadingWhitespace[0] : "";
     this.annotations = [];
     this.offset = 0;
 

--- a/packages/@atjson/source-html/test/source-html-test.ts
+++ b/packages/@atjson/source-html/test/source-html-test.ts
@@ -3,6 +3,21 @@ import HTMLSource from "../src";
 
 describe("@atjson/source-html", () => {
   describe("parser", () => {
+    test("leading whitespace parsed correctly", () => {
+      let doc = HTMLSource.fromRaw(
+        " leading <strong>whitespace</strong>"
+      ).canonical();
+      expect(doc).toMatchObject({
+        content: "leading whitespace",
+        annotations: [
+          {
+            type: "strong",
+            start: 8,
+            end: 18
+          }
+        ]
+      });
+    });
     test("annotation wraps start and end tags", () => {
       let doc = HTMLSource.fromRaw("<p>Paragraph with <b>bold</b></p>");
 
@@ -196,8 +211,7 @@ describe("@atjson/source-html", () => {
             src: "https://example.com/test.png"
           },
           children: []
-        },
-        " "
+        }
       ]
     });
   });

--- a/packages/@atjson/source-html/test/source-html-test.ts
+++ b/packages/@atjson/source-html/test/source-html-test.ts
@@ -3,21 +3,38 @@ import HTMLSource from "../src";
 
 describe("@atjson/source-html", () => {
   describe("parser", () => {
-    test("leading whitespace parsed correctly", () => {
+    test("leading space parsed correctly", () => {
       let doc = HTMLSource.fromRaw(
         " leading <strong>whitespace</strong>"
       ).canonical();
       expect(doc).toMatchObject({
-        content: "leading whitespace",
+        content: " leading whitespace",
         annotations: [
           {
             type: "strong",
-            start: 8,
-            end: 18
+            start: 9,
+            end: 19
           }
         ]
       });
     });
+
+    test("leading tab parsed correctly", () => {
+      let doc = HTMLSource.fromRaw(
+        "\tleading <strong>whitespace</strong>"
+      ).canonical();
+      expect(doc).toMatchObject({
+        content: "\tleading whitespace",
+        annotations: [
+          {
+            type: "strong",
+            start: 9,
+            end: 19
+          }
+        ]
+      });
+    });
+
     test("annotation wraps start and end tags", () => {
       let doc = HTMLSource.fromRaw("<p>Paragraph with <b>bold</b></p>");
 
@@ -211,7 +228,8 @@ describe("@atjson/source-html", () => {
             src: "https://example.com/test.png"
           },
           children: []
-        }
+        },
+        " "
       ]
     });
   });
@@ -374,6 +392,40 @@ describe("@atjson/source-html", () => {
         type: "html",
         start: 0,
         end: 5,
+        attributes: {
+          lang: "en"
+        }
+      }
+    ]);
+  });
+
+  test('  \t<!DOCTYPE html><html lang="en"><body>Hello</body></html>', () => {
+    let doc = HTMLSource.fromRaw(
+      '  \t<!DOCTYPE html><html lang="en"><body>Hello</body></html>'
+    );
+
+    expect([...doc.where({ type: "-html-body" })]).toMatchObject([
+      {
+        start: 34,
+        end: 52
+      }
+    ]);
+    expect(doc.content).toEqual(
+      '  \t<!DOCTYPE html><html lang="en"><body>Hello</body></html>'
+    );
+
+    let canonical = doc.canonical();
+    expect(canonical.content).toEqual("  \tHello");
+    expect(canonical.annotations).toMatchObject([
+      {
+        type: "body",
+        start: 3,
+        end: 8
+      },
+      {
+        type: "html",
+        start: 3,
+        end: 8,
         attributes: {
           lang: "en"
         }


### PR DESCRIPTION
Parse annotation offsets were getting messed up when content had leading whitespace -- this fixes that by trimming html prior to parse