### PR TITLE
Escape blockquote characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -189,6 +189,26 @@
       "version": "file:packages/@atjson/source-wordpress-shortcode",
       "requires": {
         "@wordpress/shortcode": "3.2.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.16.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+          "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@wordpress/shortcode": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.2.3.tgz",
+          "integrity": "sha512-zXIg2AbwJhJNCp55roC+wuyZQnMC/GLdgh95pAa5a7Hd+ThXf0hbBg+DP9lo1x+cxAZAEGZ/Bns/+SCUr1boTA==",
+          "requires": {
+            "@babel/runtime": "^7.16.0",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -2430,6 +2450,7 @@
       "version": "7.14.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
       "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -6252,16 +6273,6 @@
       "requires": {
         "@typescript-eslint/types": "5.3.0",
         "eslint-visitor-keys": "^3.0.0"
-      }
-    },
-    "@wordpress/shortcode": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.2.2.tgz",
-      "integrity": "sha512-Im3z6C/+0IYepBg7w3m+2wyAEQfNLoWN3yQ1czNPsGHMAbELvAZjhd9S1hkJXgdyS9wQnamIQhu9wGB20qeh9A==",
-      "requires": {
-        "@babel/runtime": "^7.13.10",
-        "lodash": "^4.17.21",
-        "memize": "^1.1.0"
       }
     },
     "JSONStream": {

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -218,6 +218,7 @@ function escapePunctuation(
   let escaped = text
     .replace(/([#!*+=\\^_`{|}~])/g, "\\$1")
     .replace(/(\[)([^\]]*$)/g, "\\$1$2") // Escape bare opening brackets [
+    .replace(/(^[\s]*)>/g, "$1\\>") // Escape >
     .replace(/(^[^[]*)(\].*$)/g, "$1\\$2") // Escape bare closing brackets ]
     .replace(/(\]\()/g, "]\\(") // Escape parenthesis ](
     .replace(/^(\s*\d+)\.(\s+)/gm, "$1\\.$2") // Escape list items; not all numbers

--- a/packages/@atjson/renderer-commonmark/test/escaped-text-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/escaped-text-test.ts
@@ -1,0 +1,29 @@
+import OffsetSource, { Paragraph } from "@atjson/offset-annotations";
+import CommonmarkSource from "@atjson/source-commonmark";
+import CommonmarkRenderer from "../src";
+
+describe("commonmark", () => {
+  test.each([">>", "#Chromatica", "- list item"])("escaping %s", (content) => {
+    let document = new OffsetSource({
+      content,
+      annotations: [],
+    });
+
+    expect(CommonmarkRenderer.render(document)).toBe(`\\${content}`);
+  });
+
+  test.each([">>", "#Chromatica", "- list item"])(
+    "escaping round trip %s",
+    (content) => {
+      let document = new OffsetSource({
+        content,
+        annotations: [new Paragraph({ start: 0, end: content.length })],
+      });
+      let roundTrip = CommonmarkSource.fromRaw(
+        CommonmarkRenderer.render(document)
+      ).convertTo(OffsetSource);
+
+      expect(document.equals(roundTrip)).toBe(true);
+    }
+  );
+});


### PR DESCRIPTION
While testing some markdown <-> rich text editing, I noticed that we had a review of an album, [>>](https://pitchfork.com/reviews/albums/16697-recordreview/) by Beak>. This adds tests and correct escape sequences for text that starts with `>`