### PR TITLE
Add support for text alignment

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/blockquote.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/blockquote.ts
@@ -1,7 +1,7 @@
 import { BlockAnnotation } from "@atjson/document";
 
 export class Blockquote extends BlockAnnotation<{
-  inset?: string;
+  inset?: "left" | "right";
 }> {
   static type = "blockquote";
   static vendorPrefix = "offset";

--- a/packages/@atjson/offset-annotations/src/annotations/heading.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/heading.ts
@@ -2,6 +2,7 @@ import { BlockAnnotation } from "@atjson/document";
 
 export class Heading extends BlockAnnotation<{
   level: 1 | 2 | 3 | 4 | 5 | 6;
+  alignment?: "start" | "center" | "end" | "justify";
 }> {
   static type = "heading";
   static vendorPrefix = "offset";

--- a/packages/@atjson/offset-annotations/src/annotations/paragraph.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/paragraph.ts
@@ -3,6 +3,7 @@ import { BlockAnnotation } from "@atjson/document";
 export class Paragraph<
   T = {
     decorations?: string[];
+    alignment?: "start" | "center" | "end" | "justify";
   }
 > extends BlockAnnotation<T> {
   static type = "paragraph";

--- a/packages/@atjson/renderer-html/src/index.ts
+++ b/packages/@atjson/renderer-html/src/index.ts
@@ -6,6 +6,7 @@ import {
   Link,
   List,
   TikTokEmbed,
+  Paragraph,
 } from "@atjson/offset-annotations";
 import Renderer from "@atjson/renderer-hir";
 import * as entities from "entities";
@@ -150,7 +151,11 @@ export default class HTMLRenderer extends Renderer {
   }
 
   *Heading(heading: Heading) {
-    return yield* this.$(`h${heading.attributes.level}`);
+    let style: string | undefined;
+    if (heading.attributes.alignment) {
+      style = this.textAlign(heading.attributes.alignment);
+    }
+    return yield* this.$(`h${heading.attributes.level}`, { style });
   }
 
   *HorizontalRule() {
@@ -196,8 +201,12 @@ export default class HTMLRenderer extends Renderer {
     return yield* this.$("li");
   }
 
-  *Paragraph() {
-    return yield* this.$("p");
+  *Paragraph(paragraph: Paragraph) {
+    let style: string | undefined;
+    if (paragraph.attributes.alignment) {
+      style = this.textAlign(paragraph.attributes.alignment);
+    }
+    return yield* this.$("p", { style });
   }
 
   *Section() {
@@ -230,5 +239,14 @@ export default class HTMLRenderer extends Renderer {
 
   *Underline() {
     return yield* this.$("u");
+  }
+
+  protected textAlign(alignment: "start" | "center" | "end" | "justify") {
+    if (alignment === "start") {
+      return `text-align:left;`;
+    } else if (alignment === "end") {
+      return `text-align:right;`;
+    }
+    return `text-align:${alignment};`;
   }
 }

--- a/packages/@atjson/renderer-html/test/renderer-test.ts
+++ b/packages/@atjson/renderer-html/test/renderer-test.ts
@@ -63,6 +63,35 @@ describe("renderer-html", () => {
 
       expect(Renderer.render(doc)).toEqual(`<h${level}>Hello</h${level}>`);
     });
+
+    describe("alignment", () => {
+      describe.each([
+        ["left", "start"],
+        ["center", "center"],
+        ["right", "end"],
+        ["justify", "justify"],
+      ] as const)("%s", (textAlign, alignment) => {
+        test.each([1, 2, 3, 4, 5, 6] as const)("level %s", (level) => {
+          let doc = new OffsetSource({
+            content: "Hello",
+            annotations: [
+              new Heading({
+                start: 0,
+                end: 5,
+                attributes: {
+                  level,
+                  alignment,
+                },
+              }),
+            ],
+          });
+
+          expect(Renderer.render(doc)).toEqual(
+            `<h${level} style="text-align:${textAlign};">Hello</h${level}>`
+          );
+        });
+      });
+    });
   });
 
   test("horizontal rule", () => {
@@ -289,13 +318,39 @@ describe("renderer-html", () => {
     });
   });
 
-  test("paragraph", () => {
-    let doc = new OffsetSource({
-      content: "Hello",
-      annotations: [new Paragraph({ start: 0, end: 5 })],
+  describe("paragraph", () => {
+    test("paragraph", () => {
+      let doc = new OffsetSource({
+        content: "Hello",
+        annotations: [new Paragraph({ start: 0, end: 5 })],
+      });
+
+      expect(Renderer.render(doc)).toEqual("<p>Hello</p>");
     });
 
-    expect(Renderer.render(doc)).toEqual("<p>Hello</p>");
+    describe("alignment", () => {
+      describe.each([
+        ["left", "start"],
+        ["center", "center"],
+        ["right", "end"],
+        ["justify", "justify"],
+      ] as const)("%s", (textAlign, alignment) => {
+        let doc = new OffsetSource({
+          content: "Hello",
+          annotations: [
+            new Paragraph({
+              start: 0,
+              end: 5,
+              attributes: { alignment },
+            }),
+          ],
+        });
+
+        expect(Renderer.render(doc)).toEqual(
+          `<p style="text-align:${textAlign};">Hello</p>`
+        );
+      });
+    });
   });
 
   test("section", () => {

--- a/packages/@atjson/source-gdocs-paste/src/annotations/alignment.ts
+++ b/packages/@atjson/source-gdocs-paste/src/annotations/alignment.ts
@@ -1,0 +1,9 @@
+import { BlockAnnotation } from "@atjson/document";
+
+export class Alignment extends BlockAnnotation<{
+  // Text alignment: left / center / right / justify
+  align: 0 | 1 | 2 | 3;
+}> {
+  static vendorPrefix = "gdocs";
+  static type = "ps_al"; // Text style: vertical adjust
+}

--- a/packages/@atjson/source-gdocs-paste/src/annotations/heading.ts
+++ b/packages/@atjson/source-gdocs-paste/src/annotations/heading.ts
@@ -2,6 +2,7 @@ import { BlockAnnotation } from "@atjson/document";
 
 export class Heading extends BlockAnnotation<{
   level: 1 | 2 | 3 | 4 | 5 | 6 | 100 | 101;
+  align: 0 | 1 | 2 | 3;
 }> {
   static vendorPrefix = "gdocs";
   static type = "ps_hd";

--- a/packages/@atjson/source-gdocs-paste/src/annotations/index.ts
+++ b/packages/@atjson/source-gdocs-paste/src/annotations/index.ts
@@ -1,3 +1,4 @@
+export * from "./alignment";
 export * from "./bold";
 export * from "./heading";
 export * from "./horizontal-rule";

--- a/packages/@atjson/source-gdocs-paste/src/converter.ts
+++ b/packages/@atjson/source-gdocs-paste/src/converter.ts
@@ -64,6 +64,24 @@ GDocsSource.defineConverterTo(OffsetSource, (doc) => {
     .set({ type: "-offset-heading" })
     .rename({ attributes: { "-gdocs-level": "-offset-level" } });
 
+  doc
+    .where({ type: "-offset-heading", attributes: { "-gdocs-align": 1 } })
+    .unset("attributes.-gdocs-align")
+    .set({ attributes: { "-offset-alignment": "center" } });
+
+  doc
+    .where({ type: "-offset-heading", attributes: { "-gdocs-align": 2 } })
+    .unset("attributes.-gdocs-align")
+    .set({ attributes: { "-offset-alignment": "end" } });
+
+  doc
+    .where({ type: "-offset-heading", attributes: { "-gdocs-align": 3 } })
+    .unset("attributes.-gdocs-align")
+    .set({ attributes: { "-offset-alignment": "justify" } });
+
+  // Remove all other alignments
+  doc.where({ type: "-offset-heading" }).unset("attributes.-gdocs-align");
+
   // b_gt: 9 indicates an unordered list, but ordered lists have a variety of b_gt values
   doc
     .where({ type: "-gdocs-list", attributes: { "-gdocs-ls_b_gt": 9 } })
@@ -182,6 +200,34 @@ GDocsSource.defineConverterTo(OffsetSource, (doc) => {
         );
       }
     });
+
+  doc.where({ type: "-gdocs-ps_al" }).update((align) => {
+    let alignment: "start" | "center" | "end" | "justify" | undefined;
+    switch (align.attributes.align) {
+      case 0:
+        alignment = "start";
+        break;
+      case 1:
+        alignment = "center";
+        break;
+      case 2:
+        alignment = "end";
+        break;
+      case 3:
+        alignment = "justify";
+        break;
+    }
+    doc.replaceAnnotation(
+      align,
+      new Paragraph({
+        start: align.start,
+        end: align.end,
+        attributes: {
+          alignment,
+        },
+      })
+    );
+  });
 
   // GDocs can produce lists that have paragraphs in them that are
   // not wrapped by a list item. In these cases, split the list before

--- a/packages/@atjson/source-gdocs-paste/src/paragraph-styles.ts
+++ b/packages/@atjson/source-gdocs-paste/src/paragraph-styles.ts
@@ -8,7 +8,7 @@ import { GDocsStyleSlice } from "./types";
  *
  * Paragraph style attributes are:
  *
- *   ps_al: unknown
+ *   ps_al: 0 | 1 | 2 | 3 // Paragraph alignment
  *   ps_awao: unknown
  *   ps_bb: unknown
  *   ps_bbtw: unknown
@@ -50,6 +50,18 @@ export default function extractParagraphStyles(
         end: i,
         attributes: {
           "-gdocs-level": style.ps_hd,
+          "-gdocs-align": style.ps_al,
+        },
+      });
+    }
+
+    if (style.ps_al !== 0) {
+      annotations.push({
+        type: "-gdocs-ps_al",
+        start: lastParagraphStart,
+        end: i,
+        attributes: {
+          "-gdocs-align": style.ps_al,
         },
       });
     }

--- a/packages/@atjson/source-gdocs-paste/src/source.ts
+++ b/packages/@atjson/source-gdocs-paste/src/source.ts
@@ -1,5 +1,6 @@
 import Document from "@atjson/document";
 import {
+  Alignment,
   Bold,
   Heading,
   HorizontalRule,
@@ -17,6 +18,7 @@ import GDocsParser, { GDocsPasteBuffer } from "./gdocs-parser";
 export default class extends Document {
   static contentType = "application/vnd.atjson+gdocs";
   static schema = [
+    Alignment,
     Bold,
     Heading,
     HorizontalRule,

--- a/packages/@atjson/source-gdocs-paste/test/fixtures/heading-alignment.json
+++ b/packages/@atjson/source-gdocs-paste/test/fixtures/heading-alignment.json
@@ -1,0 +1,881 @@
+{
+  "resolved": {
+    "dsl_spacers": "Left\nCentered\nRight\nJustified\n",
+    "dsl_styleslices": [
+      {
+        "stsl_type": "autogen",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "cell",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "column_sector",
+        "stsl_leading": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous",
+          "css_mb": null,
+          "css_mh": null,
+          "css_mf": null,
+          "css_ml": null,
+          "css_mr": null,
+          "css_mt": null,
+          "css_fi": null,
+          "css_hi": null,
+          "css_epfi": null,
+          "css_ephi": null,
+          "css_fpfi": null,
+          "css_fphi": null,
+          "css_ufphf": null,
+          "css_pnsi": null
+        },
+        "stsl_leadingType": "column_sector",
+        "stsl_trailing": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous",
+          "css_mb": null,
+          "css_mh": null,
+          "css_mf": null,
+          "css_ml": null,
+          "css_mr": null,
+          "css_mt": null,
+          "css_fi": null,
+          "css_hi": null,
+          "css_epfi": null,
+          "css_ephi": null,
+          "css_fpfi": null,
+          "css_fphi": null,
+          "css_ufphf": null,
+          "css_pnsi": null
+        },
+        "stsl_trailingType": "column_sector",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "comment",
+        "stsl_styles": [
+          {
+            "cs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "date_time",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "document",
+        "stsl_leading": {
+          "ds_b": {
+            "bg_c": null
+          },
+          "ds_fi": null,
+          "ds_hi": null,
+          "ds_epfi": null,
+          "ds_ephi": null,
+          "ds_uephf": false,
+          "ds_fpfi": null,
+          "ds_fphi": null,
+          "ds_ufphf": false,
+          "ds_pnsi": 1,
+          "ds_mb": 72,
+          "ds_ml": 72,
+          "ds_mr": 72,
+          "ds_mt": 72,
+          "ds_ph": 792,
+          "ds_pw": 612,
+          "ds_rtd": "",
+          "ds_mh": 36,
+          "ds_mf": 36,
+          "ds_ulhfl": false,
+          "ds_lhs": 0
+        },
+        "stsl_leadingType": "document",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation_function",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "footnote",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "headings",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "horizontal_rule",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "ignore_spellcheck",
+        "stsl_styles": [
+          {
+            "isc_osh": null
+          }
+        ]
+      },
+      {
+        "stsl_type": "import_warnings",
+        "stsl_styles": [
+          {
+            "iws_iwids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "language",
+        "stsl_trailing": {
+          "lgs_l": "en"
+        },
+        "stsl_trailingType": "language",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "link",
+        "stsl_styles": [
+          {
+            "lnks_link": null
+          }
+        ]
+      },
+      {
+        "stsl_type": "list",
+        "stsl_styles": [
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "named_range",
+        "stsl_styles": [
+          {
+            "nrs_ei": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "paragraph",
+        "stsl_styles": [
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 1,
+            "ps_hdid": "h.ov2bceg47xh6",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": true,
+            "ps_kwn": true,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 6,
+            "ps_sb": 20,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 1,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 2,
+            "ps_hdid": "h.3vd3khp3ufbt",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": true,
+            "ps_kwn": true,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 6,
+            "ps_sb": 18,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 2,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 3,
+            "ps_hdid": "h.wh4eyitqp928",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": true,
+            "ps_kwn": true,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 4,
+            "ps_sb": 16,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 3,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 4,
+            "ps_hdid": "h.z0pvl61iqp33",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": true,
+            "ps_kwn": true,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 4,
+            "ps_sb": 14,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "row",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "suppress_feature",
+        "stsl_styles": [
+          {
+            "sfs_sst": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "tbl",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "text",
+        "stsl_styles": [
+          {
+            "ts_bd": false,
+            "ts_fs": 20,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 16,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 14,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#434343"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 12,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#666666"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          }
+        ]
+      }
+    ],
+    "dsl_metastyleslices": [
+      {
+        "stsl_type": "autocorrect",
+        "stsl_styles": [
+          {
+            "ac_ot": null,
+            "ac_ct": null,
+            "ac_type": null,
+            "ac_sm": {
+              "asm_s": 0,
+              "asm_rl": 0,
+              "asm_l": ""
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "composing_decoration",
+        "stsl_styles": [
+          {
+            "cd_u": false,
+            "cd_bgc": {
+              "clr_type": 0,
+              "hclr_color": null
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "composing_region",
+        "stsl_styles": [
+          {
+            "cr_c": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "draft_comment",
+        "stsl_styles": [
+          {
+            "dcs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "ignore_word",
+        "stsl_styles": [
+          {
+            "iwos_i": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "revision_diff",
+        "stsl_styles": [
+          {
+            "revdiff_dt": 0,
+            "revdiff_a": "",
+            "revdiff_aid": ""
+          }
+        ]
+      },
+      {
+        "stsl_type": "smart_todo",
+        "stsl_styles": [
+          {
+            "sts_cid": null,
+            "sts_ot": null,
+            "sts_ac": null,
+            "sts_hi": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_pa": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_dm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "spellcheck",
+        "stsl_styles": [
+          {
+            "sc_ow": null,
+            "sc_sl": null,
+            "sc_sugg": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sc_sm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_corrections",
+        "stsl_styles": [
+          {
+            "vcs_c": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_dotted_span",
+        "stsl_styles": [
+          {
+            "vdss_p": null
+          }
+        ]
+      }
+    ],
+    "dsl_suggestedinsertions": {
+      "sgsl_sugg": [[]]
+    },
+    "dsl_suggesteddeletions": {
+      "sgsl_sugg": [[]]
+    },
+    "dsl_entitypositionmap": {},
+    "dsl_entitymap": {},
+    "dsl_entitytypemap": {},
+    "dsl_relateddocslices": {}
+  },
+  "autotext_content": {}
+}

--- a/packages/@atjson/source-gdocs-paste/test/fixtures/paragraph-alignment.json
+++ b/packages/@atjson/source-gdocs-paste/test/fixtures/paragraph-alignment.json
@@ -1,0 +1,777 @@
+{
+  "resolved": {
+    "dsl_spacers": "Left\nCentered\nRight\nJustified\n",
+    "dsl_styleslices": [
+      {
+        "stsl_type": "autogen",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "cell",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "column_sector",
+        "stsl_leading": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous",
+          "css_mb": null,
+          "css_mh": null,
+          "css_mf": null,
+          "css_ml": null,
+          "css_mr": null,
+          "css_mt": null,
+          "css_fi": null,
+          "css_hi": null,
+          "css_epfi": null,
+          "css_ephi": null,
+          "css_fpfi": null,
+          "css_fphi": null,
+          "css_ufphf": null,
+          "css_pnsi": null
+        },
+        "stsl_leadingType": "column_sector",
+        "stsl_trailing": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous",
+          "css_mb": null,
+          "css_mh": null,
+          "css_mf": null,
+          "css_ml": null,
+          "css_mr": null,
+          "css_mt": null,
+          "css_fi": null,
+          "css_hi": null,
+          "css_epfi": null,
+          "css_ephi": null,
+          "css_fpfi": null,
+          "css_fphi": null,
+          "css_ufphf": null,
+          "css_pnsi": null
+        },
+        "stsl_trailingType": "column_sector",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "comment",
+        "stsl_styles": [
+          {
+            "cs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "date_time",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "document",
+        "stsl_leading": {
+          "ds_b": {
+            "bg_c": null
+          },
+          "ds_fi": null,
+          "ds_hi": null,
+          "ds_epfi": null,
+          "ds_ephi": null,
+          "ds_uephf": false,
+          "ds_fpfi": null,
+          "ds_fphi": null,
+          "ds_ufphf": false,
+          "ds_pnsi": 1,
+          "ds_mb": 72,
+          "ds_ml": 72,
+          "ds_mr": 72,
+          "ds_mt": 72,
+          "ds_ph": 792,
+          "ds_pw": 612,
+          "ds_rtd": "",
+          "ds_mh": 36,
+          "ds_mf": 36,
+          "ds_ulhfl": false,
+          "ds_lhs": 0
+        },
+        "stsl_leadingType": "document",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation_function",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "footnote",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "headings",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "horizontal_rule",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "ignore_spellcheck",
+        "stsl_styles": [
+          {
+            "isc_osh": null
+          }
+        ]
+      },
+      {
+        "stsl_type": "import_warnings",
+        "stsl_styles": [
+          {
+            "iws_iwids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "language",
+        "stsl_trailing": {
+          "lgs_l": "en"
+        },
+        "stsl_trailingType": "language",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "link",
+        "stsl_styles": [
+          {
+            "lnks_link": null
+          }
+        ]
+      },
+      {
+        "stsl_type": "list",
+        "stsl_styles": [
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "named_range",
+        "stsl_styles": [
+          {
+            "nrs_ei": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "paragraph",
+        "stsl_styles": [
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 1,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 2,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 3,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "row",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "suppress_feature",
+        "stsl_styles": [
+          {
+            "sfs_sst": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "tbl",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "text",
+        "stsl_styles": [
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          }
+        ]
+      }
+    ],
+    "dsl_metastyleslices": [
+      {
+        "stsl_type": "autocorrect",
+        "stsl_styles": [
+          {
+            "ac_ot": null,
+            "ac_ct": null,
+            "ac_type": null,
+            "ac_sm": {
+              "asm_s": 0,
+              "asm_rl": 0,
+              "asm_l": ""
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "composing_decoration",
+        "stsl_styles": [
+          {
+            "cd_u": false,
+            "cd_bgc": {
+              "clr_type": 0,
+              "hclr_color": null
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "composing_region",
+        "stsl_styles": [
+          {
+            "cr_c": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "draft_comment",
+        "stsl_styles": [
+          {
+            "dcs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "ignore_word",
+        "stsl_styles": [
+          {
+            "iwos_i": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "revision_diff",
+        "stsl_styles": [
+          {
+            "revdiff_dt": 0,
+            "revdiff_a": "",
+            "revdiff_aid": ""
+          }
+        ]
+      },
+      {
+        "stsl_type": "smart_todo",
+        "stsl_styles": [
+          {
+            "sts_cid": null,
+            "sts_ot": null,
+            "sts_ac": null,
+            "sts_hi": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_pa": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_dm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "spellcheck",
+        "stsl_styles": [
+          {
+            "sc_ow": null,
+            "sc_sl": null,
+            "sc_sugg": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sc_sm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_corrections",
+        "stsl_styles": [
+          {
+            "vcs_c": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_dotted_span",
+        "stsl_styles": [
+          {
+            "vdss_p": null
+          }
+        ]
+      }
+    ],
+    "dsl_suggestedinsertions": {
+      "sgsl_sugg": [[]]
+    },
+    "dsl_suggesteddeletions": {
+      "sgsl_sugg": [[]]
+    },
+    "dsl_entitypositionmap": {},
+    "dsl_entitymap": {},
+    "dsl_entitytypemap": {},
+    "dsl_relateddocslices": {}
+  },
+  "autotext_content": {}
+}

--- a/packages/@atjson/source-gdocs-paste/test/fixtures/rtl-paragraph-alignment.json
+++ b/packages/@atjson/source-gdocs-paste/test/fixtures/rtl-paragraph-alignment.json
@@ -1,0 +1,843 @@
+{
+  "resolved": {
+    "dsl_spacers": "بداية\nمركز\nالنهاية\nنص\n\n",
+    "dsl_styleslices": [
+      {
+        "stsl_type": "autogen",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "cell",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "column_sector",
+        "stsl_leading": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous",
+          "css_mb": null,
+          "css_mh": null,
+          "css_mf": null,
+          "css_ml": null,
+          "css_mr": null,
+          "css_mt": null,
+          "css_fi": null,
+          "css_hi": null,
+          "css_epfi": null,
+          "css_ephi": null,
+          "css_fpfi": null,
+          "css_fphi": null,
+          "css_ufphf": null,
+          "css_pnsi": null
+        },
+        "stsl_leadingType": "column_sector",
+        "stsl_trailing": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous",
+          "css_mb": null,
+          "css_mh": null,
+          "css_mf": null,
+          "css_ml": null,
+          "css_mr": null,
+          "css_mt": null,
+          "css_fi": null,
+          "css_hi": null,
+          "css_epfi": null,
+          "css_ephi": null,
+          "css_fpfi": null,
+          "css_fphi": null,
+          "css_ufphf": null,
+          "css_pnsi": null
+        },
+        "stsl_trailingType": "column_sector",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "comment",
+        "stsl_styles": [
+          {
+            "cs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "date_time",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "document",
+        "stsl_leading": {
+          "ds_b": {
+            "bg_c": null
+          },
+          "ds_fi": null,
+          "ds_hi": null,
+          "ds_epfi": null,
+          "ds_ephi": null,
+          "ds_uephf": false,
+          "ds_fpfi": null,
+          "ds_fphi": null,
+          "ds_ufphf": false,
+          "ds_pnsi": 1,
+          "ds_mb": 72,
+          "ds_ml": 72,
+          "ds_mr": 72,
+          "ds_mt": 72,
+          "ds_ph": 792,
+          "ds_pw": 612,
+          "ds_rtd": "",
+          "ds_mh": 36,
+          "ds_mf": 36,
+          "ds_ulhfl": false,
+          "ds_lhs": 0
+        },
+        "stsl_leadingType": "document",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation_function",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "footnote",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "headings",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "horizontal_rule",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "ignore_spellcheck",
+        "stsl_styles": [
+          {
+            "isc_osh": null
+          }
+        ]
+      },
+      {
+        "stsl_type": "import_warnings",
+        "stsl_styles": [
+          {
+            "iws_iwids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "language",
+        "stsl_trailing": {
+          "lgs_l": "en"
+        },
+        "stsl_trailingType": "language",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "link",
+        "stsl_styles": [
+          {
+            "lnks_link": null
+          }
+        ]
+      },
+      {
+        "stsl_type": "list",
+        "stsl_styles": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "named_range",
+        "stsl_styles": [
+          {
+            "nrs_ei": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "paragraph",
+        "stsl_styles": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": false,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 1,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": false,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 2,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": false,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          null,
+          {
+            "ps_al": 3,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": false,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": false,
+            "ps_ls": 1.15,
+            "ps_lslm": 1,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_lslm_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "row",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "suppress_feature",
+        "stsl_styles": [
+          {
+            "sfs_sst": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "tbl",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "text",
+        "stsl_styles": [
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          }
+        ]
+      }
+    ],
+    "dsl_metastyleslices": [
+      {
+        "stsl_type": "autocorrect",
+        "stsl_styles": [
+          {
+            "ac_ot": null,
+            "ac_ct": null,
+            "ac_type": null,
+            "ac_sm": {
+              "asm_s": 0,
+              "asm_rl": 0,
+              "asm_l": ""
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "composing_decoration",
+        "stsl_styles": [
+          {
+            "cd_u": false,
+            "cd_bgc": {
+              "clr_type": 0,
+              "hclr_color": null
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "composing_region",
+        "stsl_styles": [
+          {
+            "cr_c": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "draft_comment",
+        "stsl_styles": [
+          {
+            "dcs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "ignore_word",
+        "stsl_styles": [
+          {
+            "iwos_i": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "revision_diff",
+        "stsl_styles": [
+          {
+            "revdiff_dt": 0,
+            "revdiff_a": "",
+            "revdiff_aid": ""
+          }
+        ]
+      },
+      {
+        "stsl_type": "smart_todo",
+        "stsl_styles": [
+          {
+            "sts_cid": null,
+            "sts_ot": null,
+            "sts_ac": null,
+            "sts_hi": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_pa": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_dm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "spellcheck",
+        "stsl_styles": [
+          {
+            "sc_ow": null,
+            "sc_sl": null,
+            "sc_sugg": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sc_sm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_corrections",
+        "stsl_styles": [
+          {
+            "vcs_c": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_dotted_span",
+        "stsl_styles": [
+          {
+            "vdss_p": null
+          }
+        ]
+      }
+    ],
+    "dsl_suggestedinsertions": {
+      "sgsl_sugg": [[]]
+    },
+    "dsl_suggesteddeletions": {
+      "sgsl_sugg": [[]]
+    },
+    "dsl_entitypositionmap": {},
+    "dsl_entitymap": {},
+    "dsl_entitytypemap": {},
+    "dsl_relateddocslices": {}
+  },
+  "autotext_content": {}
+}

--- a/packages/@atjson/source-gdocs-paste/test/text-alignment-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/text-alignment-test.ts
@@ -1,0 +1,210 @@
+import OffsetSource from "@atjson/offset-annotations";
+import * as fs from "fs";
+import * as path from "path";
+import GDocsSource from "../src";
+
+describe("@atjson/source-gdocs-paste", () => {
+  describe("text alignment", () => {
+    describe("headings", () => {
+      let doc: OffsetSource;
+      beforeAll(() => {
+        // https://docs.google.com/document/d/1-5dIvVfeaZKiNMXpjH3Oyg-5OsWqTQxCuZbLPCL5Y3w/edit?usp=sharing
+        let fixturePath = path.join(
+          __dirname,
+          "fixtures",
+          "heading-alignment.json"
+        );
+        let rawJSON = JSON.parse(fs.readFileSync(fixturePath).toString());
+        let gdocs = GDocsSource.fromRaw(rawJSON);
+        doc = gdocs.convertTo(OffsetSource);
+      });
+
+      test("start", () => {
+        expect(doc.content).toBe("Left\nCentered\nRight\nJustified\n");
+        expect(
+          doc
+            .where({
+              type: "-offset-heading",
+              attributes: { "-offset-level": 1 },
+            })
+            .toJSON()
+        ).toMatchObject([
+          {
+            type: "-offset-heading",
+            start: 0,
+            end: 4,
+            attributes: { "-offset-level": 1 },
+          },
+        ]);
+      });
+
+      test("center", () => {
+        expect(
+          doc
+            .where({
+              type: "-offset-heading",
+              attributes: { "-offset-level": 2 },
+            })
+            .toJSON()
+        ).toMatchObject([
+          {
+            type: "-offset-heading",
+            start: 5,
+            end: 13,
+            attributes: { "-offset-level": 2, "-offset-alignment": "center" },
+          },
+        ]);
+      });
+
+      test("end", () => {
+        expect(
+          doc
+            .where({
+              type: "-offset-heading",
+              attributes: { "-offset-level": 3 },
+            })
+            .toJSON()
+        ).toMatchObject([
+          {
+            type: "-offset-heading",
+            start: 14,
+            end: 19,
+            attributes: { "-offset-level": 3, "-offset-alignment": "end" },
+          },
+        ]);
+      });
+
+      test("justified", () => {
+        expect(
+          doc
+            .where({
+              type: "-offset-heading",
+              attributes: { "-offset-level": 4 },
+            })
+            .toJSON()
+        ).toMatchObject([
+          {
+            type: "-offset-heading",
+            start: 20,
+            end: 29,
+            attributes: { "-offset-level": 4, "-offset-alignment": "justify" },
+          },
+        ]);
+      });
+    });
+  });
+
+  describe("paragraph", () => {
+    let doc: OffsetSource;
+    beforeAll(() => {
+      // https://docs.google.com/document/d/1KDcwN4gR-Es4LNIm2YwYJdvAlGrvWNMyd1mgXWGbEp0/edit?usp=sharing
+      let fixturePath = path.join(
+        __dirname,
+        "fixtures",
+        "paragraph-alignment.json"
+      );
+      let rawJSON = JSON.parse(fs.readFileSync(fixturePath).toString());
+      let gdocs = GDocsSource.fromRaw(rawJSON);
+      doc = gdocs.convertTo(OffsetSource);
+    });
+
+    test("start", () => {
+      expect(doc.content).toBe("Left\nCentered\nRight\nJustified\n");
+      let [left] = doc.where({ type: "-offset-paragraph" }).sort();
+      expect(left.toJSON()).toMatchObject({
+        type: "-offset-paragraph",
+        start: 0,
+        end: 4,
+        attributes: {},
+      });
+    });
+
+    test("center", () => {
+      let [, center] = doc.where({ type: "-offset-paragraph" }).sort();
+
+      expect(center.toJSON()).toMatchObject({
+        type: "-offset-paragraph",
+        start: 5,
+        end: 13,
+        attributes: { "-offset-alignment": "center" },
+      });
+    });
+
+    test("end", () => {
+      let [, , right] = doc.where({ type: "-offset-paragraph" }).sort();
+      expect(right.toJSON()).toMatchObject({
+        type: "-offset-paragraph",
+        start: 14,
+        end: 19,
+        attributes: { "-offset-alignment": "end" },
+      });
+    });
+
+    test("justified", () => {
+      let [, , , justified] = doc.where({ type: "-offset-paragraph" }).sort();
+      expect(justified.toJSON()).toMatchObject({
+        type: "-offset-paragraph",
+        start: 20,
+        end: 29,
+        attributes: { "-offset-alignment": "justify" },
+      });
+    });
+  });
+
+  describe("rtl", () => {
+    let doc: OffsetSource;
+    beforeAll(() => {
+      // https://docs.google.com/document/d/1JW5m2FcdOvwTwxwVYXKpc9ljzPnyYwaLyLPeeCMUsJQ/edit?usp=sharing
+      let fixturePath = path.join(
+        __dirname,
+        "fixtures",
+        "rtl-paragraph-alignment.json"
+      );
+      let rawJSON = JSON.parse(fs.readFileSync(fixturePath).toString());
+      let gdocs = GDocsSource.fromRaw(rawJSON);
+      doc = gdocs.convertTo(OffsetSource);
+    });
+
+    test("start", () => {
+      expect(doc.content).toBe("بداية\nمركز\nالنهاية\nنص\n\n");
+      let [left] = doc.where({ type: "-offset-paragraph" }).sort();
+      expect(left.toJSON()).toMatchObject({
+        type: "-offset-paragraph",
+        start: 0,
+        end: 5,
+        attributes: {},
+      });
+    });
+
+    test("center", () => {
+      let [, center] = doc.where({ type: "-offset-paragraph" }).sort();
+
+      expect(center.toJSON()).toMatchObject({
+        type: "-offset-paragraph",
+        start: 6,
+        end: 10,
+        attributes: { "-offset-alignment": "center" },
+      });
+    });
+
+    test("end", () => {
+      let [, , right] = doc.where({ type: "-offset-paragraph" }).sort();
+      expect(right.toJSON()).toMatchObject({
+        type: "-offset-paragraph",
+        start: 11,
+        end: 18,
+        attributes: { "-offset-alignment": "end" },
+      });
+    });
+
+    test("justified", () => {
+      let [, , , justified] = doc.where({ type: "-offset-paragraph" }).sort();
+      expect(justified.toJSON()).toMatchObject({
+        type: "-offset-paragraph",
+        start: 19,
+        end: 21,
+        attributes: { "-offset-alignment": "justify" },
+      });
+    });
+  });
+});

--- a/packages/@atjson/source-html/src/converter/headings.ts
+++ b/packages/@atjson/source-html/src/converter/headings.ts
@@ -1,0 +1,50 @@
+import Document, { is, AnnotationConstructor } from "@atjson/document";
+import { Heading } from "@atjson/offset-annotations";
+import { parseCSS, toAlignment } from "./utils";
+import { H1, H2, H3, H4, H5, H6 } from "../annotations";
+
+function convert(
+  doc: Document,
+  type: AnnotationConstructor<any, any>,
+  level: 1 | 2 | 3 | 4 | 5 | 6
+) {
+  doc
+    .where((annotation) => is(annotation, type))
+    .as("heading")
+    .outerJoin(
+      doc
+        .where((annotation) => annotation.attributes.lang != null)
+        .as("languages"),
+      (heading, language) =>
+        heading.start >= language.start && heading.end <= language.end
+    )
+    .update(({ heading, languages }) => {
+      let lang = languages.sort((language) => language.end - language.start)[0];
+      let alignment = toAlignment(
+        parseCSS(heading.attributes.style)["text-align"],
+        lang?.attributes?.lang
+      );
+
+      doc.replaceAnnotation(
+        heading,
+        new Heading({
+          id: heading.id,
+          start: heading.start,
+          end: heading.end,
+          attributes: {
+            level,
+            alignment,
+          },
+        })
+      );
+    });
+}
+
+export default function (doc: Document) {
+  convert(doc, H1, 1);
+  convert(doc, H2, 2);
+  convert(doc, H3, 3);
+  convert(doc, H4, 4);
+  convert(doc, H5, 5);
+  convert(doc, H6, 6);
+}

--- a/packages/@atjson/source-html/src/converter/headings.ts
+++ b/packages/@atjson/source-html/src/converter/headings.ts
@@ -13,16 +13,23 @@ function convert(
     .as("heading")
     .outerJoin(
       doc
-        .where((annotation) => annotation.attributes.lang != null)
-        .as("languages"),
-      (heading, language) =>
-        heading.start >= language.start && heading.end <= language.end
+        .where((annotation) => annotation.attributes.dir != null)
+        .as("directions"),
+      (heading, direction) =>
+        heading.start >= direction.start && heading.end <= direction.end
     )
-    .update(({ heading, languages }) => {
-      let lang = languages.sort((language) => language.end - language.start)[0];
+    .update(({ heading, directions }) => {
+      let direction = directions.sort(
+        (direction) => direction.end - direction.start
+      )[0];
+      if (direction?.attributes.dir === "rtl") {
+        throw new Error(
+          "Right to left languages are currently not supported in atjson."
+        );
+      }
       let alignment = toAlignment(
         parseCSS(heading.attributes.style)["text-align"],
-        lang?.attributes?.lang
+        direction?.attributes?.dir
       );
 
       doc.replaceAnnotation(

--- a/packages/@atjson/source-html/src/converter/headings.ts
+++ b/packages/@atjson/source-html/src/converter/headings.ts
@@ -16,7 +16,7 @@ function convert(
         .where((annotation) => annotation.attributes.dir != null)
         .as("directions"),
       (heading, direction) =>
-        heading.start >= direction.start && heading.end <= direction.end
+        direction.start <= heading.start && heading.end <= direction.end
     )
     .update(({ heading, directions }) => {
       let direction = directions.sort(

--- a/packages/@atjson/source-html/src/converter/index.ts
+++ b/packages/@atjson/source-html/src/converter/index.ts
@@ -5,6 +5,8 @@ import HTMLSource from "../source";
 import convertSocialEmbeds from "./social-embeds";
 import convertThirdPartyEmbeds from "./third-party-embeds";
 import convertVideoEmbeds from "./video-embeds";
+import convertHeadings from "./headings";
+import convertParagraphs from "./paragraphs";
 
 function getText(doc: Document) {
   let text = "";
@@ -66,26 +68,9 @@ HTMLSource.defineConverterTo(OffsetSource, function HTMLToOffset(doc) {
 
   doc.where({ type: "-html-blockquote" }).set({ type: "-offset-blockquote" });
 
-  doc
-    .where({ type: "-html-h1" })
-    .set({ type: "-offset-heading", attributes: { "-offset-level": 1 } });
-  doc
-    .where({ type: "-html-h2" })
-    .set({ type: "-offset-heading", attributes: { "-offset-level": 2 } });
-  doc
-    .where({ type: "-html-h3" })
-    .set({ type: "-offset-heading", attributes: { "-offset-level": 3 } });
-  doc
-    .where({ type: "-html-h4" })
-    .set({ type: "-offset-heading", attributes: { "-offset-level": 4 } });
-  doc
-    .where({ type: "-html-h5" })
-    .set({ type: "-offset-heading", attributes: { "-offset-level": 5 } });
-  doc
-    .where({ type: "-html-h6" })
-    .set({ type: "-offset-heading", attributes: { "-offset-level": 6 } });
+  convertHeadings(doc);
+  convertParagraphs(doc);
 
-  doc.where({ type: "-html-p" }).set({ type: "-offset-paragraph" });
   doc.where({ type: "-html-br" }).set({ type: "-offset-line-break" });
   doc.where({ type: "-html-hr" }).set({ type: "-offset-horizontal-rule" });
 

--- a/packages/@atjson/source-html/src/converter/paragraphs.ts
+++ b/packages/@atjson/source-html/src/converter/paragraphs.ts
@@ -8,13 +8,20 @@ export default function (doc: Document) {
     .as("paragraph")
     .outerJoin(
       doc
-        .where((annotation) => annotation.attributes.lang != null)
-        .as("languages"),
-      (heading, language) =>
-        heading.start >= language.start && heading.end <= language.end
+        .where((annotation) => annotation.attributes.dir != null)
+        .as("directions"),
+      (heading, direction) =>
+        heading.start >= direction.start && heading.end <= direction.end
     )
-    .update(({ paragraph, languages }) => {
-      let lang = languages.sort((language) => language.end - language.start)[0];
+    .update(({ paragraph, directions }) => {
+      let direction = directions.sort(
+        (direction) => direction.end - direction.start
+      )[0];
+      if (direction?.attributes.dir === "rtl") {
+        throw new Error(
+          "Right to left languages are currently not supported in atjson."
+        );
+      }
 
       doc.replaceAnnotation(
         paragraph,
@@ -24,7 +31,7 @@ export default function (doc: Document) {
           attributes: {
             alignment: toAlignment(
               parseCSS(paragraph.attributes.style)["text-align"],
-              lang?.attributes?.lang
+              direction?.attributes?.lang
             ),
           },
         })

--- a/packages/@atjson/source-html/src/converter/paragraphs.ts
+++ b/packages/@atjson/source-html/src/converter/paragraphs.ts
@@ -1,0 +1,33 @@
+import Document from "@atjson/document";
+import { Paragraph } from "@atjson/offset-annotations";
+import { parseCSS, toAlignment } from "./utils";
+
+export default function (doc: Document) {
+  doc
+    .where({ type: "-html-p" })
+    .as("paragraph")
+    .outerJoin(
+      doc
+        .where((annotation) => annotation.attributes.lang != null)
+        .as("languages"),
+      (heading, language) =>
+        heading.start >= language.start && heading.end <= language.end
+    )
+    .update(({ paragraph, languages }) => {
+      let lang = languages.sort((language) => language.end - language.start)[0];
+
+      doc.replaceAnnotation(
+        paragraph,
+        new Paragraph({
+          start: paragraph.start,
+          end: paragraph.end,
+          attributes: {
+            alignment: toAlignment(
+              parseCSS(paragraph.attributes.style)["text-align"],
+              lang?.attributes?.lang
+            ),
+          },
+        })
+      );
+    });
+}

--- a/packages/@atjson/source-html/src/converter/utils.ts
+++ b/packages/@atjson/source-html/src/converter/utils.ts
@@ -10,21 +10,6 @@ export function parseCSS(css: string | undefined) {
   return styles;
 }
 
-const RightToLeft = [
-  "ar",
-  "arc",
-  "dv",
-  "fa",
-  "ha",
-  "he",
-  "khw",
-  "ks",
-  "ku",
-  "ps",
-  "ur",
-  "yi",
-];
-
 const RightToLeftAlignment = {
   left: "end",
   right: "start",
@@ -46,14 +31,13 @@ const LeftToRightAlignment = {
  */
 export function toAlignment(
   alignment: string | undefined,
-  language: string | undefined
+  direction: string | undefined
 ) {
   if (alignment == null) {
     return alignment;
   }
 
-  let [languageCode] = (language || "").toLowerCase().split("-");
-  if (RightToLeft.indexOf(languageCode) !== -1) {
+  if (direction === "rtl") {
     return RightToLeftAlignment[alignment];
   }
   return LeftToRightAlignment[alignment];

--- a/packages/@atjson/source-html/src/converter/utils.ts
+++ b/packages/@atjson/source-html/src/converter/utils.ts
@@ -1,0 +1,60 @@
+export function parseCSS(css: string | undefined) {
+  let rules = (css || "").split(";");
+  let styles: Record<string, string> = {};
+  for (let rule of rules) {
+    let [name, ...value] = rule.split(":");
+    if (value.length > 0) {
+      styles[name] = value.join(":").trim();
+    }
+  }
+  return styles;
+}
+
+const RightToLeft = [
+  "ar",
+  "arc",
+  "dv",
+  "fa",
+  "ha",
+  "he",
+  "khw",
+  "ks",
+  "ku",
+  "ps",
+  "ur",
+  "yi",
+];
+
+const RightToLeftAlignment = {
+  left: "end",
+  right: "start",
+  center: "center",
+  justify: "justify",
+} as { [key: string]: "start" | "end" | "center" | "justify" | undefined };
+
+const LeftToRightAlignment = {
+  left: "start",
+  right: "end",
+  center: "center",
+  justify: "justify",
+} as { [key: string]: "start" | "end" | "center" | "justify" | undefined };
+
+/**
+ *
+ * @param alignment The `text-align` property of the
+ * @param language The language code of
+ */
+export function toAlignment(
+  alignment: string | undefined,
+  language: string | undefined
+) {
+  if (alignment == null) {
+    return alignment;
+  }
+
+  let [languageCode] = (language || "").toLowerCase().split("-");
+  if (RightToLeft.indexOf(languageCode) !== -1) {
+    return RightToLeftAlignment[alignment];
+  }
+  return LeftToRightAlignment[alignment];
+}

--- a/packages/@atjson/source-html/test/heading-test.ts
+++ b/packages/@atjson/source-html/test/heading-test.ts
@@ -30,7 +30,7 @@ describe("headings", () => {
           "%s",
           (tagname) => {
             let doc = HTMLSource.fromRaw(
-              `<${tagname} style="text-align:${textAlign};" lang="en-US">Heading from ${tagname}</${tagname}>`
+              `<${tagname} style="text-align:${textAlign};">Heading from ${tagname}</${tagname}>`
             ).convertTo(OffsetSource);
             expect(
               doc.where({ type: `-offset-heading` }).annotations
@@ -46,16 +46,15 @@ describe("headings", () => {
         ["center", "center"],
         ["right", "start"],
         ["justify", "justify"],
-      ] as const)("%s", (textAlign, alignment) => {
+      ] as const)("%s", (textAlign) => {
         test.each([["h1"], ["h2"], ["h3"], ["h4"], ["h5"], ["h6"]])(
           "%s",
           (tagname) => {
-            let doc = HTMLSource.fromRaw(
-              `<${tagname} style="text-align:${textAlign};" lang="ar">Heading from ${tagname}</${tagname}>`
-            ).convertTo(OffsetSource);
-            expect(
-              doc.where({ type: `-offset-heading` }).annotations
-            ).toMatchObject([{ attributes: { alignment } }]);
+            expect(() => {
+              HTMLSource.fromRaw(
+                `<${tagname} style="text-align:${textAlign};" dir="rtl">Heading from ${tagname}</${tagname}>`
+              ).convertTo(OffsetSource);
+            }).toThrow();
           }
         );
       });

--- a/packages/@atjson/source-html/test/heading-test.ts
+++ b/packages/@atjson/source-html/test/heading-test.ts
@@ -21,22 +21,27 @@ describe("headings", () => {
   describe("alignment", () => {
     describe("left to right", () => {
       describe.each([
-        ["left", "start"],
-        ["center", "center"],
-        ["right", "end"],
-        ["justify", "justify"],
-      ] as const)("%s", (textAlign, alignment) => {
-        test.each([["h1"], ["h2"], ["h3"], ["h4"], ["h5"], ["h6"]])(
-          "%s",
-          (tagname) => {
-            let doc = HTMLSource.fromRaw(
-              `<${tagname} style="text-align:${textAlign};">Heading from ${tagname}</${tagname}>`
-            ).convertTo(OffsetSource);
-            expect(
-              doc.where({ type: `-offset-heading` }).annotations
-            ).toMatchObject([{ attributes: { alignment } }]);
-          }
-        );
+        ["with direction attribute", `dir="ltr"`],
+        ["without direction attribute", ""],
+      ])("%s", (dir) => {
+        describe.each([
+          ["left", "start"],
+          ["center", "center"],
+          ["right", "end"],
+          ["justify", "justify"],
+        ] as const)("%s", (textAlign, alignment) => {
+          test.each([["h1"], ["h2"], ["h3"], ["h4"], ["h5"], ["h6"]])(
+            "%s",
+            (tagname) => {
+              let doc = HTMLSource.fromRaw(
+                `<${tagname} style="text-align:${textAlign};" ${dir}>Heading from ${tagname}</${tagname}>`
+              ).convertTo(OffsetSource);
+              expect(
+                doc.where({ type: `-offset-heading` }).annotations
+              ).toMatchObject([{ attributes: { alignment } }]);
+            }
+          );
+        });
       });
     });
 

--- a/packages/@atjson/source-html/test/heading-test.ts
+++ b/packages/@atjson/source-html/test/heading-test.ts
@@ -1,0 +1,64 @@
+import OffsetSource from "@atjson/offset-annotations";
+import HTMLSource from "../src";
+
+describe("headings", () => {
+  test.each([
+    ["h1", 1],
+    ["h2", 2],
+    ["h3", 3],
+    ["h4", 4],
+    ["h5", 5],
+    ["h6", 6],
+  ])("%s", (tagname, level) => {
+    let doc = HTMLSource.fromRaw(
+      `<${tagname}>Heading from ${tagname}</${tagname}>`
+    ).convertTo(OffsetSource);
+    expect(doc.where({ type: `-offset-heading` }).annotations).toMatchObject([
+      { attributes: { level } },
+    ]);
+  });
+
+  describe("alignment", () => {
+    describe("left to right", () => {
+      describe.each([
+        ["left", "start"],
+        ["center", "center"],
+        ["right", "end"],
+        ["justify", "justify"],
+      ] as const)("%s", (textAlign, alignment) => {
+        test.each([["h1"], ["h2"], ["h3"], ["h4"], ["h5"], ["h6"]])(
+          "%s",
+          (tagname) => {
+            let doc = HTMLSource.fromRaw(
+              `<${tagname} style="text-align:${textAlign};" lang="en-US">Heading from ${tagname}</${tagname}>`
+            ).convertTo(OffsetSource);
+            expect(
+              doc.where({ type: `-offset-heading` }).annotations
+            ).toMatchObject([{ attributes: { alignment } }]);
+          }
+        );
+      });
+    });
+
+    describe("right to left", () => {
+      describe.each([
+        ["left", "end"],
+        ["center", "center"],
+        ["right", "start"],
+        ["justify", "justify"],
+      ] as const)("%s", (textAlign, alignment) => {
+        test.each([["h1"], ["h2"], ["h3"], ["h4"], ["h5"], ["h6"]])(
+          "%s",
+          (tagname) => {
+            let doc = HTMLSource.fromRaw(
+              `<${tagname} style="text-align:${textAlign};" lang="ar">Heading from ${tagname}</${tagname}>`
+            ).convertTo(OffsetSource);
+            expect(
+              doc.where({ type: `-offset-heading` }).annotations
+            ).toMatchObject([{ attributes: { alignment } }]);
+          }
+        );
+      });
+    });
+  });
+});

--- a/packages/@atjson/source-html/test/paragraph-test.ts
+++ b/packages/@atjson/source-html/test/paragraph-test.ts
@@ -4,25 +4,30 @@ import HTMLSource from "../src";
 describe("paragraphs", () => {
   describe("alignment", () => {
     describe("left to right", () => {
-      test.each([
-        ["left", "start"],
-        ["right", "end"],
-        ["center", "center"],
-        ["justify", "justify"],
-      ] as const)("%s attribute is converted", (textAlign, alignment) => {
-        let doc = HTMLSource.fromRaw(
-          `<p style="text-align:${textAlign};">Here is some text</p>`
-        ).convertTo(OffsetSource);
+      describe.each([
+        ["with direction attribute", `dir="ltr"`],
+        ["without direction attribute", ""],
+      ])("%s", (dir) => {
+        test.each([
+          ["left", "start"],
+          ["right", "end"],
+          ["center", "center"],
+          ["justify", "justify"],
+        ] as const)("%s attribute is converted", (textAlign, alignment) => {
+          let doc = HTMLSource.fromRaw(
+            `<p style="text-align:${textAlign};" ${dir}>Here is some text</p>`
+          ).convertTo(OffsetSource);
 
-        expect(
-          doc.where({ type: `-offset-paragraph` }).annotations
-        ).toMatchObject([
-          {
-            attributes: {
-              alignment,
+          expect(
+            doc.where({ type: `-offset-paragraph` }).annotations
+          ).toMatchObject([
+            {
+              attributes: {
+                alignment,
+              },
             },
-          },
-        ]);
+          ]);
+        });
       });
     });
 

--- a/packages/@atjson/source-html/test/paragraph-test.ts
+++ b/packages/@atjson/source-html/test/paragraph-test.ts
@@ -1,0 +1,52 @@
+import OffsetSource from "@atjson/offset-annotations";
+import HTMLSource from "../src";
+
+describe("paragraphs", () => {
+  describe("alignment", () => {
+    describe("left to right", () => {
+      test.each([
+        ["left", "start"],
+        ["right", "end"],
+        ["center", "center"],
+        ["justify", "justify"],
+      ] as const)("%s attribute is converted", (textAlign, alignment) => {
+        let doc = HTMLSource.fromRaw(
+          `<p style="text-align:${textAlign};" lang="en-US">Here is some text</p>`
+        ).convertTo(OffsetSource);
+
+        expect(
+          doc.where({ type: `-offset-paragraph` }).annotations
+        ).toMatchObject([
+          {
+            attributes: {
+              alignment,
+            },
+          },
+        ]);
+      });
+    });
+
+    describe("right to left", () => {
+      test.each([
+        ["left", "end"],
+        ["right", "start"],
+        ["center", "center"],
+        ["justify", "justify"],
+      ] as const)("%s attribute is converted", (textAlign, alignment) => {
+        let doc = HTMLSource.fromRaw(
+          `<p style="text-align:${textAlign};" lang="ar">Here is some text</p>`
+        ).convertTo(OffsetSource);
+
+        expect(
+          doc.where({ type: `-offset-paragraph` }).annotations
+        ).toMatchObject([
+          {
+            attributes: {
+              alignment,
+            },
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/packages/@atjson/source-html/test/paragraph-test.ts
+++ b/packages/@atjson/source-html/test/paragraph-test.ts
@@ -11,7 +11,7 @@ describe("paragraphs", () => {
         ["justify", "justify"],
       ] as const)("%s attribute is converted", (textAlign, alignment) => {
         let doc = HTMLSource.fromRaw(
-          `<p style="text-align:${textAlign};" lang="en-US">Here is some text</p>`
+          `<p style="text-align:${textAlign};">Here is some text</p>`
         ).convertTo(OffsetSource);
 
         expect(
@@ -32,20 +32,12 @@ describe("paragraphs", () => {
         ["right", "start"],
         ["center", "center"],
         ["justify", "justify"],
-      ] as const)("%s attribute is converted", (textAlign, alignment) => {
-        let doc = HTMLSource.fromRaw(
-          `<p style="text-align:${textAlign};" lang="ar">Here is some text</p>`
-        ).convertTo(OffsetSource);
-
-        expect(
-          doc.where({ type: `-offset-paragraph` }).annotations
-        ).toMatchObject([
-          {
-            attributes: {
-              alignment,
-            },
-          },
-        ]);
+      ] as const)("%s attribute is converted", (textAlign) => {
+        expect(() => {
+          HTMLSource.fromRaw(
+            `<p style="text-align:${textAlign};" dir="rtl">Here is some text</p>`
+          ).convertTo(OffsetSource);
+        }).toThrow();
       });
     });
   });

--- a/packages/@atjson/source-prism/test/__snapshots__/prism-test.ts.snap
+++ b/packages/@atjson/source-prism/test/__snapshots__/prism-test.ts.snap
@@ -2650,9 +2650,7 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {
-        "-html-class": "byline",
-      },
+      "attributes": Object {},
       "end": 752,
       "id": "Any<id>",
       "start": 639,
@@ -2725,9 +2723,7 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {
-        "-html-class": "deck",
-      },
+      "attributes": Object {},
       "end": 1086,
       "id": "Any<id>",
       "start": 753,
@@ -7714,9 +7710,7 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {
-        "-html-class": "byline",
-      },
+      "attributes": Object {},
       "end": 666,
       "id": "Any<id>",
       "start": 635,
@@ -7741,9 +7735,7 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {
-        "-html-class": "deck",
-      },
+      "attributes": Object {},
       "end": 725,
       "id": "Any<id>",
       "start": 667,
@@ -8756,9 +8748,7 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {
-        "-html-class": "byline",
-      },
+      "attributes": Object {},
       "end": 665,
       "id": "Any<id>",
       "start": 635,
@@ -8783,9 +8773,7 @@ Object {
       "type": "-atjson-parse-token",
     },
     Object {
-      "attributes": Object {
-        "-html-class": "deck",
-      },
+      "attributes": Object {},
       "end": 753,
       "id": "Any<id>",
       "start": 666,

--- a/tests/fixtures/html/paragraph.html
+++ b/tests/fixtures/html/paragraph.html
@@ -1,0 +1,4 @@
+<p>Hello, world</p>
+<p style="text-align: center">* * *</p>
+<p style="text-align: right">&lt;3</p>
+<p style="text-align: justify">&lt;3</p>

--- a/website/docs/google-docs-explainer.md
+++ b/website/docs/google-docs-explainer.md
@@ -43,9 +43,9 @@ Paragraph styles set on a character level are either `null` or an object with th
 
 `ps_al`: `integer` between `0` and `3`
 
-- `0`: Left align text
+- `0`: Align text to the start of the line
 - `1`: Center text
-- `2`: Right align text
+- `2`: Align text to the end of the line
 - `3`: Justify text
 
 `ps_hd`: `integer` between `0` and `6`, `100`, `101` (others?)

--- a/website/docs/google-docs-explainer.md
+++ b/website/docs/google-docs-explainer.md
@@ -41,6 +41,13 @@ applies (? - needs verification) to the text seen _since_ the previous paragraph
 
 Paragraph styles set on a character level are either `null` or an object with the following properties:
 
+`ps_al`: `integer` between `0` and `3`
+
+- `0`: Left align text
+- `1`: Center text
+- `2`: Right align text
+- `3`: Justify text
+
 `ps_hd`: `integer` between `0` and `6`, `100`, `101` (others?)
 
 - `0`: Normal paragraph


### PR DESCRIPTION
This adds support for text alignment, based off of new experimental CSS properties that are language independent, `start`, `end`, `center`, and `justify`.

I've added support for Google Docs and HTML parsing to automatically apply these styles to Paragraphs and Headings.

One note to do here is that we're missing language codes on subsections of the document / the whole atjson document, which may be important to correctly render out these properties of `start` / `end` to the correct values for that language.