### PR TITLE
fix: update peer dependencies to @atjson/document

### DIFF
--- a/packages/@atjson/hir/package.json
+++ b/packages/@atjson/hir/package.json
@@ -18,6 +18,6 @@
     "@atjson/document": "file:../document"
   },
   "peerDependencies": {
-    "@atjson/document": ">= 0.17.0 < 1"
+    "@atjson/document": "^0.23.0"
   }
 }

--- a/packages/@atjson/offset-annotations/package.json
+++ b/packages/@atjson/offset-annotations/package.json
@@ -13,6 +13,6 @@
     "@atjson/document": "file:../document"
   },
   "peerDependencies": {
-    "@atjson/document": ">= 0.17.0 < 1"
+    "@atjson/document": "^0.23.0"
   }
 }

--- a/packages/@atjson/renderer-commonmark/package.json
+++ b/packages/@atjson/renderer-commonmark/package.json
@@ -19,6 +19,6 @@
     "@atjson/renderer-hir": "file:../renderer-hir"
   },
   "peerDependencies": {
-    "@atjson/document": ">= 0.17.0 < 1"
+    "@atjson/document": "^0.23.0"
   }
 }

--- a/packages/@atjson/renderer-graphviz/package.json
+++ b/packages/@atjson/renderer-graphviz/package.json
@@ -16,6 +16,6 @@
     "@atjson/document": "file:../document"
   },
   "peerDependencies": {
-    "@atjson/document": ">= 0.17.0 < 1"
+    "@atjson/document": "^0.23.0"
   }
 }

--- a/packages/@atjson/renderer-hir/package.json
+++ b/packages/@atjson/renderer-hir/package.json
@@ -16,6 +16,6 @@
     "@atjson/document": "file:../document"
   },
   "peerDependencies": {
-    "@atjson/document": ">= 0.17.0 < 1"
+    "@atjson/document": "^0.23.0"
   }
 }

--- a/packages/@atjson/renderer-html/package.json
+++ b/packages/@atjson/renderer-html/package.json
@@ -18,6 +18,6 @@
     "@atjson/offset-annotations": "file:../offset-annotations"
   },
   "peerDependencies": {
-    "@atjson/document": ">= 0.17.0 < 1"
+    "@atjson/document": "^0.23.0"
   }
 }

--- a/packages/@atjson/renderer-plain-text/package.json
+++ b/packages/@atjson/renderer-plain-text/package.json
@@ -17,6 +17,6 @@
     "@atjson/renderer-hir": "file:../renderer-hir"
   },
   "peerDependencies": {
-    "@atjson/document": ">= 0.17.0 < 1"
+    "@atjson/document": "^0.23.0"
   }
 }

--- a/packages/@atjson/renderer-webcomponent/package.json
+++ b/packages/@atjson/renderer-webcomponent/package.json
@@ -17,6 +17,6 @@
     "@atjson/document": "file:../document"
   },
   "peerDependencies": {
-    "@atjson/document": ">= 0.17.0 < 1"
+    "@atjson/document": "^0.23.0"
   }
 }

--- a/packages/@atjson/source-commonmark/package.json
+++ b/packages/@atjson/source-commonmark/package.json
@@ -18,6 +18,6 @@
     "@atjson/document": "file:../document"
   },
   "peerDependencies": {
-    "@atjson/document": ">= 0.17.0 < 1"
+    "@atjson/document": "^0.23.0"
   }
 }

--- a/packages/@atjson/source-html/package.json
+++ b/packages/@atjson/source-html/package.json
@@ -24,6 +24,6 @@
     "@atjson/document": "file:../document"
   },
   "peerDependencies": {
-    "@atjson/document": ">= 0.17.0 < 1"
+    "@atjson/document": "^0.23.0"
   }
 }

--- a/packages/@atjson/source-mobiledoc/package.json
+++ b/packages/@atjson/source-mobiledoc/package.json
@@ -16,6 +16,6 @@
     "@atjson/document": "file:../document"
   },
   "peerDependencies": {
-    "@atjson/document": ">= 0.17.0 < 1"
+    "@atjson/document": "^0.23.0"
   }
 }

--- a/packages/@atjson/source-prism/package.json
+++ b/packages/@atjson/source-prism/package.json
@@ -23,6 +23,6 @@
     "@atjson/document": "file:../document"
   },
   "peerDependencies": {
-    "@atjson/document": ">= 0.17.0 < 1"
+    "@atjson/document": "^0.23.0"
   }
 }

--- a/packages/@atjson/source-url/package.json
+++ b/packages/@atjson/source-url/package.json
@@ -19,6 +19,6 @@
     "@atjson/document": "file:../document"
   },
   "peerDependencies": {
-    "@atjson/document": ">= 0.17.0 < 1"
+    "@atjson/document": "^0.23.0"
   }
 }


### PR DESCRIPTION
Some packages rely on new features in @atjson/document but their peer dependencies are out of date.