### PR TITLE
Add provider attribute to video embeds

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/video-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/video-embed.ts
@@ -1,4 +1,5 @@
 import { ObjectAnnotation } from "@atjson/document";
+import { VideoURLs } from "@atjson/offset-annotations";
 import { CaptionSource } from "./caption-source";
 import { getClosestAspectRatio } from "../utils";
 
@@ -7,6 +8,10 @@ export class VideoEmbed extends ObjectAnnotation<{
    * The embed URL of the video
    */
   url: string;
+  /**
+   * The provider of the Video
+   */
+  provider: VideoURLs.Provider;
   /**
    * A normalized aspect ratio of the video, constrained to
    * a list of aspect ratios

--- a/packages/@atjson/offset-annotations/src/annotations/video-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/video-embed.ts
@@ -1,7 +1,6 @@
 import { ObjectAnnotation } from "@atjson/document";
-import { VideoURLs } from "@atjson/offset-annotations";
 import { CaptionSource } from "./caption-source";
-import { getClosestAspectRatio } from "../utils";
+import { getClosestAspectRatio, VideoURLs } from "../utils";
 
 export class VideoEmbed extends ObjectAnnotation<{
   /**

--- a/packages/@atjson/offset-annotations/src/utils/video-urls.ts
+++ b/packages/@atjson/offset-annotations/src/utils/video-urls.ts
@@ -176,21 +176,40 @@ function isBrightcoveURL(url: IUrl) {
   );
 }
 
+export enum Provider {
+  YOUTUBE,
+  VIMEO,
+  BRIGHTCOVE,
+  DAILYMOTION
+}
+
 export function identify(url: IUrl) {
   if (isYouTubeURL(url)) {
-    return normalizeYouTubeURL(url);
+    return {
+      provider: Provider.YOUTUBE,
+      url: normalizeYouTubeURL(url)
+    };
   }
 
   if (isVimeoURL(url)) {
-    return normalizeVimeoURL(url);
+    return {
+      provider: Provider.VIMEO,
+      url: normalizeVimeoURL(url)
+    };
   }
 
   if (isDailymotionURL(url)) {
-    return normalizeDailymotionURL(url);
+    return {
+      provider: Provider.DAILYMOTION,
+      url: normalizeDailymotionURL(url)
+    };
   }
 
   if (isBrightcoveURL(url)) {
-    return toURL(url);
+    return {
+      provider: Provider.BRIGHTCOVE,
+      url: toURL(url)
+    };
   }
 
   return null;

--- a/packages/@atjson/offset-annotations/src/utils/video-urls.ts
+++ b/packages/@atjson/offset-annotations/src/utils/video-urls.ts
@@ -177,10 +177,11 @@ function isBrightcoveURL(url: IUrl) {
 }
 
 export enum Provider {
-  YOUTUBE,
-  VIMEO,
-  BRIGHTCOVE,
-  DAILYMOTION
+  YOUTUBE = "YOUTUBE",
+  VIMEO = "VIMEO",
+  BRIGHTCOVE = "BRIGHTCOVE",
+  DAILYMOTION = "DAILYMOTION",
+  OTHER = "OTHER"
 }
 
 export function identify(url: IUrl) {

--- a/packages/@atjson/offset-annotations/test/video-canonicalisation-test.ts
+++ b/packages/@atjson/offset-annotations/test/video-canonicalisation-test.ts
@@ -6,7 +6,10 @@ describe("VideoURLs", () => {
       "https://players.brightcove.net/635709154001/default_default/index.html?videoId=4898526370001",
       "https://players.brightcove.net/635709154001/default_default/index.html?videoId=5648767050001"
     ])("%s", url => {
-      expect(VideoURLs.identify(new URL(url))).toEqual(url);
+      expect(VideoURLs.identify(new URL(url))).toEqual({
+        url,
+        provider: VideoURLs.Provider.BRIGHTCOVE
+      });
     });
   });
 
@@ -15,9 +18,10 @@ describe("VideoURLs", () => {
       "https://www.dailymotion.com/video/x73oxxw",
       "https://www.dailymotion.com/embed/video/x73oxxw"
     ])("%s", url => {
-      expect(VideoURLs.identify(new URL(url))).toEqual(
-        "https://www.dailymotion.com/embed/video/x73oxxw"
-      );
+      expect(VideoURLs.identify(new URL(url))).toEqual({
+        url: "https://www.dailymotion.com/embed/video/x73oxxw",
+        provider: VideoURLs.Provider.DAILYMOTION
+      });
     });
   });
 
@@ -28,9 +32,10 @@ describe("VideoURLs", () => {
       "http://vimeo.com/156254412",
       "http://player.vimeo.com/video/156254412"
     ])("%s", url => {
-      expect(VideoURLs.identify(new URL(url))).toEqual(
-        "https://player.vimeo.com/video/156254412"
-      );
+      expect(VideoURLs.identify(new URL(url))).toEqual({
+        url: "https://player.vimeo.com/video/156254412",
+        provider: VideoURLs.Provider.VIMEO
+      });
     });
   });
 
@@ -41,9 +46,10 @@ describe("VideoURLs", () => {
       "https://youtu.be/Mh5LY4Mz15o",
       "https://www.youtube.com/embed/Mh5LY4Mz15o"
     ])("%s", url => {
-      expect(VideoURLs.identify(new URL(url))).toEqual(
-        "https://www.youtube.com/embed/Mh5LY4Mz15o"
-      );
+      expect(VideoURLs.identify(new URL(url))).toEqual({
+        url: "https://www.youtube.com/embed/Mh5LY4Mz15o",
+        provider: VideoURLs.Provider.YOUTUBE
+      });
     });
   });
 });

--- a/packages/@atjson/source-html/src/converter/video-embeds.ts
+++ b/packages/@atjson/source-html/src/converter/video-embeds.ts
@@ -79,9 +79,9 @@ export default function(doc: Document) {
       if (src?.indexOf("//") === 0) {
         src = `https:${src}`;
       }
-      let url = VideoURLs.identify(new URL(src));
+      let urlAttributes = VideoURLs.identify(new URL(src));
       assert(
-        url,
+        urlAttributes && urlAttributes.url,
         `The Vimeo embed ${video.attributes.src} was definitely defined in our queries, but was not identified.`
       );
 
@@ -100,7 +100,7 @@ export default function(doc: Document) {
           start: video.start,
           end: video.end,
           attributes: {
-            url,
+            ...urlAttributes,
             width,
             height,
             aspectRatio:
@@ -149,6 +149,7 @@ export default function(doc: Document) {
           end: video.end,
           attributes: {
             url: video.attributes.src,
+            provider: VideoURLs.Provider.BRIGHTCOVE,
             width,
             height,
             aspectRatio:
@@ -164,8 +165,8 @@ export default function(doc: Document) {
     if (src?.indexOf("//") === 0) {
       src = `https:${src}`;
     }
-    let url = VideoURLs.identify(new URL(src));
-    if (url) {
+    let urlAttributes = VideoURLs.identify(new URL(src));
+    if (urlAttributes) {
       let width = getSize(iframe, "width");
       let height = getSize(iframe, "height");
 
@@ -175,7 +176,7 @@ export default function(doc: Document) {
           start: iframe.start,
           end: iframe.end,
           attributes: {
-            url,
+            ...urlAttributes,
             width,
             height,
             aspectRatio:

--- a/packages/@atjson/source-html/test/converter-test.ts
+++ b/packages/@atjson/source-html/test/converter-test.ts
@@ -591,7 +591,7 @@ describe("@atjson/source-html", () => {
     });
 
     describe("video embeds", () => {
-      describe.only("YouTube", () => {
+      describe("YouTube", () => {
         test.each([
           ["https://www.youtube.com/embed/0-jus6AGHzQ"],
           ["https://www.youtube-nocookie.com/embed/0-jus6AGHzQ?controls=0"],
@@ -642,6 +642,7 @@ describe("@atjson/source-html", () => {
             type: "video-embed",
             attributes: {
               url: "https://player.vimeo.com/video/156254412",
+              provider: VideoURLs.Provider.VIMEO,
               width: 640,
               height: 480,
               aspectRatio: "4:3"
@@ -666,6 +667,7 @@ describe("@atjson/source-html", () => {
             type: "video-embed",
             attributes: {
               url: "https://player.vimeo.com/video/156254412",
+              provider: VideoURLs.Provider.VIMEO,
               width: 640,
               height: 480,
               aspectRatio: "4:3"
@@ -686,6 +688,7 @@ describe("@atjson/source-html", () => {
             type: "video-embed",
             attributes: {
               url: "https://player.vimeo.com/video/156254412",
+              provider: VideoURLs.Provider.VIMEO,
               width: 640,
               height: 480,
               aspectRatio: "4:3"
@@ -706,6 +709,7 @@ describe("@atjson/source-html", () => {
                 type: "video-embed",
                 attributes: {
                   url: "https://player.vimeo.com/video/156254412",
+                  provider: VideoURLs.Provider.VIMEO,
                   width: 640,
                   height: 480,
                   aspectRatio: "4:3"
@@ -729,6 +733,7 @@ describe("@atjson/source-html", () => {
             type: "video-embed",
             attributes: {
               url: "https://www.dailymotion.com/embed/video/x6gmvnp",
+              provider: VideoURLs.Provider.DAILYMOTION,
               width: 480,
               height: 270,
               aspectRatio: "16:9"
@@ -759,6 +764,7 @@ describe("@atjson/source-html", () => {
             attributes: {
               url:
                 "https://players.brightcove.net/1752604059001/default_default/index.html?videoId=5802784116001",
+              provider: VideoURLs.Provider.BRIGHTCOVE,
               width: 640,
               height: 360,
               aspectRatio: "16:9"

--- a/packages/@atjson/source-html/test/converter-test.ts
+++ b/packages/@atjson/source-html/test/converter-test.ts
@@ -1,5 +1,5 @@
 import { HIR } from "@atjson/hir";
-import OffsetSource from "@atjson/offset-annotations";
+import OffsetSource, { VideoURLs } from "@atjson/offset-annotations";
 import HTMLSource from "../src";
 
 describe("@atjson/source-html", () => {
@@ -591,7 +591,7 @@ describe("@atjson/source-html", () => {
     });
 
     describe("video embeds", () => {
-      describe("YouTube", () => {
+      describe.only("YouTube", () => {
         test.each([
           ["https://www.youtube.com/embed/0-jus6AGHzQ"],
           ["https://www.youtube-nocookie.com/embed/0-jus6AGHzQ?controls=0"],
@@ -616,6 +616,7 @@ describe("@atjson/source-html", () => {
                 type: "video-embed",
                 attributes: {
                   url,
+                  provider: VideoURLs.Provider.YOUTUBE,
                   width: 560,
                   height: 315,
                   aspectRatio: "16:9"

--- a/packages/@atjson/source-url/src/converter.ts
+++ b/packages/@atjson/source-url/src/converter.ts
@@ -31,18 +31,16 @@ URLSource.defineConverterTo(OffsetSource, doc => {
 
   doc
     .where(isURL)
-    .update(function identifyAndReplaceVidoURLs(annotation: URLAnnotation) {
-      let url = VideoURLs.identify(annotation.attributes);
-      if (url) {
+    .update(function identifyAndReplaceVideoURLs(annotation: URLAnnotation) {
+      let urlAttributes = VideoURLs.identify(annotation.attributes);
+      if (urlAttributes) {
         doc.replaceAnnotation(
           annotation,
           new VideoEmbed({
             id: annotation.id,
             start: annotation.start,
             end: annotation.end,
-            attributes: {
-              url
-            }
+            attributes: urlAttributes
           })
         );
       } else {


### PR DESCRIPTION
Since atjson is already going through the trouble of normalizing these URLs and figuring out the providers, we wanted to take it a step further on consuming applications and add a `provider` attribute that will allow us to conditionally render based on the video provider. This is mostly relevant for AMP, where we need to use a different video component per provider source.

I'm assuming this should be considered a breaking change since downstream applications / converters / etc. will need to adjust any instance where they call `VideoURLs.identify`.