### PR TITLE
Automatically merge all renovate PRs except for major releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,10 @@
   "rebaseStalePrs": false,
   "packageRules": [
     {
+      "updateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
       "packagePatterns": ["@docusaurus/*"],
       "groupName": "docusaurus monorepo",
       "groupSlug": "docusaurus-monorepo"


### PR DESCRIPTION
This helps with upkeep in this repository by not having to merge lots of PRs