### PR TITLE
chore: enable identifying spotify podcasts

### DIFF
--- a/packages/@atjson/offset-annotations/src/utils/social-urls.ts
+++ b/packages/@atjson/offset-annotations/src/utils/social-urls.ts
@@ -178,24 +178,57 @@ function normalizeGiphyURL(url: IUrl) {
 // - open.spotify.com/playlist/:id
 // - open.spotify.com/track/:id
 // - open.spotify.com/artist/:id
+// - open.spotify.com/episode/:id
+// - open.spotify.com/show/:id
 function isSpotifyUrl(url: IUrl) {
   return url.host === "open.spotify.com";
 }
 
+const spotifyEmbedTypes: {
+  [index: string]: string;
+} = {
+  episode: "embed-podcast",
+  show: "embed-podcast",
+  default: "embed"
+};
+
+const spotifyEmbedSizes: {
+  [index: string]: { height: string; width: string };
+} = {
+  default: {
+    height: "380",
+    width: "300"
+  },
+  track: {
+    height: "80",
+    width: "300"
+  },
+  episode: {
+    height: "232",
+    width: "100%"
+  },
+  show: {
+    height: "232",
+    width: "100%"
+  }
+};
+
 function normalizeSpotifyUrl(url: IUrl) {
   let parts = without<string>(url.pathname.split("/"), "");
-  if (parts[0] === "embed") {
+  if (parts[0] === "embed" || parts[0] === "embed-podcast") {
     parts.shift();
   }
   let type = parts[0];
+  let embedType = spotifyEmbedTypes[type] || spotifyEmbedTypes.default;
   let id = parts[1];
+  let { height, width } = spotifyEmbedSizes[type] || spotifyEmbedSizes.default;
 
   return {
     Class: IframeEmbed,
     attributes: {
-      url: `https://open.spotify.com/embed/${type}/${id}`,
-      width: "300",
-      height: type === "track" ? "80" : "380"
+      url: `https://open.spotify.com/${embedType}/${type}/${id}`,
+      width,
+      height
     }
   };
 }

--- a/packages/@atjson/offset-annotations/test/social-urls-test.ts
+++ b/packages/@atjson/offset-annotations/test/social-urls-test.ts
@@ -1,0 +1,113 @@
+import { IframeEmbed, SocialURLs } from "../src";
+
+describe("SocialURLs", () => {
+  describe("identify Spotify", () => {
+    test.each([
+      [
+        "https://open.spotify.com/embed-podcast/episode/5YNTk67O5fpJfYZAIpCZCz",
+        {
+          url:
+            "https://open.spotify.com/embed-podcast/episode/5YNTk67O5fpJfYZAIpCZCz",
+          height: "232",
+          width: "100%"
+        }
+      ],
+      [
+        "https://open.spotify.com/episode/056ZfewzAOQFphcDjva5bP?si=W4NnJijJR7-kwC3R2uPXHQ",
+        {
+          url:
+            "https://open.spotify.com/embed-podcast/episode/056ZfewzAOQFphcDjva5bP",
+          height: "232",
+          width: "100%"
+        }
+      ],
+      [
+        "https://open.spotify.com/track/6yIHnRHSUlhp4RuNAbB3Pf?si=M-B6Z34wSneRlUGCzTAR8g",
+        {
+          url: "https://open.spotify.com/embed/track/6yIHnRHSUlhp4RuNAbB3Pf",
+          height: "80",
+          width: "300"
+        }
+      ],
+      [
+        "https://open.spotify.com/embed/track/6yIHnRHSUlhp4RuNAbB3Pf",
+        {
+          url: "https://open.spotify.com/embed/track/6yIHnRHSUlhp4RuNAbB3Pf",
+          height: "80",
+          width: "300"
+        }
+      ],
+      [
+        "https://open.spotify.com/album/0RZ90KfXzXhQrgnoMcANUN?si=ebW0UcBIQk6dlMgdnnBETA",
+        {
+          url: "https://open.spotify.com/embed/album/0RZ90KfXzXhQrgnoMcANUN",
+          height: "380",
+          width: "300"
+        }
+      ],
+      [
+        "https://open.spotify.com/embed/album/0RZ90KfXzXhQrgnoMcANUN",
+        {
+          url: "https://open.spotify.com/embed/album/0RZ90KfXzXhQrgnoMcANUN",
+          height: "380",
+          width: "300"
+        }
+      ],
+      [
+        "https://open.spotify.com/artist/4uSftVc3FPWe6RJuMZNEe9?si=AbCHDBLAR7GAIb8b0lNsNA",
+        {
+          url: "https://open.spotify.com/embed/artist/4uSftVc3FPWe6RJuMZNEe9",
+          height: "380",
+          width: "300"
+        }
+      ],
+      [
+        "https://open.spotify.com/embed/artist/4uSftVc3FPWe6RJuMZNEe9",
+        {
+          url: "https://open.spotify.com/embed/artist/4uSftVc3FPWe6RJuMZNEe9",
+          height: "380",
+          width: "300"
+        }
+      ],
+      [
+        "https://open.spotify.com/playlist/2s1HL7UaXEPWqJR4E1Gt1A?si=RjZGyBmdTcyrh6WzjN0oDA",
+        {
+          url: "https://open.spotify.com/embed/playlist/2s1HL7UaXEPWqJR4E1Gt1A",
+          height: "380",
+          width: "300"
+        }
+      ],
+      [
+        "https://open.spotify.com/embed/playlist/2s1HL7UaXEPWqJR4E1Gt1A",
+        {
+          url: "https://open.spotify.com/embed/playlist/2s1HL7UaXEPWqJR4E1Gt1A",
+          height: "380",
+          width: "300"
+        }
+      ],
+      [
+        "https://open.spotify.com/show/1iohmBNlRooIVtukKeavRa?si=_ZEhAhfZTUGz3UOKPLkH8Q",
+        {
+          url:
+            "https://open.spotify.com/embed-podcast/show/1iohmBNlRooIVtukKeavRa",
+          height: "232",
+          width: "100%"
+        }
+      ],
+      [
+        "https://open.spotify.com/embed-podcast/show/1iohmBNlRooIVtukKeavRa",
+        {
+          url:
+            "https://open.spotify.com/embed-podcast/show/1iohmBNlRooIVtukKeavRa",
+          height: "232",
+          width: "100%"
+        }
+      ]
+    ])("%s", (url, attributes) => {
+      expect(SocialURLs.identify(new URL(url))).toMatchObject({
+        Class: IframeEmbed,
+        attributes
+      });
+    });
+  });
+});

--- a/packages/@atjson/source-html/test/converter-test.ts
+++ b/packages/@atjson/source-html/test/converter-test.ts
@@ -532,6 +532,62 @@ describe("@atjson/source-html", () => {
           ]
         });
       });
