### PR TITLE
Add support for Twitch embed recognition

### DIFF
--- a/packages/@atjson/offset-annotations/test/video-canonicalisation-test.ts
+++ b/packages/@atjson/offset-annotations/test/video-canonicalisation-test.ts
@@ -64,4 +64,41 @@ describe("VideoURLs", () => {
       });
     });
   });
+
+  describe("Twitch", () => {
+    test.each([
+      "https://www.twitch.tv/videos/956002196",
+      "https://m.twitch.tv/videos/956002196",
+      "https://player.twitch.tv/?video=956002196&parent=www.wired.com",
+    ])("%s", (url) => {
+      expect(VideoURLs.identify(new URL(url))).toEqual({
+        url: "https://player.twitch.tv/?video=956002196&parent=www.example.com",
+        provider: VideoURLs.Provider.TWITCH,
+      });
+    });
+
+    test.each([
+      "https://www.twitch.tv/dunkstream",
+      "https://m.twitch.tv/dunkstream",
+      "https://player.twitch.tv/?channel=dunkstream&parent=www.wired.com",
+    ])("%s", (url) => {
+      expect(VideoURLs.identify(new URL(url))).toEqual({
+        url:
+          "https://player.twitch.tv/?channel=dunkstream&parent=www.example.com",
+        provider: VideoURLs.Provider.TWITCH,
+      });
+    });
+
+    test.each([
+      "https://www.twitch.tv/fanbyte/clip/MistyPluckyNeanderthalWow-1bomfgLj4qFB3uO-?filter=clips&range=7d&sort=time",
+      "https://clips.twitch.tv/MistyPluckyNeanderthalWow-1bomfgLj4qFB3uO-",
+      "https://clips.twitch.tv/embed?clip=MistyPluckyNeanderthalWow-1bomfgLj4qFB3uO-&parent=www.wired.com",
+    ])("%s", (url) => {
+      expect(VideoURLs.identify(new URL(url))).toEqual({
+        url:
+          "https://clips.twitch.tv/embed?clip=MistyPluckyNeanderthalWow-1bomfgLj4qFB3uO-&parent=www.example.com",
+        provider: VideoURLs.Provider.TWITCH,
+      });
+    });
+  });
 });

--- a/packages/@atjson/source-html/test/converter-test.ts
+++ b/packages/@atjson/source-html/test/converter-test.ts
@@ -777,6 +777,50 @@ describe("@atjson/source-html", () => {
           },
         ]);
       });
+
+      test("Twitch videos", () => {
+        let doc = HTMLSource.fromRaw(
+          `<iframe src="https://player.twitch.tv/?video=956002196&parent=www.example.com" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620"></iframe>`
+        )
+          .convertTo(OffsetSource)
+          .canonical();
+
+        expect(doc.annotations).toMatchObject([
+          {
+            type: "video-embed",
+            attributes: {
+              url:
+                "https://player.twitch.tv/?video=956002196&parent=www.example.com",
+              provider: VideoURLs.Provider.TWITCH,
+              width: 620,
+              height: 378,
+              aspectRatio: "5:3",
+            },
+          },
+        ]);
+      });
+
+      test("Twitch clips", () => {
+        let doc = HTMLSource.fromRaw(
+          `<iframe src="https://clips.twitch.tv/embed?clip=StrongBlueWaterDoubleRainbow&parent=www.example.com" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620"></iframe>`
+        )
+          .convertTo(OffsetSource)
+          .canonical();
+
+        expect(doc.annotations).toMatchObject([
+          {
+            type: "video-embed",
+            attributes: {
+              url:
+                "https://clips.twitch.tv/embed?clip=StrongBlueWaterDoubleRainbow&parent=www.example.com",
+              provider: VideoURLs.Provider.TWITCH,
+              width: 620,
+              height: 378,
+              aspectRatio: "5:3",
+            },
+          },
+        ]);
+      });
     });
 
     describe("Third Party embeds", () => {


### PR DESCRIPTION
This adds support for detecting Twitch streams and turning them into iframes. For anyone who would like to use Twitch embeds in their application, they will need to manually handle the `parent` query parameter that is required by Twitch, since there's no mechanism for environment variables (nor is there a strong need for them).