### PR TITLE
Fix twitch urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
     "@atjson/renderer-commonmark": {
       "version": "file:packages/@atjson/renderer-commonmark",
       "requires": {
-        "@atjson/offset-annotations": "0.37.2",
+        "@atjson/offset-annotations": "0.38.0",
         "@atjson/renderer-hir": "0.22.11"
       }
     },
@@ -44,7 +44,7 @@
     "@atjson/renderer-plain-text": {
       "version": "file:packages/@atjson/renderer-plain-text",
       "requires": {
-        "@atjson/offset-annotations": "0.37.2",
+        "@atjson/offset-annotations": "0.38.0",
         "@atjson/renderer-hir": "0.22.11"
       }
     },
@@ -67,7 +67,7 @@
     "@atjson/source-commonmark": {
       "version": "file:packages/@atjson/source-commonmark",
       "requires": {
-        "@atjson/offset-annotations": "0.37.2",
+        "@atjson/offset-annotations": "0.38.0",
         "entities": "2.2.0",
         "markdown-it": "10.0.0"
       },
@@ -82,13 +82,13 @@
     "@atjson/source-gdocs-paste": {
       "version": "file:packages/@atjson/source-gdocs-paste",
       "requires": {
-        "@atjson/offset-annotations": "0.37.2"
+        "@atjson/offset-annotations": "0.38.0"
       }
     },
     "@atjson/source-html": {
       "version": "file:packages/@atjson/source-html",
       "requires": {
-        "@atjson/offset-annotations": "0.37.2",
+        "@atjson/offset-annotations": "0.38.0",
         "parse5": "^6.0.0"
       },
       "dependencies": {
@@ -102,14 +102,14 @@
     "@atjson/source-mobiledoc": {
       "version": "file:packages/@atjson/source-mobiledoc",
       "requires": {
-        "@atjson/offset-annotations": "0.37.2"
+        "@atjson/offset-annotations": "0.38.0"
       }
     },
     "@atjson/source-prism": {
       "version": "file:packages/@atjson/source-prism",
       "requires": {
-        "@atjson/offset-annotations": "0.37.2",
-        "@atjson/source-html": "0.31.2",
+        "@atjson/offset-annotations": "0.38.0",
+        "@atjson/source-html": "0.32.0",
         "@types/sax": "^1.0.1",
         "entities": "^2.0.0",
         "sax": "^1.2.4"
@@ -118,7 +118,7 @@
     "@atjson/source-url": {
       "version": "file:packages/@atjson/source-url",
       "requires": {
-        "@atjson/offset-annotations": "0.37.2"
+        "@atjson/offset-annotations": "0.38.0"
       }
     },
     "@atjson/source-wordpress-shortcode": {

--- a/packages/@atjson/offset-annotations/src/utils/video-urls.ts
+++ b/packages/@atjson/offset-annotations/src/utils/video-urls.ts
@@ -210,21 +210,22 @@ function isTwitchChannelURL(url: IUrl) {
 }
 
 function normalizeTwitchURL(url: IUrl) {
+  let parent = getSearchParam(url.searchParams, "parent") ?? "www.example.com";
   if (isTwitchClipURL(url)) {
     let clipID =
       getSearchParam(url.searchParams, "clip") ??
       without<string>(url.pathname.split("/"), "").pop();
-    return `https://clips.twitch.tv/embed?clip=${clipID}&parent=www.example.com`;
+    return `https://clips.twitch.tv/embed?clip=${clipID}&parent=${parent}`;
   } else if (isTwitchChannelURL(url)) {
     let channelID =
       getSearchParam(url.searchParams, "channel") ??
       without<string>(url.pathname.split("/"), "").pop();
-    return `https://player.twitch.tv/?channel=${channelID}&parent=www.example.com`;
+    return `https://player.twitch.tv/?channel=${channelID}&parent=${parent}`;
   } else {
     let videoID =
       getSearchParam(url.searchParams, "video") ??
       without<string>(url.pathname.split("/"), "").pop();
-    return `https://player.twitch.tv/?video=${videoID}&parent=www.example.com`;
+    return `https://player.twitch.tv/?video=${videoID}&parent=${parent}`;
   }
 }
 

--- a/packages/@atjson/offset-annotations/test/video-canonicalisation-test.ts
+++ b/packages/@atjson/offset-annotations/test/video-canonicalisation-test.ts
@@ -69,7 +69,8 @@ describe("VideoURLs", () => {
     test.each([
       "https://www.twitch.tv/videos/956002196",
       "https://m.twitch.tv/videos/956002196",
-      "https://player.twitch.tv/?video=956002196&parent=www.wired.com",
+      "https://player.twitch.tv/?video=956002196",
+      "https://player.twitch.tv/?video=956002196&parent=www.example.com",
     ])("%s", (url) => {
       expect(VideoURLs.identify(new URL(url))).toEqual({
         url: "https://player.twitch.tv/?video=956002196&parent=www.example.com",
@@ -80,7 +81,8 @@ describe("VideoURLs", () => {
     test.each([
       "https://www.twitch.tv/dunkstream",
       "https://m.twitch.tv/dunkstream",
-      "https://player.twitch.tv/?channel=dunkstream&parent=www.wired.com",
+      "https://player.twitch.tv/?channel=dunkstream",
+      "https://player.twitch.tv/?channel=dunkstream&parent=www.example.com",
     ])("%s", (url) => {
       expect(VideoURLs.identify(new URL(url))).toEqual({
         url:
@@ -92,11 +94,23 @@ describe("VideoURLs", () => {
     test.each([
       "https://www.twitch.tv/fanbyte/clip/MistyPluckyNeanderthalWow-1bomfgLj4qFB3uO-?filter=clips&range=7d&sort=time",
       "https://clips.twitch.tv/MistyPluckyNeanderthalWow-1bomfgLj4qFB3uO-",
-      "https://clips.twitch.tv/embed?clip=MistyPluckyNeanderthalWow-1bomfgLj4qFB3uO-&parent=www.wired.com",
+      "https://clips.twitch.tv/embed?clip=MistyPluckyNeanderthalWow-1bomfgLj4qFB3uO-",
+      "https://clips.twitch.tv/embed?clip=MistyPluckyNeanderthalWow-1bomfgLj4qFB3uO-&parent=www.example.com",
     ])("%s", (url) => {
       expect(VideoURLs.identify(new URL(url))).toEqual({
         url:
           "https://clips.twitch.tv/embed?clip=MistyPluckyNeanderthalWow-1bomfgLj4qFB3uO-&parent=www.example.com",
+        provider: VideoURLs.Provider.TWITCH,
+      });
+    });
+
+    test.each([
+      "https://player.twitch.tv/?video=956002196&parent=www.wired.com",
+      "https://player.twitch.tv/?channel=dunkstream&parent=www.wired.com",
+      "https://clips.twitch.tv/embed?clip=MistyPluckyNeanderthalWow-1bomfgLj4qFB3uO-&parent=www.wired.com",
+    ])("%s", (url) => {
+      expect(VideoURLs.identify(new URL(url))).toEqual({
+        url,
         provider: VideoURLs.Provider.TWITCH,
       });
     });


### PR DESCRIPTION
When canonicalizing Twitch URLs, preserve the `parent` parameter if it
is already set