### PR TITLE
Add WordPress shortcode source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,7 +123,6 @@
     "@atjson/source-wordpress-shortcode": {
       "version": "file:packages/@atjson/source-wordpress-shortcode",
       "requires": {
-        "@atjson/offset-annotations": "file:packages/@atjson/offset-annotations",
         "@wordpress/shortcode": "2.7.0"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,9 @@
         "@atjson/renderer-hir": "file:packages/@atjson/renderer-hir"
       }
     },
+    "@atjson/source-ckeditor": {
+      "version": "file:packages/@atjson/source-ckeditor"
+    },
     "@atjson/source-commonmark": {
       "version": "file:packages/@atjson/source-commonmark",
       "requires": {
@@ -115,6 +118,56 @@
       "version": "file:packages/@atjson/source-url",
       "requires": {
         "@atjson/offset-annotations": "file:packages/@atjson/offset-annotations"
+      }
+    },
+    "@atjson/source-wordpress-shortcode": {
+      "version": "file:packages/@atjson/source-wordpress-shortcode",
+      "requires": {
+        "@atjson/offset-annotations": "file:packages/@atjson/offset-annotations",
+        "@wordpress/shortcode": "2.7.0"
+      },
+      "dependencies": {
+        "@atjson/offset-annotations": {
+          "version": "file:packages/@atjson/offset-annotations"
+        },
+        "@babel/runtime": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@types/wordpress__shortcode": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@types/wordpress__shortcode/-/wordpress__shortcode-2.3.0.tgz",
+          "integrity": "sha512-JMLAPFnjsGfG/1IhNNn+w3+XhYqF0uJkVH43GKgIUsNX8jBKImAQxxf+xFOpH66XsLeCFnbb9PEuUQ6EhRJ+hQ=="
+        },
+        "@wordpress/shortcode": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-2.7.0.tgz",
+          "integrity": "sha512-ltcQK3FxnG45T/E7UVynzunXl/KknXk2+5+63MQ0gEhYvN8IvS2thFxWG1uwmIyAjW/oWl3kFsI11Sxwh5cFPg==",
+          "requires": {
+            "@babel/runtime": "^7.9.2",
+            "lodash": "^4.17.15",
+            "memize": "^1.1.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "memize": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
+          "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+        }
       }
     },
     "@babel/code-frame": {
@@ -7008,6 +7061,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
       "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
+      "dev": true
+    },
+    "@types/wordpress__shortcode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@types/wordpress__shortcode/-/wordpress__shortcode-2.3.0.tgz",
+      "integrity": "sha512-JMLAPFnjsGfG/1IhNNn+w3+XhYqF0uJkVH43GKgIUsNX8jBKImAQxxf+xFOpH66XsLeCFnbb9PEuUQ6EhRJ+hQ==",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/q": "1.5.4",
     "@types/react": "16.9.35",
     "@types/react-dom": "16.9.8",
+    "@types/wordpress__shortcode": "2.3.0",
     "@typescript-eslint/eslint-plugin": "2.34.0",
     "@typescript-eslint/parser": "2.34.0",
     "babel-jest": "26.0.1",
@@ -67,12 +68,14 @@
     "@atjson/renderer-plain-text": "file:packages/@atjson/renderer-plain-text",
     "@atjson/renderer-react": "file:packages/@atjson/renderer-react",
     "@atjson/renderer-webcomponent": "file:packages/@atjson/renderer-webcomponent",
+    "@atjson/source-ckeditor": "file:packages/@atjson/source-ckeditor",
     "@atjson/source-commonmark": "file:packages/@atjson/source-commonmark",
     "@atjson/source-gdocs-paste": "file:packages/@atjson/source-gdocs-paste",
     "@atjson/source-html": "file:packages/@atjson/source-html",
     "@atjson/source-mobiledoc": "file:packages/@atjson/source-mobiledoc",
     "@atjson/source-prism": "file:packages/@atjson/source-prism",
-    "@atjson/source-url": "file:packages/@atjson/source-url"
+    "@atjson/source-url": "file:packages/@atjson/source-url",
+    "@atjson/source-wordpress-shortcode": "file:packages/@atjson/source-wordpress-shortcode"
   },
   "scripts": {
     "build": "tsc -b packages/**/* --verbose && tsc -b packages/@atjson/**/tsconfig.modules.json --verbose",

--- a/packages/@atjson/source-wordpress-shortcode/.npmignore
+++ b/packages/@atjson/source-wordpress-shortcode/.npmignore
@@ -1,0 +1,11 @@
+.cache
+.vscode
+dist/**/test
+dist/**/node_modules
+scripts
+src
+public
+test
+tmp
+.npmrc
+tsconfig.json

--- a/packages/@atjson/source-wordpress-shortcode/.npmrc
+++ b/packages/@atjson/source-wordpress-shortcode/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/packages/@atjson/source-wordpress-shortcode/CHANGELOG.md
+++ b/packages/@atjson/source-wordpress-shortcode/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/@atjson/source-wordpress-shortcode/README.md
+++ b/packages/@atjson/source-wordpress-shortcode/README.md
@@ -1,0 +1,3 @@
+# @atjson/source-wordpress-shortcode
+
+See [documentation](https://atjson.condenast.io/docs/wordpress-shortcode-source) for more information.

--- a/packages/@atjson/source-wordpress-shortcode/package.json
+++ b/packages/@atjson/source-wordpress-shortcode/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@atjson/source-wordpress-shortcode",
+  "version": "0.1.0",
+  "description": "Parse Wordpress shortcodes into annotations",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/modules/index.js",
+  "types": "dist/commonjs/index.d.ts",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@atjson/offset-annotations": "file:../offset-annotations",
+    "@wordpress/shortcode": "2.7.0"
+  },
+  "devDependencies": {
+    "@atjson/document": "file:../document"
+  },
+  "peerDependencies": {
+    "@atjson/document": "^0.23.0"
+  }
+}

