### PR TITLE
feat(link): link style attribute

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/link.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/link.ts
@@ -6,6 +6,7 @@ export class Link extends InlineAnnotation<{
   rel?: string;
   target?: string;
   isAffiliateLink?: boolean;
+  linkStyle?: string;
 }> {
   static vendorPrefix = "offset";
   static type = "link";

--- a/packages/@atjson/offset-annotations/src/annotations/link.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/link.ts
@@ -6,7 +6,7 @@ export class Link extends InlineAnnotation<{
   rel?: string;
   target?: string;
   isAffiliateLink?: boolean;
-  linkStyle?: string;
+  linkStyle?: "button";
 }> {
   static vendorPrefix = "offset";
   static type = "link";


### PR DESCRIPTION
With this PR, I have added a new `linkStyle` attribute to the `Link` annotation which helps to render a link as a button or other styles (Button with icon, Link with icon etc) in consumer applications. As of now, this `Link` annotation can be used as inline anchor tag in paragraph. 

By adding this new attribute, it helps, if we want to use this anchor tag between the paragraph (see screenshot below) and need to provide any style type according to the render style in consumer applications.

![Screenshot 2021-07-06 at 6 11 04 PM](https://user-images.githubusercontent.com/86091684/129151622-9c9559fa-79c9-412c-904c-e4f939f55fe1.png)

nb. Edited to remove links to private documentation by @tim-evans 