### PR TITLE
fix: add the CKEditor type definition to the npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "@atjson/source-url": "file:packages/@atjson/source-url"
   },
   "scripts": {
-    "build": "tsc -b packages/**/* --verbose && tsc -b packages/@atjson/**/tsconfig.modules.json --verbose",
+    "build": "tsc -b packages/**/* --verbose && tsc -b packages/@atjson/**/tsconfig.modules.json --verbose && npm run copy-tsd",
+    "copy-tsd": "cp ./packages/@atjson/source-ckeditor/src/ckeditor.d.ts ./packages/@atjson/source-ckeditor/dist/commonjs/ckeditor.d.ts && cp ./packages/@atjson/source-ckeditor/src/ckeditor.d.ts ./packages/@atjson/source-ckeditor/dist/modules/ckeditor.d.ts",
     "clean": "tsc -b packages/**/* --clean && tsc -b packages/@atjson/**/tsconfig.modules.json --clean",
     "lint": "eslint packages/**/src/*.ts packages/**/test/*.ts",
     "lint-fix": "eslint packages/**/src/*.ts packages/**/test/*.ts --fix",


### PR DESCRIPTION
This copies files over to the npm package. It turns out that `tsc` doesn't copy over `.d.ts` files to its output 😭 , which means that we either need to:

1. Convert the type definition file to `.ts`
2. Copy the type definition over _manually_ after building the package.

We're doing the latter bc rewriting the interface to handle `class`es properly is pretty difficult to do correctly.