### PR TITLE
Convert link "title" attributes from HTML

### DIFF
--- a/packages/@atjson/source-html/src/converter/index.ts
+++ b/packages/@atjson/source-html/src/converter/index.ts
@@ -60,6 +60,7 @@ HTMLSource.defineConverterTo(OffsetSource, function HTMLToOffset(doc) {
         "-html-href": "-offset-url",
         "-html-rel": "-offset-rel",
         "-html-target": "-offset-target",
+        "-html-title": "-offset-title",
       },
     });
 

--- a/packages/@atjson/source-html/test/converter-test.ts
+++ b/packages/@atjson/source-html/test/converter-test.ts
@@ -145,7 +145,7 @@ describe("@atjson/source-html", () => {
 
     test("a", () => {
       let doc = HTMLSource.fromRaw(
-        'This <a href="https://condenast.com" rel="nofollow" target="_blank">is a link</a>'
+        'This <a href="https://condenast.com" rel="nofollow" target="_blank" title="Condé Nast">is a link</a>'
       );
       let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
       expect(hir).toMatchObject({
@@ -159,6 +159,7 @@ describe("@atjson/source-html", () => {
               url: "https://condenast.com",
               rel: "nofollow",
               target: "_blank",
+              title: "Condé Nast",
             },
             children: ["is a link"],
           },


### PR DESCRIPTION
This was something missed in our conversion rules— this adds support for converting titles into annotations.