### PR TITLE
feat: add channel param to firework embed

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/firework-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/firework-embed.ts
@@ -1,8 +1,9 @@
 import { ObjectAnnotation } from "@atjson/document";
 
 export class FireworkEmbed extends ObjectAnnotation<{
-  playlist: string;
-  openIn?: "default" | "_self" | "_modal" | "_blank";
+  url: string;
+  channel?: "string";
+  open?: "default" | "_self" | "_modal" | "_blank";
   /**
    * A named identifier used to quickly jump to this item
    */


### PR DESCRIPTION
Related PR: https://github.com/CondeNast/atjson/pull/1262

Added a `channel` param to the embed and renamed existing to "url" and "open" instead of "playlist" and "openIn", the new embed should be:
[#firework: url channel:value open:value]