### PR TITLE
fix: preserve original document sort in canonical

### DIFF
--- a/packages/@atjson/document/src/document.ts
+++ b/packages/@atjson/document/src/document.ts
@@ -614,6 +614,11 @@ export class Document {
     let canonicalDoc = this.clone();
     let parseTokensToDelete = [];
 
+    // preserve order in the original document before
+    // modifying it, as deleting text ranges may collapse
+    // annotations onto each other
+    canonicalDoc.annotations.sort(compareAnnotations);
+
     for (let annotation of canonicalDoc.annotations) {
       if (
         annotation.vendorPrefix === "atjson" &&
@@ -625,8 +630,6 @@ export class Document {
 
     canonicalDoc.removeAnnotations(parseTokensToDelete);
     canonicalDoc.deleteTextRanges(parseTokensToDelete);
-
-    canonicalDoc.annotations.sort(compareAnnotations);
 
     return canonicalDoc;
   }

--- a/packages/@atjson/source-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/source-commonmark/test/commonmark-test.ts
@@ -142,14 +142,14 @@ describe("images", () => {
     ).canonical();
     expect(doc.annotations).toMatchObject([
       {
+        type: "paragraph",
+      },
+      {
         type: "image",
         attributes: {
           src: "test.jpg",
           alt: "Markdown is stripped from this",
         },
-      },
-      {
-        type: "paragraph",
       },
     ]);
   });
@@ -160,15 +160,15 @@ describe("images", () => {
     ).canonical();
     expect(doc.annotations).toMatchObject([
       {
+        type: "paragraph",
+      },
+      {
         type: "image",
         attributes: {
           src: "test.jpg",
           title: "Title of test.jpg",
           alt: "",
         },
-      },
-      {
-        type: "paragraph",
       },
     ]);
   });

--- a/packages/@atjson/source-html/test/source-html-test.ts
+++ b/packages/@atjson/source-html/test/source-html-test.ts
@@ -384,17 +384,17 @@ describe("@atjson/source-html", () => {
     expect(canonical.content).toEqual("Hello");
     expect(canonical.annotations).toMatchObject([
       {
-        type: "body",
-        start: 0,
-        end: 5,
-      },
-      {
         type: "html",
         start: 0,
         end: 5,
         attributes: {
           lang: "en",
         },
+      },
+      {
+        type: "body",
+        start: 0,
+        end: 5,
       },
     ]);
   });
@@ -418,17 +418,17 @@ describe("@atjson/source-html", () => {
     expect(canonical.content).toEqual("  \tHello");
     expect(canonical.annotations).toMatchObject([
       {
-        type: "body",
-        start: 3,
-        end: 8,
-      },
-      {
         type: "html",
         start: 3,
         end: 8,
         attributes: {
           lang: "en",
         },
+      },
+      {
+        type: "body",
+        start: 3,
+        end: 8,
       },
     ]);
   });
@@ -448,17 +448,17 @@ describe("@atjson/source-html", () => {
     expect(canonical.content).toEqual("Hello");
     expect(canonical.annotations).toMatchObject([
       {
-        type: "body",
-        start: 0,
-        end: 5,
-      },
-      {
         type: "html",
         start: 0,
         end: 5,
         attributes: {
           lang: "en",
         },
+      },
+      {
+        type: "body",
+        start: 0,
+        end: 5,
       },
     ]);
   });


### PR DESCRIPTION
Sort annotations in a canonical document before deleting any text ranges, as that may cause annotations to collapse onto each other, at which point it is not possible to recover their sorting position in the original document.

We may later want to perform something more sophisticated to prevent the collapsing annotations altogether, such as selectively keeping some text that might lie under a parse annotation if it is necessary to preserve the order of other annotations in a document. Because even checking for that may be a large performance impact, we'd rather have Sources not create parse annotations like these in the first place, either in their `fromRaw` or `convertTo` steps, but this seems like a reasonable safeguard. 