### PR TITLE
Add anchorName attributes to block annotations

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/blockquote.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/blockquote.ts
@@ -2,6 +2,10 @@ import { BlockAnnotation } from "@atjson/document";
 
 export class Blockquote extends BlockAnnotation<{
   inset?: "left" | "right";
+  /**
+   * A named identifier used to quickly jump to this item
+   */
+  anchorName?: string;
 }> {
   static type = "blockquote";
   static vendorPrefix = "offset";

--- a/packages/@atjson/offset-annotations/src/annotations/ceros-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/ceros-embed.ts
@@ -4,6 +4,10 @@ export class CerosEmbed extends ObjectAnnotation<{
   url: string;
   aspectRatio: number;
   mobileAspectRatio?: number;
+  /**
+   * A named identifier used to quickly jump to this item
+   */
+  anchorName?: string;
 }> {
   static vendorPrefix = "offset";
   static type = "ceros-embed";

--- a/packages/@atjson/offset-annotations/src/annotations/group-item.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/group-item.ts
@@ -1,6 +1,13 @@
 import { BlockAnnotation } from "@atjson/document";
 
-export class GroupItem<T = {}> extends BlockAnnotation<T> {
+export class GroupItem<T = {}> extends BlockAnnotation<
+  T & {
+    /**
+     * A named identifier used to quickly jump to this item
+     */
+    anchorName?: string;
+  }
+> {
   static type = "group-item";
   static vendorPrefix = "offset";
 }

--- a/packages/@atjson/offset-annotations/src/annotations/group.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/group.ts
@@ -17,7 +17,13 @@ import { BlockAnnotation } from "@atjson/document";
  * across multiple documents.
  */
 export class Group<T = {}> extends BlockAnnotation<
-  T & { artDirection: string }
+  T & {
+    artDirection: string;
+    /**
+     * A named identifier used to quickly jump to this item
+     */
+    anchorName?: string;
+  }
 > {
   static type = "group";
   static vendorPrefix = "offset";

--- a/packages/@atjson/offset-annotations/src/annotations/heading.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/heading.ts
@@ -3,6 +3,10 @@ import { BlockAnnotation } from "@atjson/document";
 export class Heading extends BlockAnnotation<{
   level: 1 | 2 | 3 | 4 | 5 | 6;
   alignment?: "start" | "center" | "end" | "justify";
+  /**
+   * A named identifier used to quickly jump to this item
+   */
+  anchorName?: string;
 }> {
   static type = "heading";
   static vendorPrefix = "offset";

--- a/packages/@atjson/offset-annotations/src/annotations/iframe-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/iframe-embed.ts
@@ -7,6 +7,10 @@ export class IframeEmbed extends ObjectAnnotation<{
   height?: string;
   caption?: CaptionSource;
   sandbox?: string;
+  /**
+   * A named identifier used to quickly jump to this item
+   */
+  anchorName?: string;
 }> {
   static type = "iframe-embed";
   static vendorPrefix = "offset";

--- a/packages/@atjson/offset-annotations/src/annotations/image.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/image.ts
@@ -4,6 +4,10 @@ export class Image extends ObjectAnnotation<{
   url: string;
   title?: string;
   description?: string;
+  /**
+   * A named identifier used to quickly jump to this item
+   */
+  anchorName?: string;
 }> {
   static vendorPrefix = "offset";
   static type = "image";

--- a/packages/@atjson/offset-annotations/src/annotations/list-item.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/list-item.ts
@@ -1,6 +1,11 @@
 import { BlockAnnotation } from "@atjson/document";
 
-export class ListItem extends BlockAnnotation {
+export class ListItem extends BlockAnnotation<{
+  /**
+   * A named identifier used to quickly jump to this item
+   */
+  anchorName?: string;
+}> {
   static vendorPrefix = "offset";
   static type = "list-item";
 }

--- a/packages/@atjson/offset-annotations/src/annotations/list.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/list.ts
@@ -6,6 +6,10 @@ export class List extends BlockAnnotation<{
   loose?: boolean;
   level?: number;
   startsAt?: number;
+  /**
+   * A named identifier used to quickly jump to this item
+   */
+  anchorName?: string;
 }> {
   static vendorPrefix = "offset";
   static type = "list";

--- a/packages/@atjson/offset-annotations/src/annotations/paragraph.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/paragraph.ts
@@ -4,6 +4,10 @@ export class Paragraph<
   T = {
     decorations?: string[];
     alignment?: "start" | "center" | "end" | "justify";
+    /**
+     * A named identifier used to quickly jump to this item
+     */
+    anchorName?: string;
   }
 > extends BlockAnnotation<T> {
   static type = "paragraph";

--- a/packages/@atjson/offset-annotations/src/annotations/pullquote.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/pullquote.ts
@@ -1,6 +1,11 @@
 import { BlockAnnotation } from "@atjson/document";
 
-export class Pullquote extends BlockAnnotation {
+export class Pullquote extends BlockAnnotation<{
+  /**
+   * A named identifier used to quickly jump to this item
+   */
+  anchorName?: string;
+}> {
   static type = "pullquote";
   static vendorPrefix = "offset";
 }

--- a/packages/@atjson/offset-annotations/src/annotations/section.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/section.ts
@@ -1,6 +1,11 @@
 import { BlockAnnotation } from "@atjson/document";
 
-export class Section extends BlockAnnotation {
+export class Section extends BlockAnnotation<{
+  /**
+   * A named identifier used to quickly jump to this item
+   */
+  anchorName?: string;
+}> {
   static vendorPrefix = "offset";
   static type = "section";
 }

--- a/packages/@atjson/offset-annotations/src/annotations/sidebar.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/sidebar.ts
@@ -8,6 +8,10 @@ import { BlockAnnotation } from "@atjson/document";
 
 export class Sidebar extends BlockAnnotation<{
   inset: "left" | "right";
+  /**
+   * A named identifier used to quickly jump to this item
+   */
+  anchorName?: string;
 }> {
   static type = "sidebar";
   static vendorPrefix = "offset";

--- a/packages/@atjson/offset-annotations/src/annotations/video-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/video-embed.ts
@@ -29,6 +29,10 @@ export class VideoEmbed extends ObjectAnnotation<{
    */
   height?: number;
   caption?: CaptionSource;
+  /**
+   * A named identifier used to quickly jump to this item
+   */
+  anchorName?: string;
 }> {
   static type = "video-embed";
   static vendorPrefix = "offset";

--- a/packages/@atjson/renderer-html/src/index.ts
+++ b/packages/@atjson/renderer-html/src/index.ts
@@ -7,8 +7,9 @@ import {
   Link,
   List,
   ListItem,
-  TikTokEmbed,
   Paragraph,
+  Section,
+  TikTokEmbed,
 } from "@atjson/offset-annotations";
 import Renderer from "@atjson/renderer-hir";
 import * as entities from "entities";
@@ -120,6 +121,7 @@ export default class HTMLRenderer extends Renderer {
     }).join(" ")}><iframe ${this.htmlAttributes({
       allowfullscreen: true,
       src: embed.attributes.url,
+      id: embed.attributes.anchorName,
       style: [
         "position: absolute",
         "top: 0",
@@ -202,6 +204,7 @@ export default class HTMLRenderer extends Renderer {
       starts: list.attributes.startsAt,
       compact: !list.attributes.loose,
       type: list.attributes.delimiter,
+      id: list.attributes.anchorName,
     });
   }
 
@@ -219,8 +222,10 @@ export default class HTMLRenderer extends Renderer {
     return yield* this.$("p", { id: paragraph.attributes.anchorName, style });
   }
 
-  *Section() {
-    return yield* this.$("section");
+  *Section(section: Section) {
+    return yield* this.$("section", {
+      id: section.attributes.anchorName,
+    });
   }
 
   *SmallCaps() {

--- a/packages/@atjson/renderer-html/src/index.ts
+++ b/packages/@atjson/renderer-html/src/index.ts
@@ -1,10 +1,12 @@
 import {
+  Blockquote,
   CerosEmbed,
   Code,
   Heading,
   Image,
   Link,
   List,
+  ListItem,
   TikTokEmbed,
   Paragraph,
 } from "@atjson/offset-annotations";
@@ -88,8 +90,10 @@ export default class HTMLRenderer extends Renderer {
     return html.join("");
   }
 
-  *Blockquote() {
-    return yield* this.$("blockquote");
+  *Blockquote(blockquote: Blockquote) {
+    return yield* this.$("blockquote", {
+      id: blockquote.attributes.anchorName,
+    });
   }
 
   *Bold() {
@@ -155,7 +159,10 @@ export default class HTMLRenderer extends Renderer {
     if (heading.attributes.alignment) {
       style = this.textAlign(heading.attributes.alignment);
     }
-    return yield* this.$(`h${heading.attributes.level}`, { style });
+    return yield* this.$(`h${heading.attributes.level}`, {
+      id: heading.attributes.anchorName,
+      style,
+    });
   }
 
   *HorizontalRule() {
@@ -164,6 +171,7 @@ export default class HTMLRenderer extends Renderer {
 
   *Image(image: Image) {
     return yield* this.$("img", {
+      id: image.attributes.anchorName,
       src: image.attributes.url,
       title: image.attributes.title,
       alt: image.attributes.description,
@@ -197,8 +205,10 @@ export default class HTMLRenderer extends Renderer {
     });
   }
 
-  *ListItem() {
-    return yield* this.$("li");
+  *ListItem(item: ListItem) {
+    return yield* this.$("li", {
+      id: item.attributes.anchorName,
+    });
   }
 
   *Paragraph(paragraph: Paragraph) {
@@ -206,7 +216,7 @@ export default class HTMLRenderer extends Renderer {
     if (paragraph.attributes.alignment) {
       style = this.textAlign(paragraph.attributes.alignment);
     }
-    return yield* this.$("p", { style });
+    return yield* this.$("p", { id: paragraph.attributes.anchorName, style });
   }
 
   *Section() {
@@ -234,7 +244,11 @@ export default class HTMLRenderer extends Renderer {
     let parts = embed.attributes.url.split("/");
     let username = parts[parts.length - 3];
     let videoId = parts[parts.length - 1];
-    return `<blockquote class="tiktok-embed" cite="${embed.attributes.url}" data-video-id="${videoId}" style="max-width: 605px;min-width: 325px;"><section><a target="_blank" title="${username}" href="https://www.tiktok.com/${username}">${username}</a></section></blockquote><script async src="https://www.tiktok.com/embed.js"></script>`;
+    return `<blockquote${
+      embed.attributes.anchorName ? ` id=${embed.attributes.anchorName}` : ""
+    } class="tiktok-embed" cite="${
+      embed.attributes.url
+    }" data-video-id="${videoId}" style="max-width: 605px;min-width: 325px;"><section><a target="_blank" title="${username}" href="https://www.tiktok.com/${username}">${username}</a></section></blockquote><script async src="https://www.tiktok.com/embed.js"></script>`;
   }
 
   *Underline() {

--- a/packages/@atjson/renderer-html/test/renderer-test.ts
+++ b/packages/@atjson/renderer-html/test/renderer-test.ts
@@ -64,6 +64,23 @@ describe("renderer-html", () => {
       expect(Renderer.render(doc)).toEqual(`<h${level}>Hello</h${level}>`);
     });
 
+    test.each([1, 2, 3, 4, 5, 6] as const)("anchorName %s", (level) => {
+      let doc = new OffsetSource({
+        content: "Hello",
+        annotations: [
+          new Heading({
+            start: 0,
+            end: 5,
+            attributes: { level, anchorName: `test-${level}` },
+          }),
+        ],
+      });
+
+      expect(Renderer.render(doc)).toEqual(
+        `<h${level} id="test-${level}">Hello</h${level}>`
+      );
+    });
+
     describe("alignment", () => {
       describe.each([
         ["left", "start"],
@@ -328,6 +345,21 @@ describe("renderer-html", () => {
       expect(Renderer.render(doc)).toEqual("<p>Hello</p>");
     });
 
+    test("anchorName", () => {
+      let doc = new OffsetSource({
+        content: "Hello",
+        annotations: [
+          new Paragraph({
+            start: 0,
+            end: 5,
+            attributes: { anchorName: "test" },
+          }),
+        ],
+      });
+
+      expect(Renderer.render(doc)).toEqual(`<p id="test">Hello</p>`);
+    });
+
     describe("alignment", () => {
       describe.each([
         ["left", "start"],
@@ -424,6 +456,7 @@ describe("renderer-html", () => {
             start: 0,
             end: 1,
             attributes: {
+              anchorName: "carousel",
               url: "//view.ceros.com/ceros-inspire/carousel-3",
               aspectRatio: 2,
             },
@@ -432,7 +465,7 @@ describe("renderer-html", () => {
       });
 
       expect(Renderer.render(doc)).toMatchInlineSnapshot(
-        `"<div style=\\"position: relative;width: auto;padding: 0 0 50%;height: 0;top: 0;left: 0;bottom: 0;right: 0;margin: 0;border: 0 none\\" id=\\"experience-test\\" data-aspectRatio=\\"2\\"><iframe allowfullscreen src=\\"//view.ceros.com/ceros-inspire/carousel-3\\" style=\\"position: absolute;top: 0;left: 0;bottom: 0;right: 0;margin: 0;padding: 0;border: 0 none;height: 1px;width: 1px;min-height: 100%;min-width: 100%\\" frameborder=\\"0\\" class=\\"ceros-experience\\" scrolling=\\"no\\"></iframe></div><script type=\\"text/javascript\\" src=\\"//view.ceros.com/scroll-proxy.min.js\\" data-ceros-origin-domains=\\"view.ceros.com\\"></script>"`
+        `"<div style=\\"position: relative;width: auto;padding: 0 0 50%;height: 0;top: 0;left: 0;bottom: 0;right: 0;margin: 0;border: 0 none\\" id=\\"experience-test\\" data-aspectRatio=\\"2\\"><iframe allowfullscreen src=\\"//view.ceros.com/ceros-inspire/carousel-3\\" id=\\"carousel\\" style=\\"position: absolute;top: 0;left: 0;bottom: 0;right: 0;margin: 0;padding: 0;border: 0 none;height: 1px;width: 1px;min-height: 100%;min-width: 100%\\" frameborder=\\"0\\" class=\\"ceros-experience\\" scrolling=\\"no\\"></iframe></div><script type=\\"text/javascript\\" src=\\"//view.ceros.com/scroll-proxy.min.js\\" data-ceros-origin-domains=\\"view.ceros.com\\"></script>"`
       );
     });
 

--- a/packages/@atjson/source-html/scripts/generate-annotations.ts
+++ b/packages/@atjson/source-html/scripts/generate-annotations.ts
@@ -27,7 +27,11 @@ async function defineHTMLInterface(document: Document, url: string) {
       return [anchor.textContent ?? "", "string"];
     });
   }
-  attributes.push(["dataset", "{ [attribute: string]: string; }"]);
+  attributes.push(
+    ["dataset", "{ [attribute: string]: string; }"],
+    ["class", "string"],
+    ["id", "string"]
+  );
 
   writeFileSync(
     path.join(__dirname, "..", "src", "global-attributes.ts"),

--- a/packages/@atjson/source-html/src/annotations/bdi.ts
+++ b/packages/@atjson/source-html/src/annotations/bdi.ts
@@ -3,7 +3,11 @@ import { InlineAnnotation } from "@atjson/document";
 import { GlobalAttributes } from "../global-attributes";
 
 // [§ 4.5.24 The bdi element](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdi-element)
-export class TextDirectionIsolation extends InlineAnnotation<GlobalAttributes> {
+export class TextDirectionIsolation extends InlineAnnotation<
+  GlobalAttributes & {
+    dir?: string;
+  }
+> {
   static vendorPrefix = "html";
   static type = "bdi";
 }

--- a/packages/@atjson/source-html/src/annotations/bdo.ts
+++ b/packages/@atjson/source-html/src/annotations/bdo.ts
@@ -3,7 +3,11 @@ import { InlineAnnotation } from "@atjson/document";
 import { GlobalAttributes } from "../global-attributes";
 
 // [§ 4.5.25 The bdo element](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element)
-export class TextDirectionOverride extends InlineAnnotation<GlobalAttributes> {
+export class TextDirectionOverride extends InlineAnnotation<
+  GlobalAttributes & {
+    dir?: string;
+  }
+> {
   static vendorPrefix = "html";
   static type = "bdo";
 }

--- a/packages/@atjson/source-html/src/annotations/html.ts
+++ b/packages/@atjson/source-html/src/annotations/html.ts
@@ -3,11 +3,7 @@ import { BlockAnnotation } from "@atjson/document";
 import { GlobalAttributes } from "../global-attributes";
 
 // [§ 4.1.1 The html element](https://html.spec.whatwg.org/multipage/semantics.html#the-html-element)
-export class Html extends BlockAnnotation<
-  GlobalAttributes & {
-    manifest?: string;
-  }
-> {
+export class Html extends BlockAnnotation<GlobalAttributes> {
   static vendorPrefix = "html";
   static type = "html";
 }

--- a/packages/@atjson/source-html/src/annotations/iframe.ts
+++ b/packages/@atjson/source-html/src/annotations/iframe.ts
@@ -11,7 +11,6 @@ export class Iframe extends ObjectAnnotation<
     sandbox?: string;
     allow?: string;
     allowfullscreen?: string;
-    allowpaymentrequest?: string;
     width?: string;
     height?: string;
     referrerpolicy?: string;

--- a/packages/@atjson/source-html/src/converter/headings.ts
+++ b/packages/@atjson/source-html/src/converter/headings.ts
@@ -39,6 +39,7 @@ function convert(
           start: heading.start,
           end: heading.end,
           attributes: {
+            anchorName: heading.attributes.id,
             level,
             alignment,
           },

--- a/packages/@atjson/source-html/src/converter/paragraphs.ts
+++ b/packages/@atjson/source-html/src/converter/paragraphs.ts
@@ -29,6 +29,7 @@ export default function (doc: Document) {
           start: paragraph.start,
           end: paragraph.end,
           attributes: {
+            anchorName: paragraph.attributes.id,
             alignment: toAlignment(
               parseCSS(paragraph.attributes.style)["text-align"],
               direction?.attributes?.lang

--- a/packages/@atjson/source-html/src/converter/social-embeds.ts
+++ b/packages/@atjson/source-html/src/converter/social-embeds.ts
@@ -238,6 +238,7 @@ export default function (doc: Document) {
             url: attributes.url,
             height,
             width,
+            anchorName: iframe.attributes.id,
           },
         })
       );

--- a/packages/@atjson/source-html/src/converter/third-party-embeds.ts
+++ b/packages/@atjson/source-html/src/converter/third-party-embeds.ts
@@ -63,6 +63,7 @@ export default function convertThirdPartyEmbeds(doc: Document) {
           start: container.start,
           end: container.end,
           attributes: {
+            anchorName: iframes[0].attributes.id,
             aspectRatio,
             mobileAspectRatio,
             url: iframes[0].attributes.src,

--- a/packages/@atjson/source-html/src/converter/video-embeds.ts
+++ b/packages/@atjson/source-html/src/converter/video-embeds.ts
@@ -68,12 +68,12 @@ export default function (doc: Document) {
         );
       }
     )
-    .outerJoin(doc.where(isVimeoLink).as("links"), function vimeoCaptionJoin(
-      { paragraph },
-      link
-    ) {
-      return covers(paragraph[0], link);
-    })
+    .outerJoin(
+      doc.where(isVimeoLink).as("links"),
+      function vimeoCaptionJoin({ paragraph }, link) {
+        return covers(paragraph[0], link);
+      }
+    )
     .update(function convertVimeoVideos({ video, paragraph, links }) {
       let src = video.attributes.src;
       if (src?.indexOf("//") === 0) {
@@ -108,6 +108,7 @@ export default function (doc: Document) {
                 ? getClosestAspectRatio(width, height)
                 : undefined,
             caption,
+            anchorName: video.attributes.id,
           },
         })
       );
@@ -156,6 +157,7 @@ export default function (doc: Document) {
               width && height
                 ? getClosestAspectRatio(width, height)
                 : undefined,
+            anchorName: video.attributes.id,
           },
         })
       );
@@ -185,6 +187,7 @@ export default function (doc: Document) {
               width && height
                 ? getClosestAspectRatio(width, height)
                 : undefined,
+            anchorName: iframe.attributes.id,
           },
         })
       );

--- a/packages/@atjson/source-html/src/global-attributes.ts
+++ b/packages/@atjson/source-html/src/global-attributes.ts
@@ -28,4 +28,6 @@ export interface GlobalAttributes {
   title?: string;
   translate?: string;
   dataset?: { [attribute: string]: string };
+  class?: string;
+  id?: string;
 }

--- a/packages/@atjson/source-html/test/blockquote-test.ts
+++ b/packages/@atjson/source-html/test/blockquote-test.ts
@@ -1,0 +1,37 @@
+import OffsetSource from "@atjson/offset-annotations";
+import HTMLSource from "../src";
+
+describe("blockquote", () => {
+  test("without identifier", () => {
+    let doc = HTMLSource.fromRaw(
+      "<blockquote>This is a quote</blockquote>"
+    ).convertTo(OffsetSource);
+    expect(doc.where({ type: `-offset-blockquote` }).annotations).toMatchObject(
+      [
+        {
+          start: 0,
+          end: 40,
+          attributes: {},
+        },
+      ]
+    );
+  });
+
+  test("fragment ids", () => {
+    let doc = HTMLSource.fromRaw(
+      `<blockquote id="test">This is a quote</blockquote>`
+    ).convertTo(OffsetSource);
+
+    expect(doc.where({ type: `-offset-blockquote` }).annotations).toMatchObject(
+      [
+        {
+          start: 0,
+          end: 50,
+          attributes: {
+            anchorName: "test",
+          },
+        },
+      ]
+    );
+  });
+});

--- a/packages/@atjson/source-html/test/converter-test.ts
+++ b/packages/@atjson/source-html/test/converter-test.ts
@@ -208,22 +208,6 @@ describe("@atjson/source-html", () => {
       });
     });
 
-    test("blockquote", () => {
-      let doc = HTMLSource.fromRaw("<blockquote>This is a quote</blockquote>");
-      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
-          {
-            type: "blockquote",
-            attributes: {},
-            children: ["This is a quote"],
-          },
-        ],
-      });
-    });
-
     test("code", () => {
       let doc = HTMLSource.fromRaw(`<code>console.log('wowowowow');</code>`);
       let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();

--- a/packages/@atjson/source-html/test/heading-test.ts
+++ b/packages/@atjson/source-html/test/heading-test.ts
@@ -65,4 +65,18 @@ describe("headings", () => {
       });
     });
   });
+
+  describe("anchorName", () => {
+    test.each([["h1"], ["h2"], ["h3"], ["h4"], ["h5"], ["h6"]])(
+      "%s",
+      (tagname) => {
+        let doc = HTMLSource.fromRaw(
+          `<${tagname} id="test">Heading from ${tagname}</${tagname}>`
+        ).convertTo(OffsetSource);
+        expect(
+          doc.where({ type: `-offset-heading` }).annotations
+        ).toMatchObject([{ attributes: { anchorName: "test" } }]);
+      }
+    );
+  });
 });

--- a/packages/@atjson/source-html/test/paragraph-test.ts
+++ b/packages/@atjson/source-html/test/paragraph-test.ts
@@ -46,4 +46,18 @@ describe("paragraphs", () => {
       });
     });
   });
+
+  test("fragment ids", () => {
+    let doc = HTMLSource.fromRaw(
+      `<p id="test">Here is some text</p>`
+    ).convertTo(OffsetSource);
+
+    expect(doc.where({ type: `-offset-paragraph` }).annotations).toMatchObject([
+      {
+        attributes: {
+          anchorName: "test",
+        },
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
Our editors are requesting to identify blocks of content and mark them with fragment identifiers so they can directly link to them. This is used often for tables of contents to jump to specific sections of a page, or for FAQs, for example.  You can see an example of this on The New Yorker's [FAQ page](https://www.newyorker.com/about/faq).

By adding this as an annotation attribute instead of an annotation, we'll be able to collect more robust information about what _kinds_ of content our editors are linking to and it'll be easier to implement a minimal solution in renderers for this that are appropriate (most renderers that use DOM will need to add an `id` attribute to the block element).

I've added here a couple of changes:
1. Added `class` and `id` to `GlobalAttributes` so we can correctly type check against HTML annotations
2. Added `anchorName` to `Blockquote`, `Group`, `Heading`, `IframeEmbed`, `Image`, `ListItem`, `Paragraph`, `Pullquote`, `Sidebar`, and `VideoEmbed`. (List item is included but not list because linking to a list item I think is way more specific, although I could see cases to be made to link to lists. If anyone feels that List should have this as well, lmk!)
3. Added rendering to the HTML renderer to render all `anchorName`s as `id`s on these elements
4. Added conversion rules to turn `id`s on HTML elements into `anchorName`s.