### PR TITLE
chore: add filter overload to doc.slice()

### DIFF
--- a/website/docs/document-api.mdx
+++ b/website/docs/document-api.mdx
@@ -582,6 +582,7 @@ doc.slice(0, 8);
 ```
 
 `slice` is a way to pull out a fragment of the document out of the original document. It does not remove the text or annotations from the original document.
+By default, all annotations that overlap the range of the slice will be truncated and included in the slice. This can be overriden by specifying a `filter` function
 
 import HTMLSource from "@atjson/source-html";
 import CodeBlock from "@theme/CodeBlock";


### PR DESCRIPTION
Add an optional `filter` overload to `document.slice(start, end, filter?)` and `document.cut(start, end, filter?)`. The filter function allows us to override which annotations should be truncated and included in the slice or cut. By default, we had been truncating and including every annotation that overlaps the range. Sometimes, we may want to only include annotations that lie wholly within the range, such as when slicing/cutting a subdocument - in that case we (sometimes) do not want to include annotations that may be wrapping the subdocument's parent annotation:

```
<section><figure><figcaption>Here is a caption</figcaption></figure></section>
                 ^--------------- caption ----------------^
         ^------------------------ figure -------------------------^
^------------------------------  section ------------------------------------^
```

In the case above, this allows us to slice out a caption without including the `figure` or `section` annotations in the slice:
```
doc.slice(start, end, a => start <= a.start && a.end <= end);
```