### PR TITLE
feat(telegram-embed): Add Telegram urls recognition

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/index.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/index.ts
@@ -28,6 +28,7 @@ export * from "./small-caps";
 export * from "./strikethrough";
 export * from "./subscript";
 export * from "./superscript";
+export * from "./telegram-embed";
 export * from "./tiktok-embed";
 export * from "./twitter-embed";
 export * from "./underline";

--- a/packages/@atjson/offset-annotations/src/annotations/telegram-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/telegram-embed.ts
@@ -1,0 +1,6 @@
+import { IframeEmbed } from "./iframe-embed";
+
+export class TelegramEmbed extends IframeEmbed {
+  static type = "telegram-embed";
+  static vendorPrefix = "offset";
+}

--- a/packages/@atjson/offset-annotations/src/utils/social-urls.ts
+++ b/packages/@atjson/offset-annotations/src/utils/social-urls.ts
@@ -4,8 +4,9 @@ import {
   GiphyEmbed,
   InstagramEmbed,
   PinterestEmbed,
-  TwitterEmbed,
+  TelegramEmbed,
   TikTokEmbed,
+  TwitterEmbed
 } from "../annotations";
 
 function without<T>(array: T[], value: T): T[] {
@@ -331,6 +332,24 @@ function normalizeTikTokUrl(url: IUrl) {
   };
 }
 
+// Telegram URLs
+// Needs to covert post URL (https://t.me/:channelSlug/:postId) to post slug (:channelSlug/:postId)
+// Docs here https://core.telegram.org/widgets/post
+
+function isTelegramUrl(url: IUrl) {
+  return url.host === "t.me";
+}
+
+function normalizeTelegramUrl(url: IUrl) {
+  let [cahnnelSlug, postId] = without<string>(url.pathname.split("/"), "");
+  return {
+    Class: TelegramEmbed,
+    attributes: {
+      url: `${cahnnelSlug}/${postId}`,
+    },
+  };
+}
+
 export function identify(
   url: IUrl
 ): {
@@ -371,6 +390,10 @@ export function identify(
 
   if (isTikTokUrl(url)) {
     return normalizeTikTokUrl(url);
+  }
+
+  if (isTelegramUrl(url)) {
+    return normalizeTelegramUrl(url);
   }
 
   return null;

--- a/packages/@atjson/offset-annotations/test/social-urls-test.ts
+++ b/packages/@atjson/offset-annotations/test/social-urls-test.ts
@@ -1,4 +1,4 @@
-import { IframeEmbed, SocialURLs } from "../src";
+import { IframeEmbed, TelegramEmbed, SocialURLs } from "../src";
 
 describe("SocialURLs", () => {
   describe("identify Spotify", () => {
@@ -136,6 +136,28 @@ describe("SocialURLs", () => {
     ])("%s", (url, attributes) => {
       expect(SocialURLs.identify(new URL(url))).toMatchObject({
         Class: IframeEmbed,
+        attributes,
+      });
+    });
+  });
+
+  describe("identify Telegram", () => {
+    test.each([
+      [
+        "https://t.me/voguerussia/8714/",
+        {
+          url: "voguerussia/8714",
+        },
+      ],
+      [
+        "http://t.me/tatlerbutler/3416",
+        {
+          url: "tatlerbutler/3416",
+        },
+      ],
+    ])("%s", (url, attributes) => {
+      expect(SocialURLs.identify(new URL(url))).toMatchObject({
+        Class: TelegramEmbed,
         attributes,
       });
     });


### PR DESCRIPTION
Add support for Telegram embeds, which is currently used by Russian markets.