### PR TITLE
Add decorations as an optional attribute on paragraphs

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/paragraph.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/paragraph.ts
@@ -1,6 +1,10 @@
 import { BlockAnnotation } from "@atjson/document";
 
-export class Paragraph extends BlockAnnotation {
+export class Paragraph<
+  T = {
+    decorations?: string[];
+  }
+> extends BlockAnnotation<T> {
   static type = "paragraph";
   static vendorPrefix = "offset";
 

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -14,6 +14,7 @@ import {
   Italic,
   Link,
   List,
+  Paragraph,
 } from "@atjson/offset-annotations";
 import Renderer, { Context } from "@atjson/renderer-hir";
 import {
@@ -689,7 +690,10 @@ export default class CommonmarkRenderer extends Renderer {
   /**
    * Paragraphs are delimited by two or more newlines in markdown.
    */
-  *Paragraph(): Generator<void, string, string[]> {
+  *Paragraph(
+    _paragraph: Paragraph,
+    _context: Context
+  ): Generator<void, string, string[]> {
     let rawText = yield;
     let text = rawText.join("");
 


### PR DESCRIPTION
We want to support drop caps and stylistic lead ins in our text editor, and provide support that makes sense for both our text editor and our brand sites.

I've attached screenshots of what our editorial teams want (for _The New Yorker_ and _WIRED_ respectively).

![image](https://user-images.githubusercontent.com/177701/89336970-34437380-d668-11ea-89c7-1ac88f1d0dc9.png)

![image](https://user-images.githubusercontent.com/177701/89337010-48877080-d668-11ea-8380-a9a446f0fba6.png)

These will be implemented by adding a decoration to paragraphs. I'm choosing to make these arrays to allow for multiple decorations, since I've seen publications like _The Atlantic_ use both together effectively:

![image](https://user-images.githubusercontent.com/177701/89337176-8c7a7580-d668-11ea-9f05-0eca5e077ec8.png)


