### PR TITLE
chore: use commitlint bot instead of github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,6 @@ name: CI
 on: [push]
 
 jobs:
-  commitlint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install
-        run: |
-          npm ci
-      - name: ✅ Commitlint
-        run: |
-          git log --format=%B -n 1 $GITHUB_SHA | ./node_modules/.bin/commitlint
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I've installed [commitlint](https://github.com/apps/commitlint/) on atjson to help with writing correct commit messages