### PR TITLE
fix(spotify-embeds): Parse Spotify uri-based embeds

### DIFF
--- a/packages/@atjson/offset-annotations/test/social-urls-test.ts
+++ b/packages/@atjson/offset-annotations/test/social-urls-test.ts
@@ -103,6 +103,14 @@ describe("SocialURLs", () => {
           width: "100%",
         },
       ],
+      [
+        "https://open.spotify.com/embed?uri=spotify:album:0RZ90KfXzXhQrgnoMcANUN",
+        {
+          url: "https://open.spotify.com/embed/album/0RZ90KfXzXhQrgnoMcANUN",
+          height: "380",
+          width: "300",
+        },
+      ],
     ])("%s", (url, attributes) => {
       expect(SocialURLs.identify(new URL(url))).toMatchObject({
         Class: IframeEmbed,


### PR DESCRIPTION
Older Spotify embeds use a query param of `uri`, specifying a Spotify URI that corresponds to the embed type and ID. This adds support to the Spotify normalizer for this structure of embed.