### PR TITLE
Change tight attribute to loose on lists

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/list.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/list.ts
@@ -3,7 +3,7 @@ import { BlockAnnotation } from "@atjson/document";
 export class List extends BlockAnnotation<{
   type: string;
   delimiter?: string;
-  tight?: boolean;
+  loose?: boolean;
   level?: number;
   startsAt?: number;
 }> {

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -677,7 +677,7 @@ export default class CommonmarkRenderer extends Renderer {
       type: list.attributes.type,
       digit: start,
       delimiter,
-      tight: list.attributes.tight,
+      tight: !list.attributes.loose,
       hasCodeBlockFollowing,
     });
 

--- a/packages/@atjson/renderer-commonmark/test/__snapshots__/commonmark-spec-test.ts.snap
+++ b/packages/@atjson/renderer-commonmark/test/__snapshots__/commonmark-spec-test.ts.snap
@@ -3523,7 +3523,7 @@ Object {
       "children": Array [
         Object {
           "attributes": Object {
-            "tight": true,
+            "loose": false,
           },
           "children": Array [
             Object {
@@ -3551,7 +3551,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -3590,7 +3590,7 @@ Object {
       "children": Array [
         Object {
           "attributes": Object {
-            "tight": true,
+            "loose": false,
           },
           "children": Array [
             Object {
@@ -3618,7 +3618,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -13107,7 +13107,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -13152,7 +13152,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -18069,7 +18069,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -18121,7 +18121,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -20758,7 +20758,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -20803,7 +20803,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -20968,7 +20968,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -20984,7 +20984,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -21029,7 +21029,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -21045,7 +21045,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -28516,7 +28516,7 @@ Object {
           "children": Array [
             Object {
               "attributes": Object {
-                "tight": false,
+                "loose": true,
               },
               "children": Array [
                 Object {
@@ -28575,7 +28575,7 @@ Object {
           "children": Array [
             Object {
               "attributes": Object {
-                "tight": false,
+                "loose": true,
               },
               "children": Array [
                 Object {
@@ -28631,7 +28631,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -28696,7 +28696,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -28819,7 +28819,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -28884,7 +28884,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -28945,7 +28945,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -28982,7 +28982,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -29023,7 +29023,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -29088,7 +29088,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -29150,8 +29150,8 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
+        "loose": true,
         "start": 10,
-        "tight": false,
       },
       "children": Array [
         Object {
@@ -29197,8 +29197,8 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
+        "loose": true,
         "start": 10,
-        "tight": false,
       },
       "children": Array [
         Object {
@@ -29244,7 +29244,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -29289,7 +29289,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -29334,7 +29334,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -29380,7 +29380,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -29429,7 +29429,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -29494,7 +29494,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -29554,7 +29554,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -29580,7 +29580,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -29610,7 +29610,7 @@ Object {
       "children": Array [
         Object {
           "attributes": Object {
-            "tight": false,
+            "loose": true,
           },
           "children": Array [
             Object {
@@ -29661,7 +29661,7 @@ Object {
       "children": Array [
         Object {
           "attributes": Object {
-            "tight": false,
+            "loose": true,
           },
           "children": Array [
             Object {
@@ -29712,7 +29712,7 @@ Object {
       "children": Array [
         Object {
           "attributes": Object {
-            "tight": false,
+            "loose": true,
           },
           "children": Array [
             Object {
@@ -29763,7 +29763,7 @@ Object {
       "children": Array [
         Object {
           "attributes": Object {
-            "tight": false,
+            "loose": true,
           },
           "children": Array [
             Object {
@@ -29818,7 +29818,7 @@ Object {
           "children": Array [
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -29877,7 +29877,7 @@ Object {
           "children": Array [
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -29930,7 +29930,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -29966,7 +29966,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -30007,7 +30007,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -30083,7 +30083,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -30153,7 +30153,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -30189,7 +30189,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -30226,7 +30226,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -30271,7 +30271,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -30316,7 +30316,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -30361,7 +30361,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -30407,7 +30407,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -30472,7 +30472,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -30534,7 +30534,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -30542,7 +30542,7 @@ Object {
           "children": Array [
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -30585,7 +30585,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -30593,7 +30593,7 @@ Object {
           "children": Array [
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -30641,7 +30641,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -30693,7 +30693,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -30743,7 +30743,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -30789,7 +30789,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -30834,7 +30834,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -30880,7 +30880,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -30927,7 +30927,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -30943,7 +30943,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -30959,7 +30959,7 @@ Object {
                     },
                     Object {
                       "attributes": Object {
-                        "tight": true,
+                        "loose": false,
                       },
                       "children": Array [
                         Object {
@@ -30975,7 +30975,7 @@ Object {
                             },
                             Object {
                               "attributes": Object {
-                                "tight": true,
+                                "loose": false,
                               },
                               "children": Array [
                                 Object {
@@ -31037,7 +31037,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -31053,7 +31053,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -31069,7 +31069,7 @@ Object {
                     },
                     Object {
                       "attributes": Object {
-                        "tight": true,
+                        "loose": false,
                       },
                       "children": Array [
                         Object {
@@ -31085,7 +31085,7 @@ Object {
                             },
                             Object {
                               "attributes": Object {
-                                "tight": true,
+                                "loose": false,
                               },
                               "children": Array [
                                 Object {
@@ -31147,7 +31147,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -31230,7 +31230,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -31312,7 +31312,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -31370,7 +31370,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -31428,7 +31428,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -31486,7 +31486,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -31544,7 +31544,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -31589,7 +31589,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -31634,7 +31634,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -31679,7 +31679,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -31818,8 +31818,8 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
+        "loose": false,
         "start": 0,
-        "tight": true,
       },
       "children": Array [
         Object {
@@ -31854,8 +31854,8 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
+        "loose": false,
         "start": 0,
-        "tight": true,
       },
       "children": Array [
         Object {
@@ -31890,8 +31890,8 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
+        "loose": false,
         "start": 3,
-        "tight": true,
       },
       "children": Array [
         Object {
@@ -31926,8 +31926,8 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
+        "loose": false,
         "start": 3,
-        "tight": true,
       },
       "children": Array [
         Object {
@@ -31966,7 +31966,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -32023,7 +32023,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -32080,7 +32080,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -32137,7 +32137,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -32195,7 +32195,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -32260,7 +32260,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -32328,7 +32328,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -32405,7 +32405,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -32474,7 +32474,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -32482,7 +32482,7 @@ Object {
           "children": Array [
             Object {
               "attributes": Object {
-                "tight": false,
+                "loose": true,
               },
               "children": Array [
                 Object {
@@ -32490,8 +32490,8 @@ Object {
                   "children": Array [
                     Object {
                       "attributes": Object {
+                        "loose": false,
                         "start": 2,
-                        "tight": true,
                       },
                       "children": Array [
                         Object {
@@ -32542,7 +32542,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -32550,7 +32550,7 @@ Object {
           "children": Array [
             Object {
               "attributes": Object {
-                "tight": false,
+                "loose": true,
               },
               "children": Array [
                 Object {
@@ -32558,8 +32558,8 @@ Object {
                   "children": Array [
                     Object {
                       "attributes": Object {
+                        "loose": false,
                         "start": 2,
-                        "tight": true,
                       },
                       "children": Array [
                         Object {
@@ -32612,7 +32612,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -32670,7 +32670,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -32727,8 +32727,8 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
+        "loose": false,
         "start": 10,
-        "tight": true,
       },
       "children": Array [
         Object {
@@ -32744,7 +32744,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -32788,8 +32788,8 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
+        "loose": false,
         "start": 10,
-        "tight": true,
       },
       "children": Array [
         Object {
@@ -32805,7 +32805,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -32849,8 +32849,8 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
+        "loose": false,
         "start": 10,
-        "tight": true,
       },
       "children": Array [
         Object {
@@ -32874,7 +32874,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -32910,8 +32910,8 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
+        "loose": false,
         "start": 10,
-        "tight": true,
       },
       "children": Array [
         Object {
@@ -32935,7 +32935,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -32970,8 +32970,8 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
+        "loose": false,
         "start": 123456789,
-        "tight": true,
       },
       "children": Array [
         Object {
@@ -33006,8 +33006,8 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
+        "loose": false,
         "start": 123456789,
-        "tight": true,
       },
       "children": Array [
         Object {
@@ -33247,7 +33247,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -33315,7 +33315,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -33383,7 +33383,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -33442,7 +33442,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -33501,7 +33501,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -33517,7 +33517,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -33571,7 +33571,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -33587,7 +33587,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -33646,7 +33646,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -33730,7 +33730,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -33811,7 +33811,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -33892,7 +33892,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -33972,7 +33972,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -33988,7 +33988,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": false,
+                "loose": true,
               },
               "children": Array [
                 Object {
@@ -34058,7 +34058,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -34074,7 +34074,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": false,
+                "loose": true,
               },
               "children": Array [
                 Object {
@@ -34146,7 +34146,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -34162,7 +34162,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -34216,7 +34216,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -34280,7 +34280,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -34296,7 +34296,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -34350,7 +34350,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -34409,7 +34409,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -34425,7 +34425,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -34469,7 +34469,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -34485,7 +34485,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -34532,7 +34532,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -34617,7 +34617,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -34704,7 +34704,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -34835,7 +34835,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -34960,7 +34960,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -34995,7 +34995,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -35036,7 +35036,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -35112,7 +35112,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -35186,7 +35186,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -35255,7 +35255,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -35324,7 +35324,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -35401,7 +35401,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -35477,7 +35477,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -35545,7 +35545,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -35615,7 +35615,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -35685,7 +35685,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -35755,7 +35755,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -35771,7 +35771,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -35787,7 +35787,7 @@ Object {
                     },
                     Object {
                       "attributes": Object {
-                        "tight": false,
+                        "loose": true,
                       },
                       "children": Array [
                         Object {
@@ -35851,7 +35851,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -35867,7 +35867,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -35883,7 +35883,7 @@ Object {
                     },
                     Object {
                       "attributes": Object {
-                        "tight": false,
+                        "loose": true,
                       },
                       "children": Array [
                         Object {
@@ -35948,7 +35948,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -35996,7 +35996,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -36052,7 +36052,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -36100,7 +36100,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -36152,7 +36152,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -36191,7 +36191,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -36228,7 +36228,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -36267,7 +36267,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -36306,7 +36306,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -36356,7 +36356,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -36406,7 +36406,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -36469,7 +36469,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -36532,7 +36532,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -36601,7 +36601,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -36668,7 +36668,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -36707,8 +36707,8 @@ Object {
     },
     Object {
       "attributes": Object {
+        "loose": false,
         "start": 3,
-        "tight": true,
       },
       "children": Array [
         Object {
@@ -36745,7 +36745,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -36784,8 +36784,8 @@ Object {
     },
     Object {
       "attributes": Object {
+        "loose": false,
         "start": 3,
-        "tight": true,
       },
       "children": Array [
         Object {
@@ -36830,7 +36830,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -36890,7 +36890,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -36949,7 +36949,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -36993,7 +36993,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -37497,7 +37497,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -37548,7 +37548,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -39365,7 +39365,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -39407,7 +39407,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -39449,7 +39449,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -39491,7 +39491,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -40672,7 +40672,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -40717,7 +40717,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -40802,7 +40802,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -40818,7 +40818,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -40834,7 +40834,7 @@ Object {
                     },
                     Object {
                       "attributes": Object {
-                        "tight": true,
+                        "loose": false,
                       },
                       "children": Array [
                         Object {
@@ -40887,7 +40887,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -40903,7 +40903,7 @@ Object {
             },
             Object {
               "attributes": Object {
-                "tight": true,
+                "loose": false,
               },
               "children": Array [
                 Object {
@@ -40919,7 +40919,7 @@ Object {
                     },
                     Object {
                       "attributes": Object {
-                        "tight": true,
+                        "loose": false,
                       },
                       "children": Array [
                         Object {
@@ -41102,7 +41102,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -41148,7 +41148,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -41192,7 +41192,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -41228,7 +41228,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": false,
+        "loose": true,
       },
       "children": Array [
         Object {
@@ -41642,7 +41642,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -41672,7 +41672,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -41709,7 +41709,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -41739,7 +41739,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -42093,7 +42093,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -42142,7 +42142,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -42192,7 +42192,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -42222,7 +42222,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -42259,7 +42259,7 @@ Object {
   "children": Array [
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {
@@ -42289,7 +42289,7 @@ Object {
     },
     Object {
       "attributes": Object {
-        "tight": true,
+        "loose": false,
       },
       "children": Array [
         Object {

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -135,7 +135,7 @@ describe("commonmark", () => {
         {
           id: "4",
           type: "-offset-list",
-          attributes: { "-offset-type": "numbered", "-offset-tight": true },
+          attributes: { "-offset-type": "numbered", "-offset-loose": false },
           start: 14,
           end: 81,
         },
@@ -170,7 +170,7 @@ describe("commonmark", () => {
         {
           id: "9",
           type: "-offset-list",
-          attributes: { "-offset-type": "bulleted", "-offset-tight": true },
+          attributes: { "-offset-type": "bulleted", "-offset-loose": false },
           start: 67,
           end: 81,
         },

--- a/packages/@atjson/renderer-html/src/index.ts
+++ b/packages/@atjson/renderer-html/src/index.ts
@@ -192,7 +192,7 @@ export default class HTMLRenderer extends Renderer {
 
     return yield* this.$(tagName, {
       starts: list.attributes.startsAt,
-      compact: list.attributes.tight,
+      compact: !list.attributes.loose,
       type: list.attributes.delimiter,
     });
   }

--- a/packages/@atjson/renderer-html/test/renderer-test.ts
+++ b/packages/@atjson/renderer-html/test/renderer-test.ts
@@ -228,7 +228,7 @@ describe("renderer-html", () => {
         ],
       });
       expect(Renderer.render(doc)).toEqual(
-        `<ol><li>one</li>\n<li>two</li></ol>`
+        `<ol compact><li>one</li>\n<li>two</li></ol>`
       );
     });
 
@@ -249,11 +249,11 @@ describe("renderer-html", () => {
         ],
       });
       expect(Renderer.render(doc)).toEqual(
-        `<ol starts=3><li>one</li>\n<li>two</li></ol>`
+        `<ol starts=3 compact><li>one</li>\n<li>two</li></ol>`
       );
     });
 
-    test("compact", () => {
+    test("loose", () => {
       let doc = new OffsetSource({
         content: "one\ntwo",
         annotations: [
@@ -262,7 +262,7 @@ describe("renderer-html", () => {
             end: 7,
             attributes: {
               type: "numbered",
-              tight: true,
+              loose: true,
             },
           }),
           new ListItem({ start: 0, end: 3 }),
@@ -270,7 +270,7 @@ describe("renderer-html", () => {
         ],
       });
       expect(Renderer.render(doc)).toEqual(
-        `<ol compact><li>one</li>\n<li>two</li></ol>`
+        `<ol><li>one</li>\n<li>two</li></ol>`
       );
     });
   });
@@ -292,7 +292,7 @@ describe("renderer-html", () => {
         ],
       });
       expect(Renderer.render(doc)).toEqual(
-        `<ul><li>one</li>\n<li>two</li></ul>`
+        `<ul compact><li>one</li>\n<li>two</li></ul>`
       );
     });
 
@@ -313,7 +313,7 @@ describe("renderer-html", () => {
         ],
       });
       expect(Renderer.render(doc)).toEqual(
-        `<ul type="square"><li>one</li>\n<li>two</li></ul>`
+        `<ul compact type="square"><li>one</li>\n<li>two</li></ul>`
       );
     });
   });

--- a/packages/@atjson/source-commonmark/src/annotations/bullet_list.ts
+++ b/packages/@atjson/source-commonmark/src/annotations/bullet_list.ts
@@ -1,7 +1,7 @@
 import { BlockAnnotation } from "@atjson/document";
 
 export class BulletList extends BlockAnnotation<{
-  tight: boolean;
+  loose: boolean;
 }> {
   static type = "bullet_list";
   static vendorPrefix = "commonmark";

--- a/packages/@atjson/source-commonmark/src/annotations/ordered_list.ts
+++ b/packages/@atjson/source-commonmark/src/annotations/ordered_list.ts
@@ -2,7 +2,7 @@ import { BlockAnnotation } from "@atjson/document";
 
 export class OrderedList extends BlockAnnotation<{
   start: number;
-  tight: boolean;
+  loose: boolean;
 }> {
   static type = "ordered_list";
   static vendorPrefix = "commonmark";

--- a/packages/@atjson/source-commonmark/src/converter.ts
+++ b/packages/@atjson/source-commonmark/src/converter.ts
@@ -10,7 +10,7 @@ CommonmarkSource.defineConverterTo(
     doc
       .where({ type: "-commonmark-bullet_list" })
       .set({ type: "-offset-list", attributes: { "-offset-type": "bulleted" } })
-      .rename({ attributes: { "-commonmark-tight": "-offset-tight" } });
+      .rename({ attributes: { "-commonmark-loose": "-offset-loose" } });
     doc
       .where({ type: "-commonmark-code_block" })
       .set({ type: "-offset-code", attributes: { "-offset-style": "block" } });
@@ -68,7 +68,7 @@ CommonmarkSource.defineConverterTo(
       .rename({
         attributes: {
           "-commonmark-start": "-offset-startsAt",
-          "-commonmark-tight": "-offset-tight",
+          "-commonmark-loose": "-offset-loose",
         },
       });
     doc

--- a/packages/@atjson/source-commonmark/src/parser.ts
+++ b/packages/@atjson/source-commonmark/src/parser.ts
@@ -186,7 +186,7 @@ export default class Parser {
             }
           }
 
-          attrs["-commonmark-tight"] = isTight;
+          attrs["-commonmark-loose"] = !isTight;
         }
         let annotationGenerator = this.convertTokenToAnnotation(
           node.name,

--- a/packages/@atjson/source-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/source-commonmark/test/commonmark-test.ts
@@ -98,19 +98,19 @@ describe("list", () => {
       {
         type: "-commonmark-bullet_list",
         attributes: {
-          "-commonmark-tight": true,
+          "-commonmark-loose": false,
         },
       },
       {
         type: "-commonmark-bullet_list",
         attributes: {
-          "-commonmark-tight": true,
+          "-commonmark-loose": false,
         },
       },
       {
         type: "-commonmark-bullet_list",
         attributes: {
-          "-commonmark-tight": true,
+          "-commonmark-loose": false,
         },
       },
     ]);
@@ -122,13 +122,13 @@ describe("list", () => {
         type: "-commonmark-ordered_list",
         attributes: {
           "-commonmark-start": 2,
-          "-commonmark-tight": true,
+          "-commonmark-loose": false,
         },
       },
       {
         type: "-commonmark-ordered_list",
         attributes: {
-          "-commonmark-tight": false,
+          "-commonmark-loose": true,
         },
       },
     ]);

--- a/packages/@atjson/source-commonmark/test/utils.ts
+++ b/packages/@atjson/source-commonmark/test/utils.ts
@@ -14,14 +14,14 @@ class PlainTextRenderer extends Renderer {
   }
   *bullet_list(list: BulletList) {
     let wasTight = this.tight;
-    this.tight = list.attributes.tight;
+    this.tight = !list.attributes.loose;
     let text = yield;
     this.tight = wasTight;
     return text;
   }
   *ordered_list(list: OrderedList) {
     let wasTight = this.tight;
-    this.tight = list.attributes.tight;
+    this.tight = !list.attributes.loose;
     let text = yield;
     this.tight = wasTight;
     return text;


### PR DESCRIPTION
This changes defaults when creating `List` annotations without a tight attribute and will make all lists without this attribute tight by default. We're making this change to match editor expectations when writing in rich text, which we use this library for. Our editors at WIRED and Vanity Fair would like their lists to be compact by default. Our previous data structuring made everything loose by default and tight explicitly. By inverting this and making the attribute that needs to be set `loose`, we make tight lists the default and loose lists explicit.

To illustrate, the difference between tight and loose lists can be shown below:

###

**Tight lists** (now default)

```md
- one fish
- two fish
- red fish
- blue fish
```

- one fish
- two fish
- red fish
- blue fish

###

**Loose lists** (previous default)

```md
- one fish

- two fish

- red fish

- blue fish
```

- one fish

- two fish

- red fish

- blue fish

If you inspect the HTML produced, the latter wraps all list items in paragraphs. To ameliorate this for editors, we are suggesting them to use line breaks explicitly since it's impossible to have mixed tightness lists in markdown, which we must interoperate in for our CMS.