### PR TITLE
Add support for isolated modules for running atjson using vite

### DIFF
--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -1,10 +1,7 @@
 import {
   AdjacentBoundaryBehaviour,
   Annotation,
-  AnnotationConstructor,
   AnnotationCollection,
-  AnnotationJSON,
-  AttributesOf,
   BlockAnnotation,
   Change,
   compareAnnotations,
@@ -15,20 +12,23 @@ import {
   InlineAnnotation,
   Insertion,
   Join,
-  JSON,
   ObjectAnnotation,
   ParseAnnotation,
   UnknownAnnotation,
   is,
 } from "./internals";
 
+import type {
+  AnnotationConstructor,
+  AnnotationJSON,
+  AttributesOf,
+  JSON,
+} from "./internals";
+
 export {
   AdjacentBoundaryBehaviour,
   Annotation,
-  AnnotationConstructor,
   AnnotationCollection,
-  AnnotationJSON,
-  AttributesOf,
   BlockAnnotation,
   Change,
   compareAnnotations,
@@ -38,11 +38,12 @@ export {
   InlineAnnotation,
   Insertion,
   Join,
-  JSON,
   ObjectAnnotation,
   ParseAnnotation,
   UnknownAnnotation,
   is,
 };
+
+export type { AnnotationConstructor, AnnotationJSON, AttributesOf, JSON };
 
 export default Document;

--- a/packages/@atjson/document/tsconfig.modules.json
+++ b/packages/@atjson/document/tsconfig.modules.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist/modules",
+    "isolatedModules": true,
     "module": "esnext",
     "target": "ES2018"
   }


### PR DESCRIPTION
This allows atjson to be used by [vite](https://vitejs.dev) in development mode; this requires `isolatedModules` mode to be set to `true`, which caused some changes in the exports for the `index.ts` file.