### PR TITLE
Source ck from document

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1823,6 +1823,25 @@
       "integrity": "sha512-LBJk8jWKONs3BZSjgNbZbDEEgC2AD1z53sUfrduEkV5TCdYOlf+Ys0qF23MnNrfu1lwtVd6LfunS3AKymHQIiw==",
       "dev": true
     },
+    "@ckeditor/ckeditor5-engine": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-17.0.0.tgz",
+      "integrity": "sha512-3+m7Hc1QCn97JHLjJWRYg2GcI9hTcU3XGSZnsLeolyPgwBbEnkvfUGId2K5O91Bg3SKkSP4vgvydZE9JM2Q7Mg==",
+      "dev": true,
+      "requires": {
+        "@ckeditor/ckeditor5-utils": "^17.0.0",
+        "lodash-es": "^4.17.10"
+      }
+    },
+    "@ckeditor/ckeditor5-utils": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-17.0.0.tgz",
+      "integrity": "sha512-La9Au5pvafUi4uN3Zxjb6HLdacZLMkC+KerWQEohPhZYHRmy8OusaGB+X74gYRKb6O+vGfxpbgSA93e3VoE3fQ==",
+      "dev": true,
+      "requires": {
+        "lodash-es": "^4.17.10"
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -12698,6 +12717,12 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash-es": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
       "dev": true
     },
     "lodash._reinterpolate": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@babel/preset-react": "7.9.4",
     "@babel/preset-typescript": "7.9.0",
     "@ckeditor/ckeditor5-build-classic": "17.0.0",
+    "@ckeditor/ckeditor5-engine": "17.0.0",
     "@commitlint/cli": "8.3.5",
     "@commitlint/config-conventional": "8.3.4",
     "@condenast/perf-kit": "0.1.2",