+
+      test("Spotify podcast show embed", () => {
+        let doc = HTMLSource.fromRaw(
+          `<iframe src="https://open.spotify.com/embed-podcast/show/1iohmBNlRooIVtukKeavRa"
+            width="100%"
+            height="232"
+            frameborder="0"
+            allowtransparency="true"
+            allow="encrypted-media"></iframe>`
+        ).convertTo(OffsetSource);
+
+        let hir = new HIR(doc).toJSON();
+        expect(hir).toMatchObject({
+          type: "root",
+          children: [
+            {
+              type: "iframe-embed",
+              attributes: {
+                url:
+                  "https://open.spotify.com/embed-podcast/show/1iohmBNlRooIVtukKeavRa",
+                height: "232",
+                width: "100%"
+              },
+              children: []
+            }
+          ]
+        });
+      });
+
+      test("Spotify track embed", () => {
+        let doc = HTMLSource.fromRaw(
+          `<iframe src="https://open.spotify.com/embed/track/1QY4TdhuNIOX2SHLdElzd5"
+            width="300"
+            height="380"
+            frameborder="0"
+            allowtransparency="true"
+            allow="encrypted-media"></iframe>`
+        ).convertTo(OffsetSource);
+
+        let hir = new HIR(doc).toJSON();
+        expect(hir).toMatchObject({
+          type: "root",
+          children: [
+            {
+              type: "iframe-embed",
+              attributes: {
+                url:
+                  "https://open.spotify.com/embed/track/1QY4TdhuNIOX2SHLdElzd5",
+                height: "380",
+                width: "300"
+              },
+              children: []
+            }
+          ]
+        });
+      });
     });
 
     describe("video embeds", () => {


### PR DESCRIPTION
Add the ability to identify Spotify podcast embeds. The sizing info was pulled from a Spotify podcast episode embed code:
```
<iframe src="https://open.spotify.com/embed-podcast/episode/056ZfewzAOQFphcDjva5bP" width="100%" height="232" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
```
```
<iframe src="https://open.spotify.com/embed-podcast/show/1iohmBNlRooIVtukKeavRa" width="100%" height="232" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
```