### PR TITLE
Add line breaks in plain text renderer

### DIFF
--- a/packages/@atjson/renderer-plain-text/package.json
+++ b/packages/@atjson/renderer-plain-text/package.json
@@ -14,7 +14,8 @@
     "@atjson/source-html": "file:../source-html"
   },
   "dependencies": {
-    "@atjson/renderer-hir": "file:../renderer-hir"
+    "@atjson/renderer-hir": "file:../renderer-hir",
+    "@atjson/offset-annotations": "file:../offset-annotations"
   },
   "peerDependencies": {
     "@atjson/document": "^0.23.0"

--- a/packages/@atjson/renderer-plain-text/src/index.ts
+++ b/packages/@atjson/renderer-plain-text/src/index.ts
@@ -13,4 +13,8 @@ export default class PlainTextRenderer extends Renderer {
     let text = yield;
     return text.join("");
   }
+
+  *LineBreak() {
+    return "\n";
+  }
 }

--- a/packages/@atjson/renderer-plain-text/src/index.ts
+++ b/packages/@atjson/renderer-plain-text/src/index.ts
@@ -61,7 +61,7 @@ export default class PlainTextRenderer extends Renderer {
         return `${startsAt + index}. ${item}`;
       });
     }
-    return items.join("\n") + "\n";
+    return items.join("\n") + "\n\n";
   }
 
   *Paragraph() {

--- a/packages/@atjson/renderer-plain-text/src/index.ts
+++ b/packages/@atjson/renderer-plain-text/src/index.ts
@@ -7,6 +7,7 @@ export default class PlainTextRenderer extends Renderer {
     document
       .where(
         (annotation: Annotation) =>
+          // explicitly removing annotations we don't support here
           annotation.type !== "parse-token" &&
           annotation.type !== "line-break" &&
           annotation.type !== "list-item" &&

--- a/packages/@atjson/renderer-plain-text/src/index.ts
+++ b/packages/@atjson/renderer-plain-text/src/index.ts
@@ -1,10 +1,21 @@
 import Document, { Annotation } from "@atjson/document";
+import { List } from "@atjson/offset-annotations";
 import Renderer from "@atjson/renderer-hir";
 
 export default class PlainTextRenderer extends Renderer {
   constructor(document: Document, ...args: any[]) {
     document
-      .where((annotation: Annotation) => annotation.type !== "parse-token")
+      .where(
+        (annotation: Annotation) =>
+          annotation.type !== "parse-token" &&
+          annotation.type !== "line-break" &&
+          annotation.type !== "list-item" &&
+          annotation.type !== "list" &&
+          annotation.type !== "paragraph" &&
+          annotation.type !== "heading" &&
+          annotation.type !== "pullquote" &&
+          annotation.type !== "blockquote"
+      )
       .remove();
     super(document, args);
   }
@@ -16,5 +27,45 @@ export default class PlainTextRenderer extends Renderer {
 
   *LineBreak() {
     return "\n";
+  }
+
+  *Heading() {
+    let item = yield;
+    return item.join("") + "\n\n";
+  }
+
+  *Blockquote() {
+    let item = yield;
+    return item.join("") + "\n\n";
+  }
+
+  *Pullquote() {
+    let item = yield;
+    return item.join("") + "\n\n";
+  }
+
+  *ListItem() {
+    let item = yield;
+    return item.join("");
+  }
+
+  *List(annotation: List) {
+    let items: string[] = yield;
+    if (annotation.attributes.type === "bulleted") {
+      items = items.map((item) => {
+        return `- ${item}`;
+      });
+    } else if (annotation.attributes.type === "numbered") {
+      let startsAt = annotation.attributes.startsAt ?? 1;
+      items = items.map((item, index) => {
+        return `${startsAt + index}. ${item}`;
+      });
+    }
+    return items.join("\n") + "\n";
+  }
+
+  *Paragraph() {
+    let item = yield;
+    return item.join("") + "\n\n";
   }
 }

--- a/packages/@atjson/renderer-plain-text/test/text-renderer-test.ts
+++ b/packages/@atjson/renderer-plain-text/test/text-renderer-test.ts
@@ -1,6 +1,11 @@
-import Document from "@atjson/document";
+import Document, { ParseAnnotation } from "@atjson/document";
 import HTMLSource from "@atjson/source-html";
-import OffsetSource from "@atjson/offset-annotations";
+import OffsetSource, {
+  LineBreak,
+  List,
+  ListItem,
+  Pullquote,
+} from "@atjson/offset-annotations";
 
 import PlainTextRenderer from "../src";
 
@@ -38,20 +43,179 @@ describe("PlainTextRenderer", () => {
     expect(text).toBe("This is some fancy text.");
   });
 
+  it("adds newlines between paragraphs", () => {
+    let doc = HTMLSource.fromRaw("<p>One fish</p><p>Two fish</p>").convertTo(
+      OffsetSource
+    );
+
+    let text = PlainTextRenderer.render(doc);
+    expect(text).toBe("One fish\n\nTwo fish\n\n");
+  });
+
+  it("headings have newlines added around them", () => {
+    let doc = HTMLSource.fromRaw("<h2>One fish</h2><p>Two fish</p>").convertTo(
+      OffsetSource
+    );
+
+    let text = PlainTextRenderer.render(doc);
+    expect(text).toBe("One fish\n\nTwo fish\n\n");
+  });
+
+  it("blockquotes have newlines added around them", () => {
+    let doc = HTMLSource.fromRaw(
+      "<blockquote>One fish</blockquote><p>Two fish</p>"
+    ).convertTo(OffsetSource);
+
+    let text = PlainTextRenderer.render(doc);
+    expect(text).toBe("One fish\n\nTwo fish\n\n");
+  });
+
+  it("pullquotes have newlines added around them", () => {
+    let doc = new OffsetSource({
+      content: "One fish\uFFFCTwo fish",
+      annotations: [
+        new Pullquote({
+          start: 8,
+          end: 9,
+        }),
+      ],
+    });
+
+    let text = PlainTextRenderer.render(doc);
+    expect(text).toBe("One fish\n\nTwo fish");
+  });
+
   it("renders line breaks", () => {
     let document = new OffsetSource({
-      content: "first linesecond line",
+      content: "first line\uFFFCsecond line",
       annotations: [
-        {
-          type: "-offset-line-break",
+        new LineBreak({
           start: 10,
-          end: 12,
-          attributes: {},
-        },
+          end: 11,
+        }),
       ],
     });
 
     let text = PlainTextRenderer.render(document);
     expect(text).toBe("first line\nsecond line");
+  });
+
+  test.each([undefined, 2])(
+    "numbered lists starting at %s are pretty printed",
+    (startsAt) => {
+      let document = new OffsetSource({
+        content: "one fish\ntwo fish\nred fish\nblue fish",
+        annotations: [
+          new List({
+            start: 0,
+            end: 36,
+            attributes: {
+              type: "numbered",
+              startsAt,
+            },
+          }),
+          new ListItem({
+            start: 0,
+            end: 8,
+          }),
+          new ParseAnnotation({
+            start: 8,
+            end: 9,
+            attributes: {
+              reason: "list item",
+            },
+          }),
+          new ListItem({
+            start: 9,
+            end: 17,
+          }),
+          new ParseAnnotation({
+            start: 17,
+            end: 18,
+            attributes: {
+              reason: "list item",
+            },
+          }),
+          new ListItem({
+            start: 18,
+            end: 26,
+          }),
+          new ParseAnnotation({
+            start: 26,
+            end: 27,
+            attributes: {
+              reason: "list item",
+            },
+          }),
+          new ListItem({
+            start: 27,
+            end: 36,
+          }),
+        ],
+      });
+
+      let index = startsAt ?? 1;
+      let text = PlainTextRenderer.render(document);
+      expect(text).toBe(
+        `${index}. one fish\n${index + 1}. two fish\n${index + 2}. red fish\n${
+          index + 3
+        }. blue fish\n`
+      );
+    }
+  );
+
+  test("bulleted lists are pretty printed", () => {
+    let document = new OffsetSource({
+      content: "one fish\ntwo fish\nred fish\nblue fish",
+      annotations: [
+        new List({
+          start: 0,
+          end: 36,
+          attributes: {
+            type: "bulleted",
+          },
+        }),
+        new ListItem({
+          start: 0,
+          end: 8,
+        }),
+        new ParseAnnotation({
+          start: 8,
+          end: 9,
+          attributes: {
+            reason: "list item",
+          },
+        }),
+        new ListItem({
+          start: 9,
+          end: 17,
+        }),
+        new ParseAnnotation({
+          start: 17,
+          end: 18,
+          attributes: {
+            reason: "list item",
+          },
+        }),
+        new ListItem({
+          start: 18,
+          end: 26,
+        }),
+        new ParseAnnotation({
+          start: 26,
+          end: 27,
+          attributes: {
+            reason: "list item",
+          },
+        }),
+        new ListItem({
+          start: 27,
+          end: 36,
+        }),
+      ],
+    });
+
+    let text = PlainTextRenderer.render(document);
+    expect(text).toBe("- one fish\n- two fish\n- red fish\n- blue fish\n");
   });
 });

--- a/packages/@atjson/renderer-plain-text/test/text-renderer-test.ts
+++ b/packages/@atjson/renderer-plain-text/test/text-renderer-test.ts
@@ -159,7 +159,7 @@ describe("PlainTextRenderer", () => {
       expect(text).toBe(
         `${index}. one fish\n${index + 1}. two fish\n${index + 2}. red fish\n${
           index + 3
-        }. blue fish\n`
+        }. blue fish\n\n`
       );
     }
   );
@@ -216,6 +216,6 @@ describe("PlainTextRenderer", () => {
     });
 
     let text = PlainTextRenderer.render(document);
-    expect(text).toBe("- one fish\n- two fish\n- red fish\n- blue fish\n");
+    expect(text).toBe("- one fish\n- two fish\n- red fish\n- blue fish\n\n");
   });
 });

--- a/packages/@atjson/renderer-plain-text/test/text-renderer-test.ts
+++ b/packages/@atjson/renderer-plain-text/test/text-renderer-test.ts
@@ -1,5 +1,7 @@
 import Document from "@atjson/document";
 import HTMLSource from "@atjson/source-html";
+import OffsetSource from "@atjson/offset-annotations";
+
 import PlainTextRenderer from "../src";
 
 class PlainText extends Document {
@@ -34,5 +36,22 @@ describe("PlainTextRenderer", () => {
 
     let text = PlainTextRenderer.render(doc);
     expect(text).toBe("This is some fancy text.");
+  });
+
+  it("renders line breaks", () => {
+    let document = new OffsetSource({
+      content: "first linesecond line",
+      annotations: [
+        {
+          type: "-offset-line-break",
+          start: 10,
+          end: 12,
+          attributes: {},
+        },
+      ],
+    });
+
+    let text = PlainTextRenderer.render(document);
+    expect(text).toBe("first line\nsecond line");
   });
 });


### PR DESCRIPTION
For prettier formatting of lists, we'd like to add line breaks when rendering lists to plain text