@@ -107,6 +108,9 @@
     "testURL": "http://localhost",
     "testMatch": [
       "**/*-test.(ts|tsx|js|jsx)"
+    ],
+    "transformIgnorePatterns": [
+      "/node_modules/(?!@ckeditor).+\\.js$"
     ]
   },
   "husky": {

--- a/packages/@atjson/source-ckeditor/CHANGELOG.md
+++ b/packages/@atjson/source-ckeditor/CHANGELOG.md
@@ -3,37 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.2.0-dev.0](https://github.com/CondeNast/atjson/compare/@atjson/source-ckeditor@0.1.6...@atjson/source-ckeditor@0.2.0-dev.0) (2020-03-31)
+
+### Features
+
+- update fromRaw to accept doc or docFragment ([2a45912](https://github.com/CondeNast/atjson/commit/2a45912796a2c7ec043acf6ef227337b50e3754f))
+
 ## [0.1.6](https://github.com/CondeNast/atjson/compare/@atjson/source-ckeditor@0.1.5...@atjson/source-ckeditor@0.1.6) (2020-03-26)
 
 **Note:** Version bump only for package @atjson/source-ckeditor
-
-
-
-
 
 ## [0.1.5](https://github.com/CondeNast/atjson/compare/@atjson/source-ckeditor@0.1.4...@atjson/source-ckeditor@0.1.5) (2020-03-26)
 
 **Note:** Version bump only for package @atjson/source-ckeditor
 
-
-
-
-
 ## [0.1.4](https://github.com/CondeNast/atjson/compare/@atjson/source-ckeditor@0.1.3...@atjson/source-ckeditor@0.1.4) (2020-03-25)
 
 **Note:** Version bump only for package @atjson/source-ckeditor
 
-
-
-
-
 ## [0.1.4-dev.0](https://github.com/CondeNast/atjson/compare/@atjson/source-ckeditor@0.1.3...@atjson/source-ckeditor@0.1.4-dev.0) (2020-03-23)
 
 **Note:** Version bump only for package @atjson/source-ckeditor
-
-
-
-
 
 ## [0.1.3](https://github.com/CondeNast/atjson/compare/@atjson/source-ckeditor@0.1.2...@atjson/source-ckeditor@0.1.3) (2020-03-17)
 

--- a/packages/@atjson/source-ckeditor/bin/index.ts
+++ b/packages/@atjson/source-ckeditor/bin/index.ts
@@ -7,7 +7,7 @@ import minimist from "minimist";
 import * as CK from "../src/ckeditor";
 
 let dom = new JSDOM(``, {
-  url: "https://atjson.condenast.io"
+  url: "https://atjson.condenast.io",
 });
 
 (global as any).window = dom.window;
@@ -19,8 +19,8 @@ let dom = new JSDOM(``, {
   "DOMParser",
   "HTMLElement",
   "HTMLTextAreaElement",
-  "Node"
-].forEach(key => {
+  "Node",
+].forEach((key) => {
   (global as any)[key] = (dom.window as any)[key];
 });
 
@@ -35,7 +35,7 @@ function classify(name: string) {
 }
 
 function dasherize(name: string) {
-  return name.replace(/([A-Z])/g, chr => `-${chr.toLowerCase()}`);
+  return name.replace(/([A-Z])/g, (chr) => `-${chr.toLowerCase()}`);
 }
 
 function writeAnnotationFile(
@@ -55,7 +55,7 @@ import { ${AnnotationClass} } from "@atjson/document";
 export class ${classify(name)} extends ${AnnotationClass}${
           attributes.length
             ? `<{
-  ${attributes.map(attribute => `${attribute}: unknown;`).join("\n")}
+  ${attributes.map((attribute) => `${attribute}: unknown;`).join("\n")}
 }>`
             : ""
         } {
@@ -93,7 +93,7 @@ function writeAnnotationIndex(
     join(dir, "annotations", `index.${extension}`),
     format(
       `${schemas
-        .map(schema => `export * from "./${dasherize(schema.name)}";`)
+        .map((schema) => `export * from "./${dasherize(schema.name)}";`)
         .join("\n")}`,
       { parser: parser }
     )
@@ -114,8 +114,8 @@ import CKEditorSource, { CK } from "@atjson/source-ckeditor";
 import * as annotations from "./annotations";
 
 export default class ${ClassName} extends CKEditorSource {
-  static fromRaw(model: CK.Model, rootName = "main") {
-      return new this(this.fromModel(model, rootName));
+  static fromRaw(doc: CK.Document | CK.DocumentFragment, rootName?: string) {
+    return new this(this.fromDocument(doc, rootName));
   }
 
   static schema = [...Object.values(annotations)];
@@ -162,7 +162,7 @@ export default ${name};
 
 function run() {
   const args = minimist(process.argv.slice(2), {
-    string: ["out", "name", "buildPackage", "buildName", "language"]
+    string: ["out", "name", "buildPackage", "buildName", "language"],
   });
 
   let options = {
@@ -170,7 +170,7 @@ function run() {
     buildPackage: args.buildPackage || "@ckeditor/ckeditor5-build-classic",
     buildName: args.buildName || "default",
     out: join(process.cwd(), args.out || "test"),
-    name: args.name || "CKEditorClassicBuildSource"
+    name: args.name || "CKEditorClassicBuildSource",
   };
 
   console.info("Generating CKEditorSource with args:\n", options);
@@ -191,7 +191,7 @@ function run() {
     const fileInfo = {
       extension: language === "typescript" ? "ts" : "js",
       parser: language === "javascript" ? "babel" : "typescript",
-      dir: options.out
+      dir: options.out,
     } as FileInfo;
 
     let div = dom.window.document.createElement("div");
@@ -242,7 +242,7 @@ function run() {
 
 run()
   .then(() => process.exit(1))
-  .catch(e => {
+  .catch((e) => {
     console.error(e);
     process.exit(0);
   });

--- a/packages/@atjson/source-ckeditor/package.json
+++ b/packages/@atjson/source-ckeditor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/source-ckeditor",
-  "version": "0.1.6",
+  "version": "0.2.0-dev.0",
   "description": "Create atjson documents from a CKEditor5 document.",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",

--- a/packages/@atjson/source-ckeditor/package.json
+++ b/packages/@atjson/source-ckeditor/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@atjson/document": "file:../document",
     "@ckeditor/ckeditor5-build-classic": "*",
+    "@ckeditor/ckeditor5-engine": "*",
     "@types/jsdom": "*",
     "@types/minimist": "*",
     "@types/prettier": "*",

--- a/packages/@atjson/source-ckeditor/src/ckeditor.ts
+++ b/packages/@atjson/source-ckeditor/src/ckeditor.ts
@@ -238,6 +238,10 @@ export interface DocumentFragment {
   toJSON(): object;
 }
 
+export interface DocumentFragmentConstructor {
+  fromJSON(json: object[]): DocumentFragment;
+}
+
 export type PositionStickiness = "toNone" | "toNext" | "toPrevious";
 export type PositionRelation = "before" | "after" | "same";
 

--- a/packages/@atjson/source-ckeditor/src/source.ts
+++ b/packages/@atjson/source-ckeditor/src/source.ts
@@ -1,9 +1,9 @@
 import Document, { AnnotationJSON, ParseAnnotation } from "@atjson/document";
 import * as CK from "./ckeditor";
-import { isTextNode, isElement } from "./utils";
+import { isTextNode, isElement, isNode, isDocumentFragment } from "./utils";
 
 function fromNode(
-  node: CK.Node | null,
+  node: CK.Node | CK.DocumentFragment | null,
   { content, annotations }: { content: string; annotations: AnnotationJSON[] }
 ) {
   if (!node) {
@@ -12,8 +12,10 @@ function fromNode(
 
   let start = content.length;
   let attributes = {} as { [index: string]: any };
-  for (let [key, value] of node.getAttributes()) {
-    attributes[`-ckeditor-${key}`] = value;
+  if (isNode(node)) {
+    for (let [key, value] of node.getAttributes()) {
+      attributes[`-ckeditor-${key}`] = value;
+    }
   }
 
   if (isTextNode(node)) {
@@ -24,36 +26,38 @@ function fromNode(
       type: "-ckeditor-$text",
       attributes,
     });
-  } else if (isElement(node)) {
-    let openTag = `<${node.name}>`;
+  } else if (isElement(node) || isDocumentFragment(node)) {
+    let name = isElement(node) ? node.name : "$root";
+
+    let openTag = `<${name}>`;
     content += openTag;
     annotations.push(
       new ParseAnnotation({
         start: content.length - openTag.length,
         end: content.length,
         attributes: {
-          reason: `${node.name}_open`,
+          reason: `${name}_open`,
         },
       })
     );
     for (let child of node.getChildren()) {
       ({ content, annotations } = fromNode(child, { content, annotations }));
     }
-    let closeTag = `</${node.name}>`;
+    let closeTag = `</${name}>`;
     content += closeTag;
     annotations.push(
       new ParseAnnotation({
         start: content.length - closeTag.length,
         end: content.length,
         attributes: {
-          reason: `${node.name}_close`,
+          reason: `${name}_close`,
         },
       })
     );
     annotations.push({
       start,
       end: content.length,
-      type: `-ckeditor-${node.name}`,
+      type: `-ckeditor-${name}`,
       attributes,
     });
   }
@@ -62,8 +66,13 @@ function fromNode(
 }
 
 export default abstract class CKEditorSource extends Document {
-  static fromModel(model: CK.Model, rootName = "main") {
-    let root = model.document.getRoot(rootName);
+  static fromDocument(
+    doc: CK.DocumentFragment | CK.Document,
+    rootName = "main"
+  ) {
+    let root = (doc as CK.DocumentFragment).root
+      ? (doc as CK.DocumentFragment).root
+      : (doc as CK.Document).getRoot(rootName);
     let annotations: AnnotationJSON[] = [];
     let content = "";
 

--- a/packages/@atjson/source-ckeditor/src/types/@ckeditor/ckeditor5-engine/index.d.ts
+++ b/packages/@atjson/source-ckeditor/src/types/@ckeditor/ckeditor5-engine/index.d.ts
@@ -1,0 +1,8 @@
+declare module "@ckeditor/ckeditor5-engine/src/model/documentfragment" {
+  import CK from "../../../ckeditor";
+  declare class DocumentFragment implements CK.DocumentFragment {
+    static fromJSON(json: object[]): CK.DocumentFragment;
+  }
+
+  export default DocumentFragment;
+}

--- a/packages/@atjson/source-ckeditor/src/utils.ts
+++ b/packages/@atjson/source-ckeditor/src/utils.ts
@@ -1,13 +1,29 @@
 import * as CK from "./ckeditor";
 
-export function isTextNode(node: CK.Node): node is CK.TextNode {
+export function isTextNode(
+  node: CK.Node | CK.DocumentFragment
+): node is CK.TextNode {
   return node.is("text");
 }
 
-export function isRootElement(node: CK.Node): node is CK.RootElement {
+export function isRootElement(
+  node: CK.Node | CK.DocumentFragment
+): node is CK.RootElement {
   return node.is("rootElement");
 }
 
-export function isElement(node: CK.Node): node is CK.Element {
+export function isElement(
+  node: CK.Node | CK.DocumentFragment
+): node is CK.Element {
   return node.is("element");
+}
+
+export function isNode(node: CK.Node | CK.DocumentFragment): node is CK.Node {
+  return node.is("node");
+}
+
+export function isDocumentFragment(
+  node: CK.Node | CK.DocumentFragment
+): node is CK.DocumentFragment {
+  return node.is("documentFragment");
 }

--- a/packages/@atjson/source-ckeditor/test/source-ckeditor-build-classic/source.ts
+++ b/packages/@atjson/source-ckeditor/test/source-ckeditor-build-classic/source.ts
@@ -3,8 +3,8 @@ import CKEditorSource, { CK } from "../../src";
 import * as annotations from "./annotations";
 
 export default class CKEditorTestSource extends CKEditorSource {
-  static fromRaw(model: CK.Model, rootName = "main") {
-    return new this(this.fromModel(model, rootName));
+  static fromRaw(doc: CK.Document | CK.DocumentFragment, rootName?: string) {
+    return new this(this.fromDocument(doc, rootName));
   }
 
   static schema = [...Object.values(annotations)];

--- a/website/docs/ckeditor-source.md
+++ b/website/docs/ckeditor-source.md
@@ -33,3 +33,45 @@ the `@ckeditor/ckeditor5-build-classic` editor build via running:
 ```
 ts-node bin/index.ts --out=test/source-ckeditor-build-classic --name=CKEditorTestSource --buildPackage=@ckeditor/ckeditor5-build-classic --buildName=default --language=ts
 ```
+
+Once the tool has run and generated a concrete implementation of an atjson source for your build, you can use it by
+calling the static method `fromRaw` and passing either a CK [DocumentFragment](https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_model_documentfragment-DocumentFragment.html) or a CK [Model Document](https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_model_document-Document.html) along with the root from the document. As an example, see the tests written in
+`/test/source-classic-build-test.ts`:
+
+```
+import DocumentFragment from "@ckeditor/ckeditor5-engine/src/model/documentfragment";
+import CKEditorSource from "./source-ckeditor-build-classic";
+
+test("single paragraph", () => {
+  let ckDoc = DocumentFragment.fromJSON([
+    {
+      name: "paragraph",
+      children: [
+        {
+          data: "Here is a paragraph",
+        },
+      ],
+    },
+  ]);
+  let doc = CKEditorSource.fromRaw(ckDoc).canonical();
+
+  expect(doc.content).toBe("Here is a paragraph");
+  expect(doc.canonical().annotations.sort(compareAnnotations)).toMatchObject([
+    {
+      type: "$root",
+      start: 0,
+      end: 19,
+    },
+    {
+      type: "$text",
+      start: 0,
+      end: 19,
+    },
+    {
+      type: "paragraph",
+      start: 0,
+      end: 19,
+    },
+  ]);
+});
+```


### PR DESCRIPTION
Update the CKEditor Source so we can `fromRaw` using a CK Document or DocumentFragment. We want to be able to do this because:

1.) We can generate a document fragment without using an instance of an Editor build
2.) We can generate a CKEditor Source document from a subtree of a model document (which we might need to do for captions, for example)