### PR TITLE
fix: change channel param type to string

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/firework-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/firework-embed.ts
@@ -2,7 +2,7 @@ import { ObjectAnnotation } from "@atjson/document";
 
 export class FireworkEmbed extends ObjectAnnotation<{
   url: string;
-  channel?: "string";
+  channel?: string;
   open?: "default" | "_self" | "_modal" | "_blank";
   /**
    * A named identifier used to quickly jump to this item


### PR DESCRIPTION
Related PR: https://github.com/CondeNast/atjson/pull/1265

Changed `channel` param type from "string" to `string`.