--- a/packages/@atjson/source-wordpress-shortcode/package.json
+++ b/packages/@atjson/source-wordpress-shortcode/package.json
@@ -10,7 +10,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/offset-annotations": "file:../offset-annotations",
     "@wordpress/shortcode": "2.7.0"
   },
   "devDependencies": {

--- a/packages/@atjson/source-wordpress-shortcode/src/annotations/index.ts
+++ b/packages/@atjson/source-wordpress-shortcode/src/annotations/index.ts
@@ -1,0 +1,1 @@
+export * from "./shortcode";

--- a/packages/@atjson/source-wordpress-shortcode/src/annotations/shortcode.ts
+++ b/packages/@atjson/source-wordpress-shortcode/src/annotations/shortcode.ts
@@ -1,0 +1,13 @@
+import { InlineAnnotation } from "@atjson/document";
+
+export class Shortcode extends InlineAnnotation<{
+  tag: string;
+  type: "single" | "self-closing" | "closed";
+  attrs: {
+    named: object;
+    numeric: any[];
+  };
+}> {
+  static vendorPrefix = "wp";
+  static type = "shortcode";
+}

--- a/packages/@atjson/source-wordpress-shortcode/src/annotations/shortcode.ts
+++ b/packages/@atjson/source-wordpress-shortcode/src/annotations/shortcode.ts
@@ -8,6 +8,6 @@ export class Shortcode extends InlineAnnotation<{
     numeric: any[];
   };
 }> {
-  static vendorPrefix = "wp";
+  static vendorPrefix = "wordpress";
   static type = "shortcode";
 }

--- a/packages/@atjson/source-wordpress-shortcode/src/index.ts
+++ b/packages/@atjson/source-wordpress-shortcode/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./annotations";
+
+export { default } from "./source";

