### PR TITLE
fix: rename url field into id to reconciliate definitions

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/firework-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/firework-embed.ts
@@ -1,7 +1,7 @@
 import { ObjectAnnotation } from "@atjson/document";
 
 export class FireworkEmbed extends ObjectAnnotation<{
-  url: string;
+  id: string;
   channel?: string;
   open?: "default" | "_self" | "_modal" | "_blank";
   /**


### PR DESCRIPTION
Related PR: https://github.com/CondeNast/atjson/pull/1268

Renamed `url` attribute into `id` to reconciliate info accordingly to the embed code that should be:
[#firework: id channel:value open:value]

An example:
[#firework XXXXX channel:voguemagazine open:_modal]