### PR TITLE
fix: use single newline for gdocs paragraphs

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,7 +4,8 @@
   "command": {
     "publish": {
       "exact": true,
-      "conventionalCommits": true
+      "conventionalCommits": true,
+      "message": "chore(release): publish"
     },
     "bootstrap": {
       "hoist": true,

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lint": "eslint packages/**/src/*.ts packages/**/test/*.ts",
     "lint-fix": "eslint packages/**/src/*.ts packages/**/test/*.ts --fix",
     "prepublishOnly": "rm -rf packages/@atjson/**/dist && npm run build",
-    "publish": "lerna publish --no-commit-hooks",
+    "publish": "lerna publish",
     "test": "./node_modules/jest/bin/jest.js",
     "typecheck": "tsc -b packages/**/* --force",
     "anonymize-fixtures": "npx ts-node ./performance/anonymize-fixtures.ts",

--- a/packages/@atjson/renderer-commonmark/CHANGELOG.md
+++ b/packages/@atjson/renderer-commonmark/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.22.3-dev.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.22.2...@atjson/renderer-commonmark@0.22.3-dev.1) (2020-03-03)
+
+### Bug Fixes
+
+- handle newlines in list items ([2c901cb](https://github.com/CondeNast/atjson/commit/2c901cb69998e5175a8610a0ca45666c1c6535bb))
+
 ## [0.22.3-dev.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.22.2...@atjson/renderer-commonmark@0.22.3-dev.0) (2020-03-03)
 
 ### Bug Fixes

--- a/packages/@atjson/renderer-commonmark/CHANGELOG.md
+++ b/packages/@atjson/renderer-commonmark/CHANGELOG.md
@@ -3,70 +3,45 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.22.3-dev.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.22.2...@atjson/renderer-commonmark@0.22.3-dev.0) (2020-03-03)
+
+### Bug Fixes
+
+- handle newlines in list items ([2c901cb](https://github.com/CondeNast/atjson/commit/2c901cb69998e5175a8610a0ca45666c1c6535bb))
+
 ## [0.22.2](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.22.1...@atjson/renderer-commonmark@0.22.2) (2020-03-02)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
-
-
-
-
 ## [0.22.1](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.22.0...@atjson/renderer-commonmark@0.22.1) (2020-02-26)
-
 
 ### Bug Fixes
 
-* update peer dependencies to @atjson/document ([49f5fd8](https://github.com/CondeNast/atjson/commit/49f5fd849e9c6c167509e244081593662424e4a2))
-
-
-
-
+- update peer dependencies to @atjson/document ([49f5fd8](https://github.com/CondeNast/atjson/commit/49f5fd849e9c6c167509e244081593662424e4a2))
 
 # [0.22.0](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.21.25...@atjson/renderer-commonmark@0.22.0) (2020-02-20)
 
-
 ### Features
 
-* add Annotation is type narrowing function ([#423](https://github.com/CondeNast/atjson/issues/423)) ([2858a4f](https://github.com/CondeNast/atjson/commit/2858a4f707dd14d0ece5d0bc576f38363dfbe5ba))
-
-
-
-
+- add Annotation is type narrowing function ([#423](https://github.com/CondeNast/atjson/issues/423)) ([2858a4f](https://github.com/CondeNast/atjson/commit/2858a4f707dd14d0ece5d0bc576f38363dfbe5ba))
 
 ## [0.21.25](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.21.24...@atjson/renderer-commonmark@0.21.25) (2020-02-20)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
-
-
-
-
 ## [0.21.24](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/renderer-commonmark@0.21.23...@atjson/renderer-commonmark@0.21.24) (2020-02-10)
-
 
 ### Bug Fixes
 
-* just say no to Unknown-Unknowns! ([#292](https://github.com/CondeNast-Copilot/atjson/issues/292)) ([a90f294](https://github.com/CondeNast-Copilot/atjson/commit/a90f294b5964eb2c22a77eceeab70cdc600d4bf2))
-
-
-
-
+- just say no to Unknown-Unknowns! ([#292](https://github.com/CondeNast-Copilot/atjson/issues/292)) ([a90f294](https://github.com/CondeNast-Copilot/atjson/commit/a90f294b5964eb2c22a77eceeab70cdc600d4bf2))
 
 ## [0.21.23](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.21.22...@atjson/renderer-commonmark@0.21.23) (2020-01-28)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
 
-
-
-
-
 ## [0.21.22](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.21.21...@atjson/renderer-commonmark@0.21.22) (2020-01-28)
 
 **Note:** Version bump only for package @atjson/renderer-commonmark
-
-
-
-
 
 ## [0.21.21](https://github.com/CondeNast/atjson/compare/@atjson/renderer-commonmark@0.21.20...@atjson/renderer-commonmark@0.21.21) (2020-01-24)
 

--- a/packages/@atjson/renderer-commonmark/package.json
+++ b/packages/@atjson/renderer-commonmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/renderer-commonmark",
-  "version": "0.22.2",
+  "version": "0.22.3-dev.0",
   "description": "Render atjson documents into commonmark",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",

--- a/packages/@atjson/renderer-commonmark/package.json
+++ b/packages/@atjson/renderer-commonmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/renderer-commonmark",
-  "version": "0.22.3-dev.0",
+  "version": "0.22.3-dev.1",
   "description": "Render atjson documents into commonmark",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -619,9 +619,9 @@ export default class CommonmarkRenderer extends Renderer {
       "\n" +
       rest
         .map(function leftPad(line) {
-          return indent + line;
+          return indent + line + "\n";
         })
-        .join("\n")
+        .join("")
         .replace(/[ ]+$/, "");
 
     if (this.state.tight) {

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -75,6 +75,43 @@ describe("commonmark", () => {
     );
   });
 
+  test("a naive list", () => {
+    let document = new OffsetSource({
+      content: "ABC",
+      annotations: [
+        {
+          type: "-offset-list",
+          start: 0,
+          end: 3,
+          attributes: { "-offset-type": "numbered" }
+        },
+        { type: "-offset-list-item", start: 0, end: 1, attributes: {} },
+        { type: "-offset-list-item", start: 1, end: 2, attributes: {} },
+        { type: "-offset-list-item", start: 2, end: 3, attributes: {} }
+      ]
+    });
+
+    expect(CommonmarkRenderer.render(document)).toBe("1. A\n2. B\n3. C\n\n");
+  });
+
+  test("a naive list with new lines", () => {
+    let document = new OffsetSource({
+      content: "A\nBC",
+      annotations: [
+        {
+          type: "-offset-list",
+          start: 0,
+          end: 4,
+          attributes: { "-offset-type": "numbered" }
+        },
+        { type: "-offset-list-item", start: 0, end: 3, attributes: {} },
+        { type: "-offset-list-item", start: 3, end: 4, attributes: {} }
+      ]
+    });
+
+    expect(CommonmarkRenderer.render(document)).toBe("1. A\n   B\n2. C\n\n");
+  });
+
   test("a list", () => {
     let document = new OffsetSource({
       content: [
@@ -187,6 +224,37 @@ After all the lists
 
 `
     );
+  });
+
+  test("a list with internal linebreaks", () => {
+    let document = new OffsetSource({
+      content: "A\u000BB\nC",
+      annotations: [
+        {
+          type: "-offset-list",
+          start: 0,
+          end: 5,
+          attributes: { "-offset-type": "numbered" }
+        },
+        { type: "-offset-list-item", start: 0, end: 3, attributes: {} },
+        { type: "-offset-line-break", start: 1, end: 2, attributes: {} },
+        {
+          type: "-atjson-parse-token",
+          start: 1,
+          end: 2,
+          attributes: { "-atjson-reason": "vertical tab" }
+        },
+        {
+          type: "-atjson-parse-token",
+          start: 3,
+          end: 4,
+          attributes: { "-atjson-reason": "new line paragraph separator" }
+        },
+        { type: "-offset-list-item", start: 4, end: 5, attributes: {} }
+      ]
+    });
+
+    expect(CommonmarkRenderer.render(document)).toBe("1. A\\\n   B\n2. C\n\n");
   });
 
   test("preserve space between sentence-terminating italic + number.", () => {

--- a/packages/@atjson/source-gdocs-paste/CHANGELOG.md
+++ b/packages/@atjson/source-gdocs-paste/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.22.3-dev.1](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.22.2...@atjson/source-gdocs-paste@0.22.3-dev.1) (2020-03-03)
+
+### Bug Fixes
+
+- use single newline for gdocs paragraphs ([3767f37](https://github.com/CondeNast/atjson/commit/3767f373472f82078d81a7334b8cb750138d5a7e))
+
 ## [0.22.3-dev.0](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.22.2...@atjson/source-gdocs-paste@0.22.3-dev.0) (2020-03-03)
 
 ### Bug Fixes

--- a/packages/@atjson/source-gdocs-paste/CHANGELOG.md
+++ b/packages/@atjson/source-gdocs-paste/CHANGELOG.md
@@ -3,64 +3,41 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.22.3-dev.0](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.22.2...@atjson/source-gdocs-paste@0.22.3-dev.0) (2020-03-03)
+
+### Bug Fixes
+
+- use single newline for gdocs paragraphs ([3767f37](https://github.com/CondeNast/atjson/commit/3767f373472f82078d81a7334b8cb750138d5a7e))
+
 ## [0.22.2](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.22.1...@atjson/source-gdocs-paste@0.22.2) (2020-03-02)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
-
-
-
-
 
 ## [0.22.1](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.22.0...@atjson/source-gdocs-paste@0.22.1) (2020-02-26)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
-
-
-
-
 # [0.22.0](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.21.19...@atjson/source-gdocs-paste@0.22.0) (2020-02-20)
-
 
 ### Features
 
-* add Annotation is type narrowing function ([#423](https://github.com/CondeNast/atjson/issues/423)) ([2858a4f](https://github.com/CondeNast/atjson/commit/2858a4f707dd14d0ece5d0bc576f38363dfbe5ba))
-
-
-
-
+- add Annotation is type narrowing function ([#423](https://github.com/CondeNast/atjson/issues/423)) ([2858a4f](https://github.com/CondeNast/atjson/commit/2858a4f707dd14d0ece5d0bc576f38363dfbe5ba))
 
 ## [0.21.19](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.21.18...@atjson/source-gdocs-paste@0.21.19) (2020-02-20)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
-
-
-
-
 ## [0.21.18](https://github.com/CondeNast-Copilot/atjson/compare/@atjson/source-gdocs-paste@0.21.17...@atjson/source-gdocs-paste@0.21.18) (2020-02-10)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
-
-
-
-
 
 ## [0.21.17](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.21.16...@atjson/source-gdocs-paste@0.21.17) (2020-01-28)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
 
-
-
-
-
 ## [0.21.16](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.21.15...@atjson/source-gdocs-paste@0.21.16) (2020-01-28)
 
 **Note:** Version bump only for package @atjson/source-gdocs-paste
-
-
-
-
 
 ## [0.21.15](https://github.com/CondeNast/atjson/compare/@atjson/source-gdocs-paste@0.21.14...@atjson/source-gdocs-paste@0.21.15) (2020-01-24)
 

--- a/packages/@atjson/source-gdocs-paste/package.json
+++ b/packages/@atjson/source-gdocs-paste/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/source-gdocs-paste",
-  "version": "0.22.3-dev.0",
+  "version": "0.22.3-dev.1",
   "description": "Create atjson documents from Google Docs (KIX) paste buffers",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",

--- a/packages/@atjson/source-gdocs-paste/package.json
+++ b/packages/@atjson/source-gdocs-paste/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/source-gdocs-paste",
-  "version": "0.22.2",
+  "version": "0.22.3-dev.0",
   "description": "Create atjson documents from Google Docs (KIX) paste buffers",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",

--- a/packages/@atjson/source-gdocs-paste/src/converter.ts
+++ b/packages/@atjson/source-gdocs-paste/src/converter.ts
@@ -4,13 +4,33 @@ import {
   ParseAnnotation,
   is
 } from "@atjson/document";
-import OffsetSource, { LineBreak, Paragraph } from "@atjson/offset-annotations";
+import OffsetSource, {
+  LineBreak,
+  Paragraph,
+  ListItem,
+  List
+} from "@atjson/offset-annotations";
 import { Heading } from "./annotations";
 import GDocsSource from "./source";
 
 // eslint-disable-next-line no-control-regex
 const VERTICAL_TABS = /\u000B/g;
 const NEWLINE_PARAGRAPH_SEPARATOR = /\n(\s*\n)*/g;
+
+function compareAnnotations(a: Annotation<any>, b: Annotation<any>) {
+  if (a.start !== b.start) {
+    return a.start - b.start;
+  }
+  if (a.end !== b.end) {
+    return b.end - a.end;
+  }
+
+  if (a.rank !== b.rank) {
+    return a.rank - b.rank;
+  }
+
+  return a.type < b.type ? -1 : a.type > b.type ? 1 : 0;
+}
 
 GDocsSource.defineConverterTo(OffsetSource, doc => {
   // Remove all underlines that align with links, since
@@ -72,28 +92,35 @@ GDocsSource.defineConverterTo(OffsetSource, doc => {
     .set({ type: "-offset-link" })
     .rename({ attributes: { "-gdocs-ulnk_url": "-offset-url" } });
 
-  doc
+  let convertedLists = doc
     .where({ type: "-offset-list" })
     .as("list")
     .join(
       doc.where({ type: "-offset-list-item" }).as("listItems"),
-      (l, r) => l.start === r.start && l.end === r.end
-    )
-    .update(({ list, listItems }) => {
-      let item = listItems[0];
-      let insertionPoint = list.end;
-      doc.insertText(insertionPoint, "\uFFFC");
-      doc.addAnnotations(
-        new ParseAnnotation({
-          start: insertionPoint,
-          end: insertionPoint + 1,
-          attributes: {
-            reason: "object replacement character for single-item list"
-          }
-        })
+      (list, listItem) =>
+        list.start <= listItem.start && list.end >= listItem.end
+    );
+
+  convertedLists.update(({ list, listItems }) => {
+    for (let newline of doc.match(
+      NEWLINE_PARAGRAPH_SEPARATOR,
+      list.start,
+      list.end
+    )) {
+      let adjacentListItem = listItems.find(
+        listItem => listItem.end === newline.start
       );
-      item.end--;
-    });
+      if (adjacentListItem) {
+        doc.addAnnotations(
+          new ParseAnnotation({
+            start: newline.start,
+            end: newline.end,
+            attributes: { reason: "list item separator" }
+          })
+        );
+      }
+    }
+  });
 
   // Convert vertical tabs to line breaks
   for (let verticalTab of doc.match(VERTICAL_TABS)) {
@@ -141,21 +168,18 @@ GDocsSource.defineConverterTo(OffsetSource, doc => {
       );
       let lastEnd = start;
       for (let paragraphBoundary of paragraphBoundaries) {
-        doc.addAnnotations(
-          new ParseAnnotation({
-            start: paragraphBoundary.start,
-            end: paragraphBoundary.end,
-            attributes: {
-              reason: "new line paragraph separator"
-            }
-          })
-        );
-
         if (lastEnd < paragraphBoundary.start) {
           doc.addAnnotations(
             new Paragraph({
               start: lastEnd,
               end: paragraphBoundary.start
+            }),
+            new ParseAnnotation({
+              start: paragraphBoundary.start,
+              end: paragraphBoundary.end,
+              attributes: {
+                reason: "paragraph boundary"
+              }
             })
           );
         }
@@ -173,44 +197,83 @@ GDocsSource.defineConverterTo(OffsetSource, doc => {
       }
     });
 
-  // LineBreaks/Paragraphs may have been created for listItem separators,
-  // so delete those which exist in a list (or immediately after) but not in any list item
-  doc
-    .where(
-      (annotation: Annotation) =>
-        is(annotation, LineBreak) || is(annotation, Paragraph)
-    )
-    .as("lineBreak")
+  // GDocs can produce lists that have paragraphs in them that are
+  // not wrapped by a list item. In these cases, split the list before
+  // and after the paragraph, as necessary
+  convertedLists
     .join(
-      doc.where({ type: "-offset-list" }).as("lists"),
-      (l: Annotation, r: Annotation) => l.start >= r.start && l.end <= r.end + 1
+      doc.where({ type: "-offset-paragraph" }).as("paragraphs"),
+      ({ list }, paragraph) =>
+        list.start <= paragraph.start && paragraph.end <= list.end
     )
-    .outerJoin(
-      doc.where({ type: "-offset-list-item" }).as("listItems"),
-      (
-        l: { lineBreak: LineBreak | Paragraph; lists: Array<Annotation<any>> },
-        r: Annotation<any>
-      ) => {
-        return l.lineBreak.start >= r.start && l.lineBreak.end <= r.end;
-      }
-    )
-    .update(({ lineBreak, listItems }) => {
-      if (listItems.length === 0) {
-        doc.removeAnnotation(lineBreak);
+    .update(({ list, listItems, paragraphs }) => {
+      let blocks = [...listItems, ...paragraphs];
+
+      // Sort list items and paragraphs topologically so we can determine their
+      // nested structure
+      blocks.sort(compareAnnotations);
+
+      let lastListItem = null;
+      let currentList = list;
+      let listEnd = list.end;
+      for (let block of blocks) {
+        // We have a list item, so mark it as the last seen.
+        if (is(block, ListItem)) {
+          lastListItem = block;
+
+          // if the list was previously split, wrap the remainder in a new
+          // list annotation. We only have to do this in this case when we've
+          // found more list items that now lie outside the current list
+          if (currentList.end < block.end) {
+            currentList = new List({
+              ...currentList,
+              start: block.start,
+              end: listEnd
+            });
+            doc.addAnnotations(currentList);
+          }
+          continue;
+        }
+
+        // In this case we have a paragraph that is wrapped in a list item
+        // We can just continue
+        if (lastListItem && lastListItem.end >= block.end) {
+          continue;
+        }
+
+        // We've found a paragraph with no wrapping list item. If the current
+        // list overlaps this paragraph, truncate it to the beginning of the
+        // of the paragraph.
+        if (currentList.end > block.start) {
+          currentList.end = block.start;
+        }
       }
     });
 
-  // LineBreaks may have been created at a block boundary co-terminating
-  // with a paragraph, so delete those which match a paragraph end
+  // Resolve single-item lists. New ones may have been created by splitting
+  // lists
   doc
-    .where(annotation => is(annotation, LineBreak))
-    .as("lineBreak")
+    .where({ type: "-offset-list" })
+    .as("list")
     .join(
-      doc.where(annotation => is(annotation, Paragraph)).as("paragraphs"),
-      (l: Annotation, r: Annotation) => l.end === r.end
+      doc.where({ type: "-offset-list-item" }).as("listItems"),
+      (list, listItem) =>
+        list.start === listItem.start && list.end === listItem.end
     )
-    .update(({ lineBreak }) => {
-      doc.removeAnnotation(lineBreak);
+    .update(({ list, listItems }) => {
+      let insertionPoint = list.end;
+      let item = listItems[0];
+      doc.insertText(insertionPoint, "\uFFFC");
+      doc.addAnnotations(
+        new ParseAnnotation({
+          start: insertionPoint,
+          end: insertionPoint + 1,
+          attributes: {
+            reason: "object replacement character for single-item list"
+          }
+        })
+      );
+      item.end--;
     });
 
   return doc;

--- a/packages/@atjson/source-gdocs-paste/test/fixtures/list-with-interrupting-paragraph.json
+++ b/packages/@atjson/source-gdocs-paste/test/fixtures/list-with-interrupting-paragraph.json
@@ -1,0 +1,1080 @@
+{
+  "resolved": {
+    "dsl_spacers": "A\nB\nC\nD",
+    "dsl_styleslices": [
+      {
+        "stsl_type": "autogen",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "cell",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "column_sector",
+        "stsl_leading": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous",
+          "css_mb": null,
+          "css_mh": null,
+          "css_mf": null,
+          "css_ml": null,
+          "css_mr": null,
+          "css_mt": null,
+          "css_fi": null,
+          "css_hi": null,
+          "css_epfi": null,
+          "css_ephi": null,
+          "css_fpfi": null,
+          "css_fphi": null,
+          "css_ufphf": null,
+          "css_pnsi": null
+        },
+        "stsl_leadingType": "column_sector",
+        "stsl_trailing": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous",
+          "css_mb": null,
+          "css_mh": null,
+          "css_mf": null,
+          "css_ml": null,
+          "css_mr": null,
+          "css_mt": null,
+          "css_fi": null,
+          "css_hi": null,
+          "css_epfi": null,
+          "css_ephi": null,
+          "css_fpfi": null,
+          "css_fphi": null,
+          "css_ufphf": null,
+          "css_pnsi": null
+        },
+        "stsl_trailingType": "column_sector",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "comment",
+        "stsl_styles": [
+          {
+            "cs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "date_time",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "document",
+        "stsl_leading": {
+          "ds_b": {
+            "bg_c": null
+          },
+          "ds_fi": null,
+          "ds_hi": null,
+          "ds_epfi": null,
+          "ds_ephi": null,
+          "ds_uephf": false,
+          "ds_fpfi": null,
+          "ds_fphi": null,
+          "ds_ufphf": false,
+          "ds_pnsi": 1,
+          "ds_mb": 72,
+          "ds_ml": 72,
+          "ds_mr": 72,
+          "ds_mt": 72,
+          "ds_ph": 792,
+          "ds_pw": 612,
+          "ds_rtd": "",
+          "ds_mh": 36,
+          "ds_mf": 36,
+          "ds_ulhfl": false
+        },
+        "stsl_leadingType": "document",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation_function",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "footnote",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "headings",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "horizontal_rule",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "ignore_spellcheck",
+        "stsl_styles": [
+          {
+            "isc_osh": null
+          }
+        ]
+      },
+      {
+        "stsl_type": "import_warnings",
+        "stsl_styles": [
+          {
+            "iws_iwids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "language",
+        "stsl_trailing": {
+          "lgs_l": "en"
+        },
+        "stsl_trailingType": "language",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "link",
+        "stsl_styles": [
+          {
+            "lnks_link": null
+          }
+        ]
+      },
+      {
+        "stsl_type": "list",
+        "stsl_trailing": {
+          "ls_nest": 0,
+          "ls_id": "kix.dko8rpu5p1u6",
+          "ls_ts": {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          }
+        },
+        "stsl_trailingType": "list",
+        "stsl_styles": [
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": "kix.dko8rpu5p1u6",
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": "kix.dko8rpu5p1u6",
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "named_range",
+        "stsl_styles": [
+          {
+            "nrs_ei": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "paragraph",
+        "stsl_trailing": {
+          "ps_al": 0,
+          "ps_awao": true,
+          "ps_sd": null,
+          "ps_bbtw": null,
+          "ps_bb": null,
+          "ps_bl": null,
+          "ps_br": null,
+          "ps_bt": null,
+          "ps_hd": 0,
+          "ps_hdid": "",
+          "ps_ifl": 18,
+          "ps_il": 36,
+          "ps_ir": 0,
+          "ps_klt": false,
+          "ps_kwn": false,
+          "ps_ltr": true,
+          "ps_ls": 1.15,
+          "ps_lslm": 1,
+          "ps_sm": 0,
+          "ps_sa": 0,
+          "ps_sb": 0,
+          "ps_al_i": false,
+          "ps_awao_i": false,
+          "ps_sd_i": false,
+          "ps_bbtw_i": false,
+          "ps_bb_i": false,
+          "ps_bl_i": false,
+          "ps_br_i": false,
+          "ps_bt_i": false,
+          "ps_ifl_i": false,
+          "ps_il_i": false,
+          "ps_ir_i": false,
+          "ps_klt_i": false,
+          "ps_kwn_i": false,
+          "ps_ls_i": false,
+          "ps_lslm_i": false,
+          "ps_rd": "",
+          "ps_sm_i": false,
+          "ps_sa_i": false,
+          "ps_sb_i": false,
+          "ps_shd": false,
+          "ps_ts": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          }
+        },
+        "stsl_trailingType": "paragraph",
+        "stsl_styles": [
+          null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 18,
+            "ps_il": 36,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 18,
+            "ps_il": 36,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "row",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "suppress_feature",
+        "stsl_styles": [
+          {
+            "sfs_sst": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "tbl",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "text",
+        "stsl_styles": [
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          }
+        ]
+      }
+    ],
+    "dsl_metastyleslices": [
+      {
+        "stsl_type": "autocorrect",
+        "stsl_styles": [
+          {
+            "ac_ot": null,
+            "ac_ct": null,
+            "ac_type": null,
+            "ac_sm": {
+              "asm_s": 0,
+              "asm_rl": 0
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "composing_decoration",
+        "stsl_styles": [
+          {
+            "cd_u": false,
+            "cd_bgc": {
+              "clr_type": 0,
+              "hclr_color": null
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "composing_region",
+        "stsl_styles": [
+          {
+            "cr_c": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "draft_comment",
+        "stsl_styles": [
+          {
+            "dcs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "ignore_word",
+        "stsl_styles": [
+          {
+            "iwos_i": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "revision_diff",
+        "stsl_styles": [
+          {
+            "revdiff_dt": 0,
+            "revdiff_a": "",
+            "revdiff_aid": ""
+          }
+        ]
+      },
+      {
+        "stsl_type": "smart_todo",
+        "stsl_styles": [
+          {
+            "sts_cid": null,
+            "sts_ot": null,
+            "sts_ac": null,
+            "sts_hi": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_pa": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_dm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "spellcheck",
+        "stsl_styles": [
+          {
+            "sc_ow": null,
+            "sc_sl": null,
+            "sc_sugg": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sc_sm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_corrections",
+        "stsl_styles": [
+          {
+            "vcs_c": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_dotted_span",
+        "stsl_styles": [
+          {
+            "vdss_p": null
+          }
+        ]
+      }
+    ],
+    "dsl_suggestedinsertions": {
+      "sgsl_sugg": [[]]
+    },
+    "dsl_suggesteddeletions": {
+      "sgsl_sugg": [[]]
+    },
+    "dsl_entitypositionmap": {},
+    "dsl_entitymap": {
+      "kix.dko8rpu5p1u6": {
+        "le_nb": {
+          "nl_0": {
+            "b_a": 0,
+            "b_ifl": 18,
+            "b_il": 36,
+            "b_gt": 10,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%0.",
+            "b_gs": "●"
+          },
+          "nl_1": {
+            "b_a": 0,
+            "b_ifl": 54,
+            "b_il": 72,
+            "b_gt": 13,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%1.",
+            "b_gs": "◆"
+          },
+          "nl_2": {
+            "b_a": 2,
+            "b_ifl": 90,
+            "b_il": 108,
+            "b_gt": 15,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%2.",
+            "b_gs": "●"
+          },
+          "nl_3": {
+            "b_a": 0,
+            "b_ifl": 126,
+            "b_il": 144,
+            "b_gt": 10,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%3.",
+            "b_gs": "○"
+          },
+          "nl_4": {
+            "b_a": 0,
+            "b_ifl": 162,
+            "b_il": 180,
+            "b_gt": 13,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%4.",
+            "b_gs": "◆"
+          },
+          "nl_5": {
+            "b_a": 2,
+            "b_ifl": 198,
+            "b_il": 216,
+            "b_gt": 15,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%5.",
+            "b_gs": "●"
+          },
+          "nl_6": {
+            "b_a": 0,
+            "b_ifl": 234,
+            "b_il": 252,
+            "b_gt": 10,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%6.",
+            "b_gs": "○"
+          },
+          "nl_7": {
+            "b_a": 0,
+            "b_ifl": 270,
+            "b_il": 288,
+            "b_gt": 13,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%7.",
+            "b_gs": "◆"
+          },
+          "nl_8": {
+            "b_a": 2,
+            "b_ifl": 306,
+            "b_il": 324,
+            "b_gt": 15,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%8.",
+            "b_gs": "●"
+          }
+        }
+      }
+    },
+    "dsl_entitytypemap": {
+      "kix.dko8rpu5p1u6": "list"
+    },
+    "dsl_relateddocslices": {}
+  },
+  "autotext_content": {}
+}


### PR DESCRIPTION
Switch the GDocs paragraph boundary sequence from two or more new lines
to a single new line character, and convert vertical tabs to linebreaks.

This is more consistent with GDocs formatting rules. Sequences of
multiple new line characters containing interstitial whitespace will be
collapsed into a single paragraph boundary.


Edit: this also adds support for pasting Lists with "interrupting paragraphs" which
can occur in GDocs (Ex https://docs.google.com/document/d/e/2PACX-1vRX6dmzmlW4NtjFj-KlXp3TGQTVyMBVBCVBwO4q9Bwwv8clmULhLmKjGxbz6Lf_qnLEQX9gewoAVJaz/pub)

In those cases we have text that is wrapped in a List but is not contained in any list
item. Because that text will always end in a newline which is now a paragraph separator,
that text will now be wrapped in a paragraph, producing something like:
```
List Item\nInterstitial Text\nList item
^-item--^  ^---paragraph---^  ^-item--^
^-------------- list -----------------^
```

In these cases, when converting we split the list to produce something more reasonable:
```
List Item\nInterstitial Text\nList item[OBJ]
^-item--^  ^---paragraph---^  ^-item--^
^--list---^                   ^---list-----^
```