--- a/packages/@atjson/source-wordpress-shortcode/src/source.ts
+++ b/packages/@atjson/source-wordpress-shortcode/src/source.ts
@@ -1,0 +1,82 @@
+import Document, { ParseAnnotation } from "@atjson/document";
+import { attrs, regexp } from "@wordpress/shortcode";
+import { Shortcode } from "./annotations";
+
+const REGEXP = regexp("[a-zA-Z_]+");
+
+function parse(text: string) {
+  let match;
+  let annotations = [];
+
+  while ((match = REGEXP.exec(text)) !== null) {
+    if ("[" === match[1] && "]" === match[7]) {
+      continue;
+    }
+    let end = REGEXP.lastIndex;
+    let start = end - match[0].length;
+    let type: "single" | "self-closing" | "closed";
+    if (match[4]) {
+      type = "self-closing";
+    } else if (match[6]) {
+      type = "closed";
+    } else {
+      type = "single";
+    }
+
+    annotations.push(
+      new Shortcode({
+        start,
+        end,
+        attributes: {
+          tag: match[2],
+          type,
+          attrs: attrs(match[3]),
+        },
+      })
+    );
+
+    if (match[5] == null) {
+      annotations.push(
+        new ParseAnnotation({
+          start,
+          end,
+          attributes: {
+            reason: `[${match[2]} /]`,
+          },
+        })
+      );
+    } else {
+      let openingShortcodeEnd = start + match[2].length + match[3].length + 2;
+      let endingShortcodeStart = openingShortcodeEnd + match[5].length;
+      annotations.push(
+        new ParseAnnotation({
+          start,
+          end: openingShortcodeEnd,
+          attributes: {
+            reason: `[${match[2]}]`,
+          },
+        }),
+        new ParseAnnotation({
+          start: endingShortcodeStart,
+          end,
+          attributes: {
+            reason: `[/${match[2]}]`,
+          },
+        })
+      );
+    }
+  }
+
+  return annotations;
+}
+
+export default class WordpressShortcodeSource extends Document {
+  static contentType = "application/vnd.atjson+wp";
+  static schema = [Shortcode];
+  static fromRaw(content: string) {
+    return new this({
+      content,
+      annotations: parse(content),
+    });
+  }
+}

