### PR TITLE
chore: store vendorPrefix on annotation instances

### DIFF
--- a/packages/@atjson/document/src/annotation.ts
+++ b/packages/@atjson/document/src/annotation.ts
@@ -142,6 +142,7 @@ export abstract class Annotation<Attributes = {}> {
   }
 
   readonly type: string;
+  readonly vendorPrefix: string;
   abstract get rank(): number;
   id: string;
   start: number;
@@ -156,6 +157,7 @@ export abstract class Annotation<Attributes = {}> {
   }) {
     let AnnotationClass = this.getAnnotationConstructor();
     this.type = AnnotationClass.type;
+    this.vendorPrefix = AnnotationClass.vendorPrefix;
     this.id = attrs.id || uuid();
     this.start = attrs.start;
     this.end = attrs.end;
@@ -172,9 +174,6 @@ export abstract class Annotation<Attributes = {}> {
   }
 
   equals(annotationToCompare: Annotation<any>): boolean {
-    let AnnotationClass = this.getAnnotationConstructor();
-    let AnnotationToCompareClass = annotationToCompare.getAnnotationConstructor();
-
     let lhsAnnotationAttributes = removeUndefinedValuesFromObject(
       this.attributes
     );
@@ -186,7 +185,7 @@ export abstract class Annotation<Attributes = {}> {
       this.start === annotationToCompare.start &&
       this.end === annotationToCompare.end &&
       this.type === annotationToCompare.type &&
-      AnnotationClass.vendorPrefix === AnnotationToCompareClass.vendorPrefix &&
+      this.vendorPrefix === annotationToCompare.vendorPrefix &&
       areAttributesEqual(lhsAnnotationAttributes, rhsAnnotationAttributes)
     );
   }
@@ -297,14 +296,12 @@ export abstract class Annotation<Attributes = {}> {
   }
 
   toJSON() {
-    let AnnotationClass = this.getAnnotationConstructor();
-    let vendorPrefix = AnnotationClass.vendorPrefix;
     return {
       id: this.id,
-      type: `-${vendorPrefix}-${this.type}`,
+      type: `-${this.vendorPrefix}-${this.type}`,
       start: this.start,
       end: this.end,
-      attributes: toJSON(vendorPrefix, this.attributes)
+      attributes: toJSON(this.vendorPrefix, this.attributes)
     };
   }
 }

--- a/packages/@atjson/document/src/collection.ts
+++ b/packages/@atjson/document/src/collection.ts
@@ -84,12 +84,10 @@ export class Collection {
     if (Object.keys(filter).length === 1 && filter.type != null) {
       let annotations = [];
       for (let a of this.annotations) {
-        let annotationClass = a.getAnnotationConstructor();
-        let vendorPrefix = annotationClass.vendorPrefix;
         if (
-          filter.type === `-${vendorPrefix}-${a.type}` ||
+          filter.type === `-${a.vendorPrefix}-${a.type}` ||
           (a.type === "unknown" &&
-            vendorPrefix === "atjson" &&
+            a.vendorPrefix === "atjson" &&
             a.attributes.type === filter.type)
         ) {
           annotations.push(a);

--- a/packages/@atjson/document/src/document.ts
+++ b/packages/@atjson/document/src/document.ts
@@ -617,8 +617,10 @@ export class Document {
     let parseTokensToDelete = [];
 
     for (let annotation of canonicalDoc.annotations) {
-      let vendorPrefix = annotation.getAnnotationConstructor().vendorPrefix;
-      if (vendorPrefix === "atjson" && annotation.type === "parse-token") {
+      if (
+        annotation.vendorPrefix === "atjson" &&
+        annotation.type === "parse-token"
+      ) {
         parseTokensToDelete.push(annotation);
       }
     }

--- a/packages/@atjson/document/src/utils.ts
+++ b/packages/@atjson/document/src/utils.ts
@@ -14,6 +14,6 @@ export function is<
   return (
     annotation &&
     annotation.type === Class.type &&
-    annotation.getAnnotationConstructor().vendorPrefix === Class.vendorPrefix
+    annotation.vendorPrefix === Class.vendorPrefix
   );
 }

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -39,18 +39,16 @@ function getEnd(a: { end: number }) {
 function isParseAnnotation(
   annotation: Annotation<any>
 ): annotation is ParseAnnotation {
-  let constructor = annotation.getAnnotationConstructor();
   return (
-    constructor.vendorPrefix === "atjson" && annotation.type === "parse-token"
+    annotation.vendorPrefix === "atjson" && annotation.type === "parse-token"
   );
 }
 
 function isParseOrUnknown(
   annotation: Annotation<any>
 ): annotation is ParseAnnotation | UnknownAnnotation {
-  let constructor = annotation.getAnnotationConstructor();
   return (
-    constructor.vendorPrefix === "atjson" &&
+    annotation.vendorPrefix === "atjson" &&
     (annotation.type === "parse-token" || annotation.type === "unknown")
   );
 }

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -69,9 +69,7 @@ export interface Context {
 }
 
 function isTextAnnotation(a: Annotation<any>): a is TextAnnotation {
-  return (
-    a.getAnnotationConstructor().vendorPrefix === "atjson" && a.type === "text"
-  );
+  return a.vendorPrefix === "atjson" && a.type === "text";
 }
 
 function compile(

--- a/packages/@atjson/source-html/src/converter/video-embeds.ts
+++ b/packages/@atjson/source-html/src/converter/video-embeds.ts
@@ -1,4 +1,4 @@
-import Document, { Annotation, AnnotationConstructor } from "@atjson/document";
+import Document, { Annotation, is } from "@atjson/document";
 import OffsetSource, {
   getClosestAspectRatio,
   VideoEmbed,
@@ -15,17 +15,6 @@ function assert(value: any, message: string): asserts value {
   if (!value) {
     throw new Error(message);
   }
-}
-
-function is<T extends AnnotationConstructor<any, any>>(
-  annotation: Annotation<any>,
-  Class: T
-): annotation is InstanceType<T> {
-  let AnnotationClass = annotation.getAnnotationConstructor();
-  return (
-    AnnotationClass.vendorPrefix === Class.vendorPrefix &&
-    annotation.type === Class.type
-  );
 }
 
 function isIframe(annotation: Annotation<any>) {


### PR DESCRIPTION
This will reduce calls to annotation.constructor, which had some wacky type coercion going on, and was a lookup that could be saved in many cases.