### PR TITLE
Default sort

### DIFF
--- a/packages/@atjson/document/src/collection.ts
+++ b/packages/@atjson/document/src/collection.ts
@@ -2,10 +2,15 @@ import { Annotation, AnnotationJSON, Document, Join } from "./internals";
 
 export function compareAnnotations(a: Annotation<any>, b: Annotation<any>) {
   let startDelta = a.start - b.start;
-  let endDelta = a.end - b.end;
+  let endDelta = b.end - a.end;
+  let rankDelta = a.rank - b.rank;
   if (startDelta === 0) {
     if (endDelta === 0) {
-      return a.type > b.type ? 1 : a.type < b.type ? -1 : 0;
+      if (rankDelta === 0) {
+        return a.type > b.type ? 1 : a.type < b.type ? -1 : 0;
+      } else {
+        return rankDelta;
+      }
     } else {
       return endDelta;
     }

--- a/packages/@atjson/document/src/collection.ts
+++ b/packages/@atjson/document/src/collection.ts
@@ -1,5 +1,12 @@
 import { Annotation, AnnotationJSON, Document, Join } from "./internals";
 
+/*
+  This is a hierarchical sort, meaning annotations are sorted by their position
+  with wrapping annotations appearing before nested annotations. To determine
+  nestedness, use start/end positions to see which annotations cover others. When
+  these coincide, sort by rank as the annotation with the lower rank would wrap
+  the other. If these are equal, just sort by type.
+*/
 export function compareAnnotations(a: Annotation<any>, b: Annotation<any>) {
   let startDelta = a.start - b.start;
   let endDelta = b.end - a.end;

--- a/packages/@atjson/document/test/atjson-test.ts
+++ b/packages/@atjson/document/test/atjson-test.ts
@@ -319,14 +319,14 @@ describe("new Document", () => {
             end: 20,
           },
           {
-            type: "-atjson-parse-token",
-            start: 7,
-            end: 10,
-          },
-          {
             type: "-test-bold",
             start: 7,
             end: 19,
+          },
+          {
+            type: "-atjson-parse-token",
+            start: 7,
+            end: 10,
           },
           {
             type: "-atjson-parse-token",
@@ -366,13 +366,6 @@ describe("new Document", () => {
         contentType: "application/vnd.atjson+test",
         annotations: [
           {
-            id: "1",
-            type: "-test-bold",
-            start: 0,
-            end: 5,
-            attributes: {},
-          },
-          {
             id: "2",
             type: "-test-italic",
             start: 0,
@@ -384,6 +377,13 @@ describe("new Document", () => {
             type: "-test-underline",
             start: 0,
             end: 13,
+            attributes: {},
+          },
+          {
+            id: "1",
+            type: "-test-bold",
+            start: 0,
+            end: 5,
             attributes: {},
           },
           {
@@ -517,12 +517,6 @@ describe("new Document", () => {
         contentType: "application/vnd.atjson+test",
         annotations: [
           {
-            type: "-atjson-parse-token",
-            start: 0,
-            end: 3,
-            attributes: {},
-          },
-          {
             type: "-test-bold",
             start: 0,
             end: 12,
@@ -532,6 +526,12 @@ describe("new Document", () => {
             type: "-test-italic",
             start: 0,
             end: 12,
+            attributes: {},
+          },
+          {
+            type: "-atjson-parse-token",
+            start: 0,
+            end: 3,
             attributes: {},
           },
           {
@@ -548,15 +548,15 @@ describe("new Document", () => {
         annotations: [
           {
             attributes: {},
-            end: 4,
-            start: 0,
-            type: "-atjson-parse-token",
-          },
-          {
-            attributes: {},
             end: 17,
             start: 0,
             type: "-test-italic",
+          },
+          {
+            attributes: {},
+            end: 4,
+            start: 0,
+            type: "-atjson-parse-token",
           },
           {
             attributes: {},

--- a/packages/@atjson/document/test/document-test.ts
+++ b/packages/@atjson/document/test/document-test.ts
@@ -226,7 +226,7 @@ describe("Document#canonical", () => {
     });
   });
 
-  test("annotations are properly sorted", () => {
+  test("annotations are sorted by position and rank", () => {
     let testDoc = new TestSource({
       content: "Hello World!",
       annotations: [

--- a/packages/@atjson/document/test/document-test.ts
+++ b/packages/@atjson/document/test/document-test.ts
@@ -1,5 +1,5 @@
 import { mergeRanges } from "../src/internals";
-import TestSource, { Bold, Paragraph } from "./test-source";
+import TestSource, { Bold, Italic, Paragraph } from "./test-source";
 import { ParseAnnotation } from "../src";
 
 describe("Document#deleteTextRanges", () => {
@@ -145,8 +145,8 @@ describe("Document#removeAnnotations", () => {
 
     expect(testDoc).toMatchObject({
       annotations: [
-        { type: "bold", start: 0, end: 12 },
         { type: "paragraph", start: 0, end: 13 },
+        { type: "bold", start: 0, end: 12 },
       ],
     });
   });
@@ -211,19 +211,38 @@ describe("Document#canonical", () => {
       content: "Hello,\n World!",
       annotations: [
         {
-          type: "bold",
-          start: 0,
-          end: 5,
-          attributes: {},
-        },
-        {
           type: "paragraph",
           start: 0,
           end: 6,
           attributes: {},
         },
+        {
+          type: "bold",
+          start: 0,
+          end: 5,
+          attributes: {},
+        },
       ],
     });
+  });
+
+  test("annotations are properly sorted", () => {
+    let testDoc = new TestSource({
+      content: "Hello World!",
+      annotations: [
+        new Italic({ start: 4, end: 7 }),
+        new Bold({ start: 0, end: 12 }),
+        new Italic({ start: 0, end: 1 }),
+        new Paragraph({ start: 0, end: 12 }),
+      ],
+    });
+
+    expect(testDoc.canonical().annotations).toMatchObject([
+      { type: "paragraph", start: 0, end: 12 },
+      { type: "bold", start: 0, end: 12 },
+      { type: "italic", start: 0, end: 1 },
+      { type: "italic", start: 4, end: 7 },
+    ]);
   });
 });
 

--- a/packages/@atjson/document/test/test-source.ts
+++ b/packages/@atjson/document/test/test-source.ts
@@ -4,6 +4,7 @@ import Document, {
   InlineAnnotation,
   Insertion,
   ObjectAnnotation,
+  BlockAnnotation,
 } from "../src";
 
 export class Anchor extends InlineAnnotation<{
@@ -34,7 +35,7 @@ export class Instagram extends ObjectAnnotation {
   static type = "instagram";
 }
 
-export class Paragraph extends ObjectAnnotation {
+export class Paragraph extends BlockAnnotation {
   static vendorPrefix = "test";
   static type = "paragraph";
 }

--- a/packages/@atjson/source-ckeditor/test/source-classic-build-editor-test.ts
+++ b/packages/@atjson/source-ckeditor/test/source-classic-build-editor-test.ts
@@ -1,19 +1,7 @@
 import ClassicEditor from "@ckeditor/ckeditor5-build-classic";
-import { Annotation } from "@atjson/document";
+import { compareAnnotations } from "@atjson/document";
 import { CK } from "../src";
 import CKEditorSource from "./source-ckeditor-build-classic";
-
-function compareAnnotations(a: Annotation, b: Annotation) {
-  if (a.start !== b.start) {
-    return a.start - b.start;
-  }
-
-  if (a.end !== b.end) {
-    return b.end - a.end;
-  }
-
-  return a.type > b.type ? 1 : a.type < b.type ? -1 : 0;
-}
 
 describe("@atjson/source-ckeditor classic build", () => {
   let editor: CK.Editor;
@@ -36,19 +24,19 @@ describe("@atjson/source-ckeditor classic build", () => {
     let doc = CKEditorSource.fromRaw(editor.model.document).canonical();
 
     expect(doc.content).toBe("Here is a paragraph");
-    expect(doc.canonical().annotations.sort(compareAnnotations)).toMatchObject([
+    expect(doc.canonical().annotations).toMatchObject([
       {
         type: "$root",
         start: 0,
         end: 19,
       },
       {
-        type: "$text",
+        type: "paragraph",
         start: 0,
         end: 19,
       },
       {
-        type: "paragraph",
+        type: "$text",
         start: 0,
         end: 19,
       },
@@ -69,22 +57,22 @@ describe("@atjson/source-ckeditor classic build", () => {
         end: 44,
       },
       {
-        type: "$text",
-        start: 0,
-        end: 19,
-      },
-      {
         type: "paragraph",
         start: 0,
         end: 19,
       },
       {
         type: "$text",
+        start: 0,
+        end: 19,
+      },
+      {
+        type: "paragraph",
         start: 19,
         end: 44,
       },
       {
-        type: "paragraph",
+        type: "$text",
         start: 19,
         end: 44,
       },
@@ -103,12 +91,12 @@ describe("@atjson/source-ckeditor classic build", () => {
         end: 13,
       },
       {
-        type: "$text",
+        type: "paragraph",
         start: 0,
         end: 13,
       },
       {
-        type: "paragraph",
+        type: "$text",
         start: 0,
         end: 13,
       },

--- a/packages/@atjson/source-ckeditor/test/source-classic-build-editor-test.ts
+++ b/packages/@atjson/source-ckeditor/test/source-classic-build-editor-test.ts
@@ -1,5 +1,4 @@
 import ClassicEditor from "@ckeditor/ckeditor5-build-classic";
-import { compareAnnotations } from "@atjson/document";
 import { CK } from "../src";
 import CKEditorSource from "./source-ckeditor-build-classic";
 
@@ -24,7 +23,7 @@ describe("@atjson/source-ckeditor classic build", () => {
     let doc = CKEditorSource.fromRaw(editor.model.document).canonical();
 
     expect(doc.content).toBe("Here is a paragraph");
-    expect(doc.canonical().annotations).toMatchObject([
+    expect(doc.annotations).toMatchObject([
       {
         type: "$root",
         start: 0,
@@ -50,7 +49,7 @@ describe("@atjson/source-ckeditor classic build", () => {
     let doc = CKEditorSource.fromRaw(editor.model.document).canonical();
 
     expect(doc.content).toBe("Here is a paragraphHere is another paragraph");
-    expect(doc.annotations.sort(compareAnnotations)).toMatchObject([
+    expect(doc.all().sort().annotations).toMatchObject([
       {
         type: "$root",
         start: 0,
@@ -84,7 +83,7 @@ describe("@atjson/source-ckeditor classic build", () => {
     let doc = CKEditorSource.fromRaw(editor.model.document).canonical();
 
     expect(doc.content).toBe("autoparagraph");
-    expect(doc.annotations.sort(compareAnnotations)).toMatchObject([
+    expect(doc.all().sort().annotations).toMatchObject([
       {
         type: "$root",
         start: 0,
@@ -110,7 +109,7 @@ describe("@atjson/source-ckeditor classic build", () => {
     let doc = CKEditorSource.fromRaw(editor.model.document).canonical();
 
     expect(doc.content).toBe("Bold italic link");
-    expect(doc.annotations.sort(compareAnnotations)).toMatchObject([
+    expect(doc.all().sort().annotations).toMatchObject([
       {
         type: "$root",
         start: 0,
@@ -161,7 +160,7 @@ describe("@atjson/source-ckeditor classic build", () => {
     let doc = CKEditorSource.fromRaw(editor.model.document).canonical();
 
     expect(doc.content).toBe("Bold and italic bold link just bold");
-    expect(doc.annotations.sort(compareAnnotations)).toMatchObject([
+    expect(doc.all().sort().annotations).toMatchObject([
       {
         type: "$root",
         start: 0,
@@ -209,7 +208,7 @@ describe("@atjson/source-ckeditor classic build", () => {
     let doc = CKEditorSource.fromRaw(editor.model.document);
 
     expect(doc.content).toBe("<$root><listItem>List item 1</listItem></$root>");
-    expect(doc.annotations.sort(compareAnnotations)).toMatchObject([
+    expect(doc.all().sort().annotations).toMatchObject([
       {
         type: "$root",
         start: 0,

--- a/packages/@atjson/source-ckeditor/test/source-classic-build-test.ts
+++ b/packages/@atjson/source-ckeditor/test/source-classic-build-test.ts
@@ -1,4 +1,3 @@
-import { compareAnnotations } from "@atjson/document";
 import DocumentFragment from "@ckeditor/ckeditor5-engine/src/model/documentfragment";
 import CKEditorSource from "./source-ckeditor-build-classic";
 
@@ -17,7 +16,7 @@ describe("@atjson/source-ckeditor classic build", () => {
     let doc = CKEditorSource.fromRaw(ckDoc).canonical();
 
     expect(doc.content).toBe("Here is a paragraph");
-    expect(doc.canonical().annotations.sort(compareAnnotations)).toMatchObject([
+    expect(doc.annotations).toMatchObject([
       {
         type: "$root",
         start: 0,
@@ -58,7 +57,7 @@ describe("@atjson/source-ckeditor classic build", () => {
     let doc = CKEditorSource.fromRaw(ckDoc).canonical();
 
     expect(doc.content).toBe("Here is a paragraphHere is another paragraph");
-    expect(doc.annotations.sort(compareAnnotations)).toMatchObject([
+    expect(doc.all().sort().annotations).toMatchObject([
       {
         type: "$root",
         start: 0,
@@ -116,7 +115,7 @@ describe("@atjson/source-ckeditor classic build", () => {
     let doc = CKEditorSource.fromRaw(ckDoc).canonical();
 
     expect(doc.content).toBe("Bold italic link");
-    expect(doc.annotations.sort(compareAnnotations)).toMatchObject([
+    expect(doc.all().sort().annotations).toMatchObject([
       {
         type: "$root",
         start: 0,
@@ -186,7 +185,7 @@ describe("@atjson/source-ckeditor classic build", () => {
     let doc = CKEditorSource.fromRaw(ckDoc).canonical();
 
     expect(doc.content).toBe("Bold and italic bold link just bold");
-    expect(doc.annotations.sort(compareAnnotations)).toMatchObject([
+    expect(doc.all().sort().annotations).toMatchObject([
       {
         type: "$root",
         start: 0,
@@ -245,7 +244,7 @@ describe("@atjson/source-ckeditor classic build", () => {
     let doc = CKEditorSource.fromRaw(ckDoc);
 
     expect(doc.content).toBe("<$root><listItem>List item 1</listItem></$root>");
-    expect(doc.annotations.sort(compareAnnotations)).toMatchObject([
+    expect(doc.all().sort().annotations).toMatchObject([
       {
         type: "$root",
         start: 0,

--- a/packages/@atjson/source-ckeditor/test/source-classic-build-test.ts
+++ b/packages/@atjson/source-ckeditor/test/source-classic-build-test.ts
@@ -1,18 +1,6 @@
-import { Annotation } from "@atjson/document";
+import { compareAnnotations } from "@atjson/document";
 import DocumentFragment from "@ckeditor/ckeditor5-engine/src/model/documentfragment";
 import CKEditorSource from "./source-ckeditor-build-classic";
-
-function compareAnnotations(a: Annotation, b: Annotation) {
-  if (a.start !== b.start) {
-    return a.start - b.start;
-  }
-
-  if (a.end !== b.end) {
-    return b.end - a.end;
-  }
-
-  return a.type > b.type ? 1 : a.type < b.type ? -1 : 0;
-}
 
 describe("@atjson/source-ckeditor classic build", () => {
   test("single paragraph", () => {
@@ -36,12 +24,12 @@ describe("@atjson/source-ckeditor classic build", () => {
         end: 19,
       },
       {
-        type: "$text",
+        type: "paragraph",
         start: 0,
         end: 19,
       },
       {
-        type: "paragraph",
+        type: "$text",
         start: 0,
         end: 19,
       },
@@ -77,22 +65,22 @@ describe("@atjson/source-ckeditor classic build", () => {
         end: 44,
       },
       {
-        type: "$text",
-        start: 0,
-        end: 19,
-      },
-      {
         type: "paragraph",
         start: 0,
         end: 19,
       },
       {
         type: "$text",
+        start: 0,
+        end: 19,
+      },
+      {
+        type: "paragraph",
         start: 19,
         end: 44,
       },
       {
-        type: "paragraph",
+        type: "$text",
         start: 19,
         end: 44,
       },

--- a/packages/@atjson/source-gdocs-paste/src/converter.ts
+++ b/packages/@atjson/source-gdocs-paste/src/converter.ts
@@ -2,6 +2,7 @@ import {
   Annotation,
   BlockAnnotation,
   ParseAnnotation,
+  compareAnnotations,
   is,
 } from "@atjson/document";
 import OffsetSource, {
@@ -16,21 +17,6 @@ import GDocsSource from "./source";
 // eslint-disable-next-line no-control-regex
 const VERTICAL_TABS = /\u000B/g;
 const NEWLINE_PARAGRAPH_SEPARATOR = /\n(\s*\n)*/g;
-
-function compareAnnotations(a: Annotation<any>, b: Annotation<any>) {
-  if (a.start !== b.start) {
-    return a.start - b.start;
-  }
-  if (a.end !== b.end) {
-    return b.end - a.end;
-  }
-
-  if (a.rank !== b.rank) {
-    return a.rank - b.rank;
-  }
-
-  return a.type < b.type ? -1 : a.type > b.type ? 1 : 0;
-}
 
 GDocsSource.defineConverterTo(OffsetSource, (doc) => {
   // Remove all underlines that align with links, since

--- a/packages/@atjson/source-prism/test/__snapshots__/prism-test.ts.snap
+++ b/packages/@atjson/source-prism/test/__snapshots__/prism-test.ts.snap
@@ -2574,6 +2574,15 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-pam-xmlns": "http://www.w3.org/1999/xhtml",
+      },
+      "end": 14096,
+      "id": "Any<id>",
+      "start": 39,
+      "type": "-pam-message",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "<pam:message>",
       },
       "end": 578,
@@ -2582,13 +2591,11 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {
-        "-pam-xmlns": "http://www.w3.org/1999/xhtml",
-      },
-      "end": 14096,
+      "attributes": Object {},
+      "end": 14081,
       "id": "Any<id>",
-      "start": 39,
-      "type": "-pam-message",
+      "start": 579,
+      "type": "-pam-article",
     },
     Object {
       "attributes": Object {
@@ -2601,10 +2608,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 14081,
+      "end": 14066,
       "id": "Any<id>",
-      "start": 579,
-      "type": "-pam-article",
+      "start": 611,
+      "type": "-html-body",
     },
     Object {
       "attributes": Object {
@@ -2613,22 +2620,6 @@ Object {
       "end": 617,
       "id": "Any<id>",
       "start": 611,
-      "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 14066,
-      "id": "Any<id>",
-      "start": 611,
-      "type": "-html-body",
-    },
-    Object {
-      "attributes": Object {
-        "-atjson-reason": "<h1>",
-      },
-      "end": 622,
-      "id": "Any<id>",
-      "start": 618,
       "type": "-atjson-parse-token",
     },
     Object {
@@ -2642,20 +2633,20 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-atjson-reason": "<h1>",
+      },
+      "end": 622,
+      "id": "Any<id>",
+      "start": 618,
+      "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "</h1>",
       },
       "end": 638,
       "id": "Any<id>",
       "start": 633,
-      "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {
-        "-atjson-reason": "<p>",
-      },
-      "end": 657,
-      "id": "Any<id>",
-      "start": 639,
       "type": "-atjson-parse-token",
     },
     Object {
@@ -2666,6 +2657,15 @@ Object {
       "id": "Any<id>",
       "start": 639,
       "type": "-offset-paragraph",
+    },
+    Object {
+      "attributes": Object {
+        "-atjson-reason": "<p>",
+      },
+      "end": 657,
+      "id": "Any<id>",
+      "start": 639,
+      "type": "-atjson-parse-token",
     },
     Object {
       "attributes": Object {},
@@ -2726,15 +2726,6 @@ Object {
     },
     Object {
       "attributes": Object {
-        "-atjson-reason": "<p>",
-      },
-      "end": 769,
-      "id": "Any<id>",
-      "start": 753,
-      "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {
         "-html-class": "deck",
       },
       "end": 1086,
@@ -2744,20 +2735,20 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-atjson-reason": "<p>",
+      },
+      "end": 769,
+      "id": "Any<id>",
+      "start": 753,
+      "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "</p>",
       },
       "end": 1086,
       "id": "Any<id>",
       "start": 1082,
-      "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {
-        "-atjson-reason": "<h2>",
-      },
-      "end": 1096,
-      "id": "Any<id>",
-      "start": 1092,
       "type": "-atjson-parse-token",
     },
     Object {
@@ -2771,12 +2762,28 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-atjson-reason": "<h2>",
+      },
+      "end": 1096,
+      "id": "Any<id>",
+      "start": 1092,
+      "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "</h2>",
       },
       "end": 1112,
       "id": "Any<id>",
       "start": 1107,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 1159,
+      "id": "Any<id>",
+      "start": 1114,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -2789,10 +2796,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 1159,
+      "end": 1150,
       "id": "Any<id>",
-      "start": 1114,
-      "type": "-offset-paragraph",
+      "start": 1117,
+      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -2802,13 +2809,6 @@ Object {
       "id": "Any<id>",
       "start": 1117,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 1150,
-      "id": "Any<id>",
-      "start": 1117,
-      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -2829,6 +2829,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 1194,
+      "id": "Any<id>",
+      "start": 1160,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -2839,10 +2846,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 1194,
+      "end": 1190,
       "id": "Any<id>",
-      "start": 1160,
-      "type": "-offset-paragraph",
+      "start": 1163,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -2852,13 +2859,6 @@ Object {
       "id": "Any<id>",
       "start": 1163,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 1190,
-      "id": "Any<id>",
-      "start": 1163,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {},
@@ -2895,6 +2895,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 1493,
+      "id": "Any<id>",
+      "start": 1197,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -2905,10 +2912,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 1493,
+      "end": 1261,
       "id": "Any<id>",
-      "start": 1197,
-      "type": "-offset-paragraph",
+      "start": 1200,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -2921,10 +2928,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 1261,
+      "end": 1257,
       "id": "Any<id>",
-      "start": 1200,
-      "type": "-offset-bold",
+      "start": 1203,
+      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -2934,13 +2941,6 @@ Object {
       "id": "Any<id>",
       "start": 1203,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 1257,
-      "id": "Any<id>",
-      "start": 1203,
-      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -2970,6 +2970,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 1622,
+      "id": "Any<id>",
+      "start": 1494,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -2980,10 +2987,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 1622,
+      "end": 1618,
       "id": "Any<id>",
-      "start": 1494,
-      "type": "-offset-paragraph",
+      "start": 1497,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -2996,10 +3003,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 1618,
+      "end": 1524,
       "id": "Any<id>",
-      "start": 1497,
-      "type": "-offset-bold",
+      "start": 1500,
+      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -3009,13 +3016,6 @@ Object {
       "id": "Any<id>",
       "start": 1500,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 1524,
-      "id": "Any<id>",
-      "start": 1500,
-      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -3045,6 +3045,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 2058,
+      "id": "Any<id>",
+      "start": 1623,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -3055,10 +3062,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 2058,
+      "end": 1660,
       "id": "Any<id>",
-      "start": 1623,
-      "type": "-offset-paragraph",
+      "start": 1626,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3071,10 +3078,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 1660,
+      "end": 1656,
       "id": "Any<id>",
-      "start": 1626,
-      "type": "-offset-bold",
+      "start": 1629,
+      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -3084,13 +3091,6 @@ Object {
       "id": "Any<id>",
       "start": 1629,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 1656,
-      "id": "Any<id>",
-      "start": 1629,
-      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -3120,6 +3120,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 2116,
+      "id": "Any<id>",
+      "start": 2059,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -3130,10 +3137,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 2116,
+      "end": 2112,
       "id": "Any<id>",
-      "start": 2059,
-      "type": "-offset-paragraph",
+      "start": 2062,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3143,13 +3150,6 @@ Object {
       "id": "Any<id>",
       "start": 2062,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 2112,
-      "id": "Any<id>",
-      "start": 2062,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3170,6 +3170,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 2211,
+      "id": "Any<id>",
+      "start": 2117,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -3179,13 +3186,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 2211,
-      "id": "Any<id>",
-      "start": 2117,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -3193,6 +3193,13 @@ Object {
       "id": "Any<id>",
       "start": 2207,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 2289,
+      "id": "Any<id>",
+      "start": 2212,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -3205,10 +3212,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 2289,
+      "end": 2285,
       "id": "Any<id>",
-      "start": 2212,
-      "type": "-offset-paragraph",
+      "start": 2215,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3218,13 +3225,6 @@ Object {
       "id": "Any<id>",
       "start": 2215,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 2285,
-      "id": "Any<id>",
-      "start": 2215,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3245,6 +3245,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 2329,
+      "id": "Any<id>",
+      "start": 2290,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -3254,13 +3261,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 2329,
-      "id": "Any<id>",
-      "start": 2290,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -3268,6 +3268,13 @@ Object {
       "id": "Any<id>",
       "start": 2325,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 2397,
+      "id": "Any<id>",
+      "start": 2330,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -3280,10 +3287,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 2397,
+      "end": 2393,
       "id": "Any<id>",
-      "start": 2330,
-      "type": "-offset-paragraph",
+      "start": 2333,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3293,13 +3300,6 @@ Object {
       "id": "Any<id>",
       "start": 2333,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 2393,
-      "id": "Any<id>",
-      "start": 2333,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3320,6 +3320,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 2489,
+      "id": "Any<id>",
+      "start": 2398,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -3329,13 +3336,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 2489,
-      "id": "Any<id>",
-      "start": 2398,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -3343,6 +3343,13 @@ Object {
       "id": "Any<id>",
       "start": 2485,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 2536,
+      "id": "Any<id>",
+      "start": 2490,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -3355,10 +3362,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 2536,
+      "end": 2532,
       "id": "Any<id>",
-      "start": 2490,
-      "type": "-offset-paragraph",
+      "start": 2493,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3368,13 +3375,6 @@ Object {
       "id": "Any<id>",
       "start": 2493,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 2532,
-      "id": "Any<id>",
-      "start": 2493,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3395,6 +3395,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 2595,
+      "id": "Any<id>",
+      "start": 2537,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -3404,13 +3411,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 2595,
-      "id": "Any<id>",
-      "start": 2537,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -3418,6 +3418,13 @@ Object {
       "id": "Any<id>",
       "start": 2591,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 2699,
+      "id": "Any<id>",
+      "start": 2596,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -3430,10 +3437,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 2699,
+      "end": 2695,
       "id": "Any<id>",
-      "start": 2596,
-      "type": "-offset-paragraph",
+      "start": 2599,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3443,13 +3450,6 @@ Object {
       "id": "Any<id>",
       "start": 2599,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 2695,
-      "id": "Any<id>",
-      "start": 2599,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3470,6 +3470,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 2745,
+      "id": "Any<id>",
+      "start": 2700,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -3479,13 +3486,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 2745,
-      "id": "Any<id>",
-      "start": 2700,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -3493,6 +3493,13 @@ Object {
       "id": "Any<id>",
       "start": 2741,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 2841,
+      "id": "Any<id>",
+      "start": 2746,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -3505,10 +3512,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 2841,
+      "end": 2837,
       "id": "Any<id>",
-      "start": 2746,
-      "type": "-offset-paragraph",
+      "start": 2749,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3518,13 +3525,6 @@ Object {
       "id": "Any<id>",
       "start": 2749,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 2837,
-      "id": "Any<id>",
-      "start": 2749,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3545,6 +3545,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 3159,
+      "id": "Any<id>",
+      "start": 2842,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -3554,13 +3561,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 3159,
-      "id": "Any<id>",
-      "start": 2842,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -3568,6 +3568,13 @@ Object {
       "id": "Any<id>",
       "start": 3155,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 3240,
+      "id": "Any<id>",
+      "start": 3160,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -3580,10 +3587,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 3240,
+      "end": 3236,
       "id": "Any<id>",
-      "start": 3160,
-      "type": "-offset-paragraph",
+      "start": 3163,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3593,13 +3600,6 @@ Object {
       "id": "Any<id>",
       "start": 3163,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 3236,
-      "id": "Any<id>",
-      "start": 3163,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3620,6 +3620,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 3409,
+      "id": "Any<id>",
+      "start": 3241,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -3629,13 +3636,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 3409,
-      "id": "Any<id>",
-      "start": 3241,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -3643,6 +3643,13 @@ Object {
       "id": "Any<id>",
       "start": 3405,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 3488,
+      "id": "Any<id>",
+      "start": 3410,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -3655,10 +3662,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 3488,
+      "end": 3484,
       "id": "Any<id>",
-      "start": 3410,
-      "type": "-offset-paragraph",
+      "start": 3413,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3668,13 +3675,6 @@ Object {
       "id": "Any<id>",
       "start": 3413,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 3484,
-      "id": "Any<id>",
-      "start": 3413,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3695,6 +3695,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 3566,
+      "id": "Any<id>",
+      "start": 3489,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -3704,28 +3711,12 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 3566,
-      "id": "Any<id>",
-      "start": 3489,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
       "end": 3566,
       "id": "Any<id>",
       "start": 3562,
-      "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {
-        "-atjson-reason": "<h2>",
-      },
-      "end": 3571,
-      "id": "Any<id>",
-      "start": 3567,
       "type": "-atjson-parse-token",
     },
     Object {
@@ -3739,12 +3730,28 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-atjson-reason": "<h2>",
+      },
+      "end": 3571,
+      "id": "Any<id>",
+      "start": 3567,
+      "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "</h2>",
       },
       "end": 3591,
       "id": "Any<id>",
       "start": 3586,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 3638,
+      "id": "Any<id>",
+      "start": 3593,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -3757,10 +3764,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 3638,
+      "end": 3629,
       "id": "Any<id>",
-      "start": 3593,
-      "type": "-offset-paragraph",
+      "start": 3596,
+      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -3770,13 +3777,6 @@ Object {
       "id": "Any<id>",
       "start": 3596,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 3629,
-      "id": "Any<id>",
-      "start": 3596,
-      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -3797,6 +3797,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 3675,
+      "id": "Any<id>",
+      "start": 3639,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -3807,10 +3814,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 3675,
+      "end": 3671,
       "id": "Any<id>",
-      "start": 3639,
-      "type": "-offset-paragraph",
+      "start": 3642,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3820,13 +3827,6 @@ Object {
       "id": "Any<id>",
       "start": 3642,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 3671,
-      "id": "Any<id>",
-      "start": 3642,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {},
@@ -3863,6 +3863,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 4097,
+      "id": "Any<id>",
+      "start": 3676,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -3873,10 +3880,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 4097,
+      "end": 3720,
       "id": "Any<id>",
-      "start": 3676,
-      "type": "-offset-paragraph",
+      "start": 3679,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3889,10 +3896,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 3720,
+      "end": 3716,
       "id": "Any<id>",
-      "start": 3679,
-      "type": "-offset-bold",
+      "start": 3682,
+      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -3902,13 +3909,6 @@ Object {
       "id": "Any<id>",
       "start": 3682,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 3716,
-      "id": "Any<id>",
-      "start": 3682,
-      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -3929,6 +3929,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 4044,
+      "id": "Any<id>",
+      "start": 4027,
+      "type": "-offset-italic",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<i>",
       },
@@ -3936,13 +3943,6 @@ Object {
       "id": "Any<id>",
       "start": 4027,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 4044,
-      "id": "Any<id>",
-      "start": 4027,
-      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -3963,6 +3963,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 4226,
+      "id": "Any<id>",
+      "start": 4098,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -3973,10 +3980,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 4226,
+      "end": 4222,
       "id": "Any<id>",
-      "start": 4098,
-      "type": "-offset-paragraph",
+      "start": 4101,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -3989,10 +3996,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 4222,
+      "end": 4128,
       "id": "Any<id>",
-      "start": 4101,
-      "type": "-offset-bold",
+      "start": 4104,
+      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -4002,13 +4009,6 @@ Object {
       "id": "Any<id>",
       "start": 4104,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 4128,
-      "id": "Any<id>",
-      "start": 4104,
-      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -4038,6 +4038,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 4945,
+      "id": "Any<id>",
+      "start": 4227,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4048,10 +4055,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 4945,
+      "end": 4268,
       "id": "Any<id>",
-      "start": 4227,
-      "type": "-offset-paragraph",
+      "start": 4230,
+      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -4064,10 +4071,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 4268,
+      "end": 4260,
       "id": "Any<id>",
-      "start": 4230,
-      "type": "-html-small",
+      "start": 4237,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4077,13 +4084,6 @@ Object {
       "id": "Any<id>",
       "start": 4237,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 4260,
-      "id": "Any<id>",
-      "start": 4237,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4113,6 +4113,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 5003,
+      "id": "Any<id>",
+      "start": 4946,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4123,10 +4130,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 5003,
+      "end": 4999,
       "id": "Any<id>",
-      "start": 4946,
-      "type": "-offset-paragraph",
+      "start": 4949,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4136,13 +4143,6 @@ Object {
       "id": "Any<id>",
       "start": 4949,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 4999,
-      "id": "Any<id>",
-      "start": 4949,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4163,6 +4163,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 5524,
+      "id": "Any<id>",
+      "start": 5004,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4173,10 +4180,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 5524,
+      "end": 5062,
       "id": "Any<id>",
-      "start": 5004,
-      "type": "-offset-paragraph",
+      "start": 5049,
+      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -4186,13 +4193,6 @@ Object {
       "id": "Any<id>",
       "start": 5049,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 5062,
-      "id": "Any<id>",
-      "start": 5049,
-      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -4213,6 +4213,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 5602,
+      "id": "Any<id>",
+      "start": 5525,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4223,10 +4230,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 5602,
+      "end": 5598,
       "id": "Any<id>",
-      "start": 5525,
-      "type": "-offset-paragraph",
+      "start": 5528,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4236,13 +4243,6 @@ Object {
       "id": "Any<id>",
       "start": 5528,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 5598,
-      "id": "Any<id>",
-      "start": 5528,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4263,6 +4263,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 5973,
+      "id": "Any<id>",
+      "start": 5603,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4272,13 +4279,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 5973,
-      "id": "Any<id>",
-      "start": 5603,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -4286,6 +4286,13 @@ Object {
       "id": "Any<id>",
       "start": 5969,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 6041,
+      "id": "Any<id>",
+      "start": 5974,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -4298,10 +4305,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 6041,
+      "end": 6037,
       "id": "Any<id>",
-      "start": 5974,
-      "type": "-offset-paragraph",
+      "start": 5977,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4311,13 +4318,6 @@ Object {
       "id": "Any<id>",
       "start": 5977,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 6037,
-      "id": "Any<id>",
-      "start": 5977,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4338,6 +4338,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 6251,
+      "id": "Any<id>",
+      "start": 6042,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4347,13 +4354,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 6251,
-      "id": "Any<id>",
-      "start": 6042,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -4361,6 +4361,13 @@ Object {
       "id": "Any<id>",
       "start": 6247,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 6301,
+      "id": "Any<id>",
+      "start": 6255,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -4373,10 +4380,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 6301,
+      "end": 6297,
       "id": "Any<id>",
-      "start": 6255,
-      "type": "-offset-paragraph",
+      "start": 6258,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4386,13 +4393,6 @@ Object {
       "id": "Any<id>",
       "start": 6258,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 6297,
-      "id": "Any<id>",
-      "start": 6258,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4413,6 +4413,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 6556,
+      "id": "Any<id>",
+      "start": 6302,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4422,13 +4429,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 6556,
-      "id": "Any<id>",
-      "start": 6302,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -4436,6 +4436,13 @@ Object {
       "id": "Any<id>",
       "start": 6552,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 6652,
+      "id": "Any<id>",
+      "start": 6557,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -4448,10 +4455,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 6652,
+      "end": 6648,
       "id": "Any<id>",
-      "start": 6557,
-      "type": "-offset-paragraph",
+      "start": 6560,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4461,13 +4468,6 @@ Object {
       "id": "Any<id>",
       "start": 6560,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 6648,
-      "id": "Any<id>",
-      "start": 6560,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4488,6 +4488,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 7094,
+      "id": "Any<id>",
+      "start": 6653,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4497,13 +4504,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 7094,
-      "id": "Any<id>",
-      "start": 6653,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -4511,6 +4511,13 @@ Object {
       "id": "Any<id>",
       "start": 7090,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 7175,
+      "id": "Any<id>",
+      "start": 7095,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -4523,10 +4530,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 7175,
+      "end": 7171,
       "id": "Any<id>",
-      "start": 7095,
-      "type": "-offset-paragraph",
+      "start": 7098,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4536,13 +4543,6 @@ Object {
       "id": "Any<id>",
       "start": 7098,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 7171,
-      "id": "Any<id>",
-      "start": 7098,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4563,6 +4563,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 7461,
+      "id": "Any<id>",
+      "start": 7176,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4572,13 +4579,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 7461,
-      "id": "Any<id>",
-      "start": 7176,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -4586,6 +4586,13 @@ Object {
       "id": "Any<id>",
       "start": 7457,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 7540,
+      "id": "Any<id>",
+      "start": 7462,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -4598,10 +4605,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 7540,
+      "end": 7536,
       "id": "Any<id>",
-      "start": 7462,
-      "type": "-offset-paragraph",
+      "start": 7465,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4611,13 +4618,6 @@ Object {
       "id": "Any<id>",
       "start": 7465,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 7536,
-      "id": "Any<id>",
-      "start": 7465,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4638,6 +4638,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 7927,
+      "id": "Any<id>",
+      "start": 7541,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4647,13 +4654,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 7927,
-      "id": "Any<id>",
-      "start": 7541,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -4661,6 +4661,13 @@ Object {
       "id": "Any<id>",
       "start": 7923,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 8031,
+      "id": "Any<id>",
+      "start": 7928,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -4673,10 +4680,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 8031,
+      "end": 8027,
       "id": "Any<id>",
-      "start": 7928,
-      "type": "-offset-paragraph",
+      "start": 7931,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4686,13 +4693,6 @@ Object {
       "id": "Any<id>",
       "start": 7931,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 8027,
-      "id": "Any<id>",
-      "start": 7931,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4713,6 +4713,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 8155,
+      "id": "Any<id>",
+      "start": 8032,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4722,28 +4729,12 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 8155,
-      "id": "Any<id>",
-      "start": 8032,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
       "end": 8155,
       "id": "Any<id>",
       "start": 8151,
-      "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {
-        "-atjson-reason": "<h2>",
-      },
-      "end": 8160,
-      "id": "Any<id>",
-      "start": 8156,
       "type": "-atjson-parse-token",
     },
     Object {
@@ -4757,12 +4748,28 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-atjson-reason": "<h2>",
+      },
+      "end": 8160,
+      "id": "Any<id>",
+      "start": 8156,
+      "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "</h2>",
       },
       "end": 8180,
       "id": "Any<id>",
       "start": 8175,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 8227,
+      "id": "Any<id>",
+      "start": 8182,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -4775,10 +4782,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 8227,
+      "end": 8218,
       "id": "Any<id>",
-      "start": 8182,
-      "type": "-offset-paragraph",
+      "start": 8185,
+      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -4788,13 +4795,6 @@ Object {
       "id": "Any<id>",
       "start": 8185,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 8218,
-      "id": "Any<id>",
-      "start": 8185,
-      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -4815,6 +4815,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 8262,
+      "id": "Any<id>",
+      "start": 8228,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4825,10 +4832,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 8262,
+      "end": 8258,
       "id": "Any<id>",
-      "start": 8228,
-      "type": "-offset-paragraph",
+      "start": 8231,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4838,13 +4845,6 @@ Object {
       "id": "Any<id>",
       "start": 8231,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 8258,
-      "id": "Any<id>",
-      "start": 8231,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {},
@@ -4881,6 +4881,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 8654,
+      "id": "Any<id>",
+      "start": 8263,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4891,10 +4898,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 8654,
+      "end": 8303,
       "id": "Any<id>",
-      "start": 8263,
-      "type": "-offset-paragraph",
+      "start": 8266,
+      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -4907,10 +4914,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 8303,
+      "end": 8295,
       "id": "Any<id>",
-      "start": 8266,
-      "type": "-html-small",
+      "start": 8273,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4920,13 +4927,6 @@ Object {
       "id": "Any<id>",
       "start": 8273,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 8295,
-      "id": "Any<id>",
-      "start": 8273,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4956,6 +4956,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 8783,
+      "id": "Any<id>",
+      "start": 8655,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -4966,10 +4973,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 8783,
+      "end": 8779,
       "id": "Any<id>",
-      "start": 8655,
-      "type": "-offset-paragraph",
+      "start": 8658,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -4982,10 +4989,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 8779,
+      "end": 8685,
       "id": "Any<id>",
-      "start": 8658,
-      "type": "-offset-bold",
+      "start": 8661,
+      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -4995,13 +5002,6 @@ Object {
       "id": "Any<id>",
       "start": 8661,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 8685,
-      "id": "Any<id>",
-      "start": 8661,
-      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -5031,6 +5031,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 9213,
+      "id": "Any<id>",
+      "start": 8784,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5041,10 +5048,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 9213,
+      "end": 8825,
       "id": "Any<id>",
-      "start": 8784,
-      "type": "-offset-paragraph",
+      "start": 8787,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5057,10 +5064,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 8825,
+      "end": 8821,
       "id": "Any<id>",
-      "start": 8787,
-      "type": "-offset-bold",
+      "start": 8790,
+      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -5070,13 +5077,6 @@ Object {
       "id": "Any<id>",
       "start": 8790,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 8821,
-      "id": "Any<id>",
-      "start": 8790,
-      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -5106,6 +5106,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 9271,
+      "id": "Any<id>",
+      "start": 9214,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5116,10 +5123,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 9271,
+      "end": 9267,
       "id": "Any<id>",
-      "start": 9214,
-      "type": "-offset-paragraph",
+      "start": 9217,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5129,13 +5136,6 @@ Object {
       "id": "Any<id>",
       "start": 9217,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 9267,
-      "id": "Any<id>",
-      "start": 9217,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5156,6 +5156,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 9573,
+      "id": "Any<id>",
+      "start": 9272,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5165,13 +5172,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 9573,
-      "id": "Any<id>",
-      "start": 9272,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -5179,6 +5179,13 @@ Object {
       "id": "Any<id>",
       "start": 9569,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 9651,
+      "id": "Any<id>",
+      "start": 9574,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -5191,10 +5198,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 9651,
+      "end": 9647,
       "id": "Any<id>",
-      "start": 9574,
-      "type": "-offset-paragraph",
+      "start": 9577,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5204,13 +5211,6 @@ Object {
       "id": "Any<id>",
       "start": 9577,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 9647,
-      "id": "Any<id>",
-      "start": 9577,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5231,6 +5231,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 9881,
+      "id": "Any<id>",
+      "start": 9652,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5240,13 +5247,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 9881,
-      "id": "Any<id>",
-      "start": 9652,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -5254,6 +5254,13 @@ Object {
       "id": "Any<id>",
       "start": 9877,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 9962,
+      "id": "Any<id>",
+      "start": 9882,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -5266,10 +5273,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 9962,
+      "end": 9958,
       "id": "Any<id>",
-      "start": 9882,
-      "type": "-offset-paragraph",
+      "start": 9885,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5279,13 +5286,6 @@ Object {
       "id": "Any<id>",
       "start": 9885,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 9958,
-      "id": "Any<id>",
-      "start": 9885,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5306,6 +5306,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 9993,
+      "id": "Any<id>",
+      "start": 9963,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5315,13 +5322,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 9993,
-      "id": "Any<id>",
-      "start": 9963,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -5329,6 +5329,13 @@ Object {
       "id": "Any<id>",
       "start": 9989,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 10061,
+      "id": "Any<id>",
+      "start": 9994,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -5341,10 +5348,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 10061,
+      "end": 10057,
       "id": "Any<id>",
-      "start": 9994,
-      "type": "-offset-paragraph",
+      "start": 9997,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5354,13 +5361,6 @@ Object {
       "id": "Any<id>",
       "start": 9997,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 10057,
-      "id": "Any<id>",
-      "start": 9997,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5381,6 +5381,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 10145,
+      "id": "Any<id>",
+      "start": 10062,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5390,13 +5397,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 10145,
-      "id": "Any<id>",
-      "start": 10062,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -5404,6 +5404,13 @@ Object {
       "id": "Any<id>",
       "start": 10141,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 10192,
+      "id": "Any<id>",
+      "start": 10146,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -5416,10 +5423,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 10192,
+      "end": 10188,
       "id": "Any<id>",
-      "start": 10146,
-      "type": "-offset-paragraph",
+      "start": 10149,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5429,13 +5436,6 @@ Object {
       "id": "Any<id>",
       "start": 10149,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 10188,
-      "id": "Any<id>",
-      "start": 10149,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5456,6 +5456,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 10320,
+      "id": "Any<id>",
+      "start": 10193,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5465,13 +5472,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 10320,
-      "id": "Any<id>",
-      "start": 10193,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -5479,6 +5479,13 @@ Object {
       "id": "Any<id>",
       "start": 10316,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 10416,
+      "id": "Any<id>",
+      "start": 10321,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -5491,10 +5498,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 10416,
+      "end": 10412,
       "id": "Any<id>",
-      "start": 10321,
-      "type": "-offset-paragraph",
+      "start": 10324,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5504,13 +5511,6 @@ Object {
       "id": "Any<id>",
       "start": 10324,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 10412,
-      "id": "Any<id>",
-      "start": 10324,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5531,6 +5531,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 11071,
+      "id": "Any<id>",
+      "start": 10417,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5541,10 +5548,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 11071,
+      "end": 10522,
       "id": "Any<id>",
-      "start": 10417,
-      "type": "-offset-paragraph",
+      "start": 10464,
+      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -5554,13 +5561,6 @@ Object {
       "id": "Any<id>",
       "start": 10464,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 10522,
-      "id": "Any<id>",
-      "start": 10464,
-      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -5581,6 +5581,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 11150,
+      "id": "Any<id>",
+      "start": 11072,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5591,10 +5598,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 11150,
+      "end": 11146,
       "id": "Any<id>",
-      "start": 11072,
-      "type": "-offset-paragraph",
+      "start": 11075,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5604,13 +5611,6 @@ Object {
       "id": "Any<id>",
       "start": 11075,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 11146,
-      "id": "Any<id>",
-      "start": 11075,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5631,6 +5631,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 11427,
+      "id": "Any<id>",
+      "start": 11151,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5640,13 +5647,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 11427,
-      "id": "Any<id>",
-      "start": 11151,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -5654,6 +5654,13 @@ Object {
       "id": "Any<id>",
       "start": 11423,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 11531,
+      "id": "Any<id>",
+      "start": 11428,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -5666,10 +5673,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 11531,
+      "end": 11527,
       "id": "Any<id>",
-      "start": 11428,
-      "type": "-offset-paragraph",
+      "start": 11431,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5679,13 +5686,6 @@ Object {
       "id": "Any<id>",
       "start": 11431,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 11527,
-      "id": "Any<id>",
-      "start": 11431,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5706,6 +5706,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 11546,
+      "id": "Any<id>",
+      "start": 11532,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5715,28 +5722,12 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 11546,
-      "id": "Any<id>",
-      "start": 11532,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
       "end": 11546,
       "id": "Any<id>",
       "start": 11542,
-      "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {
-        "-atjson-reason": "<h2>",
-      },
-      "end": 11554,
-      "id": "Any<id>",
-      "start": 11550,
       "type": "-atjson-parse-token",
     },
     Object {
@@ -5750,12 +5741,28 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-atjson-reason": "<h2>",
+      },
+      "end": 11554,
+      "id": "Any<id>",
+      "start": 11550,
+      "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "</h2>",
       },
       "end": 11570,
       "id": "Any<id>",
       "start": 11565,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 11617,
+      "id": "Any<id>",
+      "start": 11572,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -5768,10 +5775,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 11617,
+      "end": 11608,
       "id": "Any<id>",
-      "start": 11572,
-      "type": "-offset-paragraph",
+      "start": 11575,
+      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -5781,13 +5788,6 @@ Object {
       "id": "Any<id>",
       "start": 11575,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 11608,
-      "id": "Any<id>",
-      "start": 11575,
-      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -5808,6 +5808,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 11657,
+      "id": "Any<id>",
+      "start": 11618,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5818,10 +5825,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 11657,
+      "end": 11653,
       "id": "Any<id>",
-      "start": 11618,
-      "type": "-offset-paragraph",
+      "start": 11621,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5831,13 +5838,6 @@ Object {
       "id": "Any<id>",
       "start": 11621,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 11653,
-      "id": "Any<id>",
-      "start": 11621,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {},
@@ -5874,6 +5874,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 11995,
+      "id": "Any<id>",
+      "start": 11661,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5884,10 +5891,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 11995,
+      "end": 11713,
       "id": "Any<id>",
-      "start": 11661,
-      "type": "-offset-paragraph",
+      "start": 11664,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5900,10 +5907,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 11713,
+      "end": 11709,
       "id": "Any<id>",
-      "start": 11664,
-      "type": "-offset-bold",
+      "start": 11667,
+      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -5913,13 +5920,6 @@ Object {
       "id": "Any<id>",
       "start": 11667,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 11709,
-      "id": "Any<id>",
-      "start": 11667,
-      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -5949,6 +5949,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 12124,
+      "id": "Any<id>",
+      "start": 11996,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -5959,10 +5966,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 12124,
+      "end": 12120,
       "id": "Any<id>",
-      "start": 11996,
-      "type": "-offset-paragraph",
+      "start": 11999,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -5975,10 +5982,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 12120,
+      "end": 12026,
       "id": "Any<id>",
-      "start": 11999,
-      "type": "-offset-bold",
+      "start": 12002,
+      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -5988,13 +5995,6 @@ Object {
       "id": "Any<id>",
       "start": 12002,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 12026,
-      "id": "Any<id>",
-      "start": 12002,
-      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -6024,6 +6024,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 12331,
+      "id": "Any<id>",
+      "start": 12125,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -6034,10 +6041,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 12331,
+      "end": 12162,
       "id": "Any<id>",
-      "start": 12125,
-      "type": "-offset-paragraph",
+      "start": 12128,
+      "type": "-html-small",
     },
     Object {
       "attributes": Object {
@@ -6050,10 +6057,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 12162,
+      "end": 12154,
       "id": "Any<id>",
-      "start": 12128,
-      "type": "-html-small",
+      "start": 12135,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6063,13 +6070,6 @@ Object {
       "id": "Any<id>",
       "start": 12135,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 12154,
-      "id": "Any<id>",
-      "start": 12135,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6099,6 +6099,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 12389,
+      "id": "Any<id>",
+      "start": 12332,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -6109,10 +6116,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 12389,
+      "end": 12385,
       "id": "Any<id>",
-      "start": 12332,
-      "type": "-offset-paragraph",
+      "start": 12335,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6122,13 +6129,6 @@ Object {
       "id": "Any<id>",
       "start": 12335,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 12385,
-      "id": "Any<id>",
-      "start": 12335,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6149,6 +6149,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 12579,
+      "id": "Any<id>",
+      "start": 12390,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -6158,13 +6165,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 12579,
-      "id": "Any<id>",
-      "start": 12390,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -6172,6 +6172,13 @@ Object {
       "id": "Any<id>",
       "start": 12575,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 12657,
+      "id": "Any<id>",
+      "start": 12580,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -6184,10 +6191,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 12657,
+      "end": 12653,
       "id": "Any<id>",
-      "start": 12580,
-      "type": "-offset-paragraph",
+      "start": 12583,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6197,13 +6204,6 @@ Object {
       "id": "Any<id>",
       "start": 12583,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 12653,
-      "id": "Any<id>",
-      "start": 12583,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6224,6 +6224,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 12737,
+      "id": "Any<id>",
+      "start": 12658,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -6233,13 +6240,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 12737,
-      "id": "Any<id>",
-      "start": 12658,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -6247,6 +6247,13 @@ Object {
       "id": "Any<id>",
       "start": 12733,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 12805,
+      "id": "Any<id>",
+      "start": 12738,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -6259,10 +6266,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 12805,
+      "end": 12801,
       "id": "Any<id>",
-      "start": 12738,
-      "type": "-offset-paragraph",
+      "start": 12741,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6272,13 +6279,6 @@ Object {
       "id": "Any<id>",
       "start": 12741,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 12801,
-      "id": "Any<id>",
-      "start": 12741,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6299,6 +6299,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 12885,
+      "id": "Any<id>",
+      "start": 12806,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -6308,13 +6315,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 12885,
-      "id": "Any<id>",
-      "start": 12806,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -6322,6 +6322,13 @@ Object {
       "id": "Any<id>",
       "start": 12881,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 12932,
+      "id": "Any<id>",
+      "start": 12886,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -6334,10 +6341,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 12932,
+      "end": 12928,
       "id": "Any<id>",
-      "start": 12886,
-      "type": "-offset-paragraph",
+      "start": 12889,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6347,13 +6354,6 @@ Object {
       "id": "Any<id>",
       "start": 12889,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 12928,
-      "id": "Any<id>",
-      "start": 12889,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6374,6 +6374,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 13028,
+      "id": "Any<id>",
+      "start": 12933,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -6383,13 +6390,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 13028,
-      "id": "Any<id>",
-      "start": 12933,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -6397,6 +6397,13 @@ Object {
       "id": "Any<id>",
       "start": 13024,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 13124,
+      "id": "Any<id>",
+      "start": 13029,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -6409,10 +6416,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 13124,
+      "end": 13120,
       "id": "Any<id>",
-      "start": 13029,
-      "type": "-offset-paragraph",
+      "start": 13032,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6422,13 +6429,6 @@ Object {
       "id": "Any<id>",
       "start": 13032,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 13120,
-      "id": "Any<id>",
-      "start": 13032,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6449,6 +6449,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 13515,
+      "id": "Any<id>",
+      "start": 13125,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -6458,13 +6465,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 13515,
-      "id": "Any<id>",
-      "start": 13125,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -6472,6 +6472,13 @@ Object {
       "id": "Any<id>",
       "start": 13511,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 13596,
+      "id": "Any<id>",
+      "start": 13516,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -6484,10 +6491,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 13596,
+      "end": 13592,
       "id": "Any<id>",
-      "start": 13516,
-      "type": "-offset-paragraph",
+      "start": 13519,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6497,13 +6504,6 @@ Object {
       "id": "Any<id>",
       "start": 13519,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 13592,
-      "id": "Any<id>",
-      "start": 13519,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6524,6 +6524,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 13657,
+      "id": "Any<id>",
+      "start": 13597,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -6533,13 +6540,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 13657,
-      "id": "Any<id>",
-      "start": 13597,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -6547,6 +6547,13 @@ Object {
       "id": "Any<id>",
       "start": 13653,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 13736,
+      "id": "Any<id>",
+      "start": 13658,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -6559,10 +6566,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 13736,
+      "end": 13732,
       "id": "Any<id>",
-      "start": 13658,
-      "type": "-offset-paragraph",
+      "start": 13661,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6572,13 +6579,6 @@ Object {
       "id": "Any<id>",
       "start": 13661,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 13732,
-      "id": "Any<id>",
-      "start": 13661,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6599,6 +6599,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 13754,
+      "id": "Any<id>",
+      "start": 13737,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -6608,13 +6615,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 13754,
-      "id": "Any<id>",
-      "start": 13737,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -6622,6 +6622,13 @@ Object {
       "id": "Any<id>",
       "start": 13750,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 13794,
+      "id": "Any<id>",
+      "start": 13755,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -6634,10 +6641,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 13794,
+      "end": 13790,
       "id": "Any<id>",
-      "start": 13755,
-      "type": "-offset-paragraph",
+      "start": 13758,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6647,13 +6654,6 @@ Object {
       "id": "Any<id>",
       "start": 13758,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 13790,
-      "id": "Any<id>",
-      "start": 13758,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6674,6 +6674,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 13917,
+      "id": "Any<id>",
+      "start": 13795,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -6683,13 +6690,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 13917,
-      "id": "Any<id>",
-      "start": 13795,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -6697,6 +6697,13 @@ Object {
       "id": "Any<id>",
       "start": 13913,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 14021,
+      "id": "Any<id>",
+      "start": 13918,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -6709,10 +6716,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 14021,
+      "end": 14017,
       "id": "Any<id>",
-      "start": 13918,
-      "type": "-offset-paragraph",
+      "start": 13921,
+      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6722,13 +6729,6 @@ Object {
       "id": "Any<id>",
       "start": 13921,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 14017,
-      "id": "Any<id>",
-      "start": 13921,
-      "type": "-offset-bold",
     },
     Object {
       "attributes": Object {
@@ -6749,6 +6749,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 14058,
+      "id": "Any<id>",
+      "start": 14022,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -6756,13 +6763,6 @@ Object {
       "id": "Any<id>",
       "start": 14022,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 14058,
-      "id": "Any<id>",
-      "start": 14022,
-      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -7636,6 +7636,15 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-pam-xmlns": "http://www.w3.org/1999/xhtml",
+      },
+      "end": 5143,
+      "id": "Any<id>",
+      "start": 39,
+      "type": "-pam-message",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "<pam:message>",
       },
       "end": 578,
@@ -7644,13 +7653,11 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {
-        "-pam-xmlns": "http://www.w3.org/1999/xhtml",
-      },
-      "end": 5143,
+      "attributes": Object {},
+      "end": 5128,
       "id": "Any<id>",
-      "start": 39,
-      "type": "-pam-message",
+      "start": 579,
+      "type": "-pam-article",
     },
     Object {
       "attributes": Object {
@@ -7663,10 +7670,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 5128,
+      "end": 5113,
       "id": "Any<id>",
-      "start": 579,
-      "type": "-pam-article",
+      "start": 611,
+      "type": "-html-body",
     },
     Object {
       "attributes": Object {
@@ -7675,22 +7682,6 @@ Object {
       "end": 617,
       "id": "Any<id>",
       "start": 611,
-      "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 5113,
-      "id": "Any<id>",
-      "start": 611,
-      "type": "-html-body",
-    },
-    Object {
-      "attributes": Object {
-        "-atjson-reason": "<h1>",
-      },
-      "end": 622,
-      "id": "Any<id>",
-      "start": 618,
       "type": "-atjson-parse-token",
     },
     Object {
@@ -7704,20 +7695,20 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-atjson-reason": "<h1>",
+      },
+      "end": 622,
+      "id": "Any<id>",
+      "start": 618,
+      "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "</h1>",
       },
       "end": 634,
       "id": "Any<id>",
       "start": 629,
-      "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {
-        "-atjson-reason": "<p>",
-      },
-      "end": 653,
-      "id": "Any<id>",
-      "start": 635,
       "type": "-atjson-parse-token",
     },
     Object {
@@ -7731,20 +7722,20 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-atjson-reason": "<p>",
+      },
+      "end": 653,
+      "id": "Any<id>",
+      "start": 635,
+      "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "</p>",
       },
       "end": 666,
       "id": "Any<id>",
       "start": 662,
-      "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {
-        "-atjson-reason": "<p>",
-      },
-      "end": 683,
-      "id": "Any<id>",
-      "start": 667,
       "type": "-atjson-parse-token",
     },
     Object {
@@ -7758,12 +7749,28 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-atjson-reason": "<p>",
+      },
+      "end": 683,
+      "id": "Any<id>",
+      "start": 667,
+      "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "</p>",
       },
       "end": 725,
       "id": "Any<id>",
       "start": 721,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 1481,
+      "id": "Any<id>",
+      "start": 732,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -7776,10 +7783,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 1481,
+      "end": 834,
       "id": "Any<id>",
-      "start": 732,
-      "type": "-offset-paragraph",
+      "start": 810,
+      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -7789,13 +7796,6 @@ Object {
       "id": "Any<id>",
       "start": 810,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 834,
-      "id": "Any<id>",
-      "start": 810,
-      "type": "-offset-italic",
     },
     Object {
       "attributes": Object {
@@ -7816,6 +7816,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 2092,
+      "id": "Any<id>",
+      "start": 1482,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -7823,13 +7830,6 @@ Object {
       "id": "Any<id>",
       "start": 1482,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 2092,
-      "id": "Any<id>",
-      "start": 1482,
-      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -7841,6 +7841,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 2826,
+      "id": "Any<id>",
+      "start": 2093,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -7848,13 +7855,6 @@ Object {
       "id": "Any<id>",
       "start": 2093,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 2826,
-      "id": "Any<id>",
-      "start": 2093,
-      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -7866,6 +7866,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 3339,
+      "id": "Any<id>",
+      "start": 2827,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -7873,13 +7880,6 @@ Object {
       "id": "Any<id>",
       "start": 2827,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 3339,
-      "id": "Any<id>",
-      "start": 2827,
-      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -7891,6 +7891,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 3906,
+      "id": "Any<id>",
+      "start": 3340,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -7898,13 +7905,6 @@ Object {
       "id": "Any<id>",
       "start": 3340,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 3906,
-      "id": "Any<id>",
-      "start": 3340,
-      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -7916,6 +7916,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 4399,
+      "id": "Any<id>",
+      "start": 3907,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -7923,13 +7930,6 @@ Object {
       "id": "Any<id>",
       "start": 3907,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 4399,
-      "id": "Any<id>",
-      "start": 3907,
-      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -7941,6 +7941,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 5105,
+      "id": "Any<id>",
+      "start": 4400,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -7948,13 +7955,6 @@ Object {
       "id": "Any<id>",
       "start": 4400,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 5105,
-      "id": "Any<id>",
-      "start": 4400,
-      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -8676,6 +8676,15 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-pam-xmlns": "http://www.w3.org/1999/xhtml",
+      },
+      "end": 4011,
+      "id": "Any<id>",
+      "start": 39,
+      "type": "-pam-message",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "<pam:message>",
       },
       "end": 578,
@@ -8684,13 +8693,11 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {
-        "-pam-xmlns": "http://www.w3.org/1999/xhtml",
-      },
-      "end": 4011,
+      "attributes": Object {},
+      "end": 3996,
       "id": "Any<id>",
-      "start": 39,
-      "type": "-pam-message",
+      "start": 579,
+      "type": "-pam-article",
     },
     Object {
       "attributes": Object {
@@ -8703,10 +8710,10 @@ Object {
     },
     Object {
       "attributes": Object {},
-      "end": 3996,
+      "end": 3981,
       "id": "Any<id>",
-      "start": 579,
-      "type": "-pam-article",
+      "start": 611,
+      "type": "-html-body",
     },
     Object {
       "attributes": Object {
@@ -8715,22 +8722,6 @@ Object {
       "end": 617,
       "id": "Any<id>",
       "start": 611,
-      "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 3981,
-      "id": "Any<id>",
-      "start": 611,
-      "type": "-html-body",
-    },
-    Object {
-      "attributes": Object {
-        "-atjson-reason": "<h1>",
-      },
-      "end": 622,
-      "id": "Any<id>",
-      "start": 618,
       "type": "-atjson-parse-token",
     },
     Object {
@@ -8744,20 +8735,20 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-atjson-reason": "<h1>",
+      },
+      "end": 622,
+      "id": "Any<id>",
+      "start": 618,
+      "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "</h1>",
       },
       "end": 634,
       "id": "Any<id>",
       "start": 629,
-      "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {
-        "-atjson-reason": "<p>",
-      },
-      "end": 653,
-      "id": "Any<id>",
-      "start": 635,
       "type": "-atjson-parse-token",
     },
     Object {
@@ -8771,20 +8762,20 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-atjson-reason": "<p>",
+      },
+      "end": 653,
+      "id": "Any<id>",
+      "start": 635,
+      "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "</p>",
       },
       "end": 665,
       "id": "Any<id>",
       "start": 661,
-      "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {
-        "-atjson-reason": "<p>",
-      },
-      "end": 682,
-      "id": "Any<id>",
-      "start": 666,
       "type": "-atjson-parse-token",
     },
     Object {
@@ -8798,12 +8789,28 @@ Object {
     },
     Object {
       "attributes": Object {
+        "-atjson-reason": "<p>",
+      },
+      "end": 682,
+      "id": "Any<id>",
+      "start": 666,
+      "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {
         "-atjson-reason": "</p>",
       },
       "end": 753,
       "id": "Any<id>",
       "start": 749,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 1697,
+      "id": "Any<id>",
+      "start": 757,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -8815,13 +8822,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 1697,
-      "id": "Any<id>",
-      "start": 757,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -8829,6 +8829,13 @@ Object {
       "id": "Any<id>",
       "start": 1693,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 2475,
+      "id": "Any<id>",
+      "start": 1698,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -8840,13 +8847,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 2475,
-      "id": "Any<id>",
-      "start": 1698,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -8854,6 +8854,13 @@ Object {
       "id": "Any<id>",
       "start": 2471,
       "type": "-atjson-parse-token",
+    },
+    Object {
+      "attributes": Object {},
+      "end": 3165,
+      "id": "Any<id>",
+      "start": 2476,
+      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {
@@ -8865,13 +8872,6 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {},
-      "end": 3165,
-      "id": "Any<id>",
-      "start": 2476,
-      "type": "-offset-paragraph",
-    },
-    Object {
       "attributes": Object {
         "-atjson-reason": "</p>",
       },
@@ -8881,6 +8881,13 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
+      "attributes": Object {},
+      "end": 3970,
+      "id": "Any<id>",
+      "start": 3166,
+      "type": "-offset-paragraph",
+    },
+    Object {
       "attributes": Object {
         "-atjson-reason": "<p>",
       },
@@ -8888,13 +8895,6 @@ Object {
       "id": "Any<id>",
       "start": 3166,
       "type": "-atjson-parse-token",
-    },
-    Object {
-      "attributes": Object {},
-      "end": 3970,
-      "id": "Any<id>",
-      "start": 3166,
-      "type": "-offset-paragraph",
     },
     Object {
       "attributes": Object {

--- a/packages/@atjson/source-prism/test/prism-test.ts
+++ b/packages/@atjson/source-prism/test/prism-test.ts
@@ -24,13 +24,13 @@ describe("@atjson/source-prism", () => {
     let doc = PRISMSource.fromRaw("<body>some text</body>");
 
     expect(doc.where({}).sort().toJSON()).toMatchObject([
+      { type: "-html-body", start: 0, end: 22 },
       {
         type: "-atjson-parse-token",
         start: 0,
         end: 6,
         attributes: { "-atjson-reason": "<body>" },
       },
-      { type: "-html-body", start: 0, end: 22 },
       {
         type: "-atjson-parse-token",
         start: 15,
@@ -70,20 +70,20 @@ describe("@atjson/source-prism", () => {
         end: 38,
         attributes: { "-atjson-reason": "<?xml>" },
       },
+      { type: "-pam-message", start: 38, end: 117 },
       {
         type: "-atjson-parse-token",
         start: 38,
         end: 51,
         attributes: { "-atjson-reason": "<pam:message>" },
       },
-      { type: "-pam-message", start: 38, end: 117 },
+      { type: "-pam-article", start: 51, end: 103 },
       {
         type: "-atjson-parse-token",
         start: 51,
         end: 64,
         attributes: { "-atjson-reason": "<pam:article>" },
       },
-      { type: "-pam-article", start: 51, end: 103 },
       { type: "-html-head", start: 64, end: 72 },
       {
         type: "-atjson-parse-token",
@@ -91,13 +91,13 @@ describe("@atjson/source-prism", () => {
         end: 72,
         attributes: { "-atjson-reason": "<head/>" },
       },
+      { type: "-html-body", start: 72, end: 89 },
       {
         type: "-atjson-parse-token",
         start: 72,
         end: 78,
         attributes: { "-atjson-reason": "<body>" },
       },
-      { type: "-html-body", start: 72, end: 89 },
       {
         type: "-atjson-parse-token",
         start: 82,
@@ -148,27 +148,27 @@ describe("@atjson/source-prism", () => {
         "<pam:article><head><dc:title>Title</dc:title></head><body><p>∀x∈Λ, x∨¬x∎</p></body></pam:article>"
       );
       expect(doc.where({}).sort().toJSON()).toMatchObject([
+        { type: "-pam-article", start: 0, end: 97 },
         {
           type: "-atjson-parse-token",
           start: 0,
           end: 13,
           attributes: { "-atjson-reason": "<pam:article>" },
         },
-        { type: "-pam-article", start: 0, end: 97 },
+        { type: "-html-head", start: 13, end: 52 },
         {
           type: "-atjson-parse-token",
           start: 13,
           end: 19,
           attributes: { "-atjson-reason": "<head>" },
         },
-        { type: "-html-head", start: 13, end: 52 },
+        { type: "-dc-title", start: 19, end: 45 },
         {
           type: "-atjson-parse-token",
           start: 19,
           end: 29,
           attributes: { "-atjson-reason": "<dc:title>" },
         },
-        { type: "-dc-title", start: 19, end: 45 },
         {
           type: "-atjson-parse-token",
           start: 34,
@@ -181,20 +181,20 @@ describe("@atjson/source-prism", () => {
           end: 52,
           attributes: { "-atjson-reason": "</head>" },
         },
+        { type: "-html-body", start: 52, end: 83 },
         {
           type: "-atjson-parse-token",
           start: 52,
           end: 58,
           attributes: { "-atjson-reason": "<body>" },
         },
-        { type: "-html-body", start: 52, end: 83 },
+        { type: "-html-p", start: 58, end: 76 },
         {
           type: "-atjson-parse-token",
           start: 58,
           end: 61,
           attributes: { "-atjson-reason": "<p>" },
         },
-        { type: "-html-p", start: 58, end: 76 },
         {
           type: "-atjson-parse-token",
           start: 72,

--- a/website/docs/ckeditor-source.md
+++ b/website/docs/ckeditor-source.md
@@ -56,19 +56,19 @@ test("single paragraph", () => {
   let doc = CKEditorSource.fromRaw(ckDoc).canonical();
 
   expect(doc.content).toBe("Here is a paragraph");
-  expect(doc.canonical().annotations.sort(compareAnnotations)).toMatchObject([
+  expect(doc.canonical().annotations.sort()).toMatchObject([
     {
       type: "$root",
       start: 0,
       end: 19,
     },
     {
-      type: "$text",
+      type: "paragraph",
       start: 0,
       end: 19,
     },
     {
-      type: "paragraph",
+      type: "$text",
       start: 0,
       end: 19,
     },

--- a/website/docs/ckeditor-source.md
+++ b/website/docs/ckeditor-source.md
@@ -56,7 +56,7 @@ test("single paragraph", () => {
   let doc = CKEditorSource.fromRaw(ckDoc).canonical();
 
   expect(doc.content).toBe("Here is a paragraph");
-  expect(doc.canonical().annotations.sort()).toMatchObject([
+  expect(doc.annotations).toMatchObject([
     {
       type: "$root",
       start: 0,


### PR DESCRIPTION
Update the default sort function in @atjson/document `collection.compareAnnotations` to produce a sort order that maintains the hierarchical structure of the annotations. Given a hierarchical structure like
```
A
  A1
  A2
B
  B1
  B2
```
we'd like the comparison function to sort the annotations as `A, A1, A2, B, B1, B2`. To do this, we first sort by start position ascending, then end position descending, then rank ascending, and then by type ascending. This method of sorting was already independently implemented in source-ckeditor and source-gdocs-paste.

This sort still produces indeterminate results if two annotations of the same type are placed exactly at the same position - if we'd like to provide a consistent ordering in those situations, we could then sort on some hash value that takes into account the attributes, but I'd like to see if this is needed before adding it here.