### PR TITLE
React-renderer: spread annotation children argument

### DIFF
--- a/packages/@atjson/renderer-react/src/index.ts
+++ b/packages/@atjson/renderer-react/src/index.ts
@@ -90,7 +90,7 @@ export default class ReactRenderer extends Renderer {
           return React.createElement(
             AnnotationComponent,
             annotation.attributes,
-            annotationChildren
+            ...annotationChildren
           );
         } else {
           return annotationChildren;


### PR DESCRIPTION
I was investigating an issue in Rocket using atjson and we were seeing this when trying to render `HorizontalRule` annotations into `hr` tags:

``Error: hr is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`.``

I believe there may be a few forces at play here that create this issue in the particular implementation, as I'm unable to reproduce a test case that can create this error in the tests here, but that may be because the component structure is different enough that it's hard to force the same error.

Regardless, in looking at the renderer implementation, I realized we likely want to spread on the `children` argument to match the `createElement` implementation specified in the [React docs](https://reactjs.org/docs/react-api.html#createelement), so I've done that here. Previously we would have been passing in an empty array (a truthy val) for this arg but the spread makes this a falsy value and  thus React doesn't think it has children. Making this change in Rocket fixed the issue.

Tests still pass, but if there's an easy way to re-create the issue so we can test against it, let's talk!