--- a/packages/@atjson/source-wordpress-shortcode/src/source.ts
+++ b/packages/@atjson/source-wordpress-shortcode/src/source.ts
@@ -71,7 +71,7 @@ function parse(text: string) {
 }
 
 export default class WordpressShortcodeSource extends Document {
-  static contentType = "application/vnd.atjson+wp";
+  static contentType = "application/vnd.atjson+wordpress";
   static schema = [Shortcode];
   static fromRaw(content: string) {
     return new this({

--- a/packages/@atjson/source-wordpress-shortcode/test/source-test.ts
+++ b/packages/@atjson/source-wordpress-shortcode/test/source-test.ts
@@ -1,0 +1,112 @@
+import WPShortcodeSource from "../src";
+
+describe("@atjson/source-wordpress-shortcode", () => {
+  test("single shortcodes", () => {
+    let doc = WPShortcodeSource.fromRaw(
+      `[gallery id="123" size="medium"]`
+    ).canonical();
+    expect(doc).toMatchObject({
+      content: "",
+      annotations: [
+        {
+          type: "shortcode",
+          start: 0,
+          end: 0,
+          attributes: {
+            tag: "gallery",
+            type: "single",
+            attrs: {
+              named: { id: "123", size: "medium" },
+              numeric: [],
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  test("numeric attrs", () => {
+    let doc = WPShortcodeSource.fromRaw(
+      `[happy "happy" 'joy' joy]`
+    ).canonical();
+    expect(doc).toMatchObject({
+      content: "",
+      annotations: [
+        {
+          type: "shortcode",
+          start: 0,
+          end: 0,
+          attributes: {
+            tag: "happy",
+            type: "single",
+            attrs: {
+              named: {},
+              numeric: ["happy", "joy", "joy"],
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  test("self-closing shortcodes", () => {
+    let doc = WPShortcodeSource.fromRaw(`[happy /]`).canonical();
+    expect(doc).toMatchObject({
+      content: "",
+      annotations: [
+        {
+          type: "shortcode",
+          start: 0,
+          end: 0,
+          attributes: {
+            tag: "happy",
+            type: "self-closing",
+            attrs: {
+              named: {},
+              numeric: [],
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  test("closed shortcodes", () => {
+    let doc = WPShortcodeSource.fromRaw(
+      `[caption id="attachment_6" align="alignright" width="300"]<img src="http://localhost/wp-content/uploads/2010/07/800px-Great_Wave_off_Kanagawa2-300x205.jpg" alt="Kanagawa" title="The Great Wave" width="300" height="205" class="size-medium wp-image-6" /> The Great Wave[/caption]`
+    ).canonical();
+    expect(doc).toMatchObject({
+      content: `<img src="http://localhost/wp-content/uploads/2010/07/800px-Great_Wave_off_Kanagawa2-300x205.jpg" alt="Kanagawa" title="The Great Wave" width="300" height="205" class="size-medium wp-image-6" /> The Great Wave`,
+      annotations: [
+        {
+          type: "shortcode",
+          start: 0,
+          end: 209,
+          attributes: {
+            tag: "caption",
+            type: "closed",
+            attrs: {
+              named: {
+                id: "attachment_6",
+                align: "alignright",
+                width: "300",
+              },
+              numeric: [],
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  test.each(["[[gallery]]", "[[shortcode] ... [/shortcode]]"])(
+    "escaped shortcodes (%s)",
+    (code) => {
+      let doc = WPShortcodeSource.fromRaw(code).canonical();
+      expect(doc).toMatchObject({
+        content: code,
+        annotations: [],
+      });
+    }
+  );
+});

--- a/packages/@atjson/source-wordpress-shortcode/tsconfig.json
+++ b/packages/@atjson/source-wordpress-shortcode/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "references": [{ "path": "../document" }, { "path": "../offset-annotations" }]
+  "references": [{ "path": "../document" }]
 }

--- a/packages/@atjson/source-wordpress-shortcode/tsconfig.json
+++ b/packages/@atjson/source-wordpress-shortcode/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/commonjs",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "references": [{ "path": "../document" }, { "path": "../offset-annotations" }]
+}

--- a/packages/@atjson/source-wordpress-shortcode/tsconfig.modules.json
+++ b/packages/@atjson/source-wordpress-shortcode/tsconfig.modules.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/modules",
+    "module": "esnext",
+    "target": "ES2018"
+  }
+}

--- a/website/docs/wordpress-shortcode-source.mdx
+++ b/website/docs/wordpress-shortcode-source.mdx
@@ -1,0 +1,63 @@
+---
+title: Wordpress Shortcode
+---
+
+The Wordpress Shortcode source adds annotations to documents with Wordpress shortcodes.
+
+## Getting Started
+
+Install the HTML source using `npm`:
+
+```bash
+npm install --save @atjson/source-wordpress-shortcode
+```
+
+## Using with HTML
+
+This plugin only handles Wordpress shortcodes, and requires a converter to be written to turn the shortcodes into a well understood format.
+
+You can combine the annotations together from the Wordpress Shortcode source and the HTML source:
+
+```ts
+import OffsetSource from "@atjson/offset-annotations";
+import HTMLSource from "@atjson/source-html";
+import WPSource from "@atjson/source-wordpress-shortcode";
+
+WPSource.defineConverterTo(OffsetSource, (doc) => {
+  // Write your conversions here
+  return doc;
+});
+
+function getAnnotatedSource(html: string) {
+  let doc = HTMLSource.fromRaw(html).convertTo(OffsetSource);
+  let wpDoc = WPSource.fromRaw(doc.content).convertTo(offsetSource);
+  doc.addAnnotations(...wpDoc.annotations);
+  return doc;
+}
+```
+
+## Test
+
+Test your Wordpress code here. (This website doesn't collect any data, and this runs completely on this page with bundled packages)
+
+import { useState } from "react";
+import { TextArea } from "../src/components/TextArea.tsx";
+import HTMLSource from "@atjson/source-html";
+import WPSource from "@atjson/source-wordpress-shortcode";
+
+export const WPDemo = (props) => {
+  let [code, setCode] = useState(
+    `[caption id="attachment_6" align="alignright" width="300"]<img src="http://localhost/wp-content/uploads/2010/07/800px-Great_Wave_off_Kanagawa2-300x205.jpg" alt="Kanagawa" title="The Great Wave" width="300" height="205" class="size-medium wp-image-6" /> The Great Wave[/caption]`
+  );
+  let doc = HTMLSource.fromRaw(code);
+  doc.addAnnotations(...WPSource.fromRaw(code).annotations);
+  return (
+    <>
+      <TextArea value={code} onChange={(evt) => setCode(evt.target.value)} />
+      <code language="json">{JSON.stringify(doc.toJSON(), null, 2)}</code>
+      <code>{doc.canonical().content}</code>
+    </>
+  );
+};
+
+<WPDemo />

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -16,7 +16,8 @@
       "html-source",
       "markdown-source",
       "prism-source",
-      "mobiledoc-source"
+      "mobiledoc-source",
+      "wordpress-shortcode-source"
     ],
     "Rendering": [
       "react-renderer",


### PR DESCRIPTION
This source is designed to annotate WordPress shortcodes, allowing for content from WordPress to be converted into other formats. Since WordPress instances are highly customised, we don't provide any converters (currently) out of the box.

In the documentation site, I've provided an example of combining the WordPress shortcode source with the HTML source to get a fully annotated WordPress story.