### PR TITLE
chore: use whole-number aspect ratios

### DIFF
--- a/packages/@atjson/offset-annotations/src/utils/aspect-ratios.ts
+++ b/packages/@atjson/offset-annotations/src/utils/aspect-ratios.ts
@@ -26,19 +26,19 @@ const ASPECT_RATIOS = [
   // HD video standard / Digital broadcast TV standard
   "16:9",
   // US widescreen cinema standard
-  "1.85:1",
+  "37:20",
   // 4K & 2K standard
-  "1.9:1",
+  "19:10",
   // Univisium
   "2:1",
   // 70mm film
-  "2.2:1",
+  "11:5",
   // Cinematic widescreen
   "21:9",
   // Widescreen cinema standard
-  "2.4:1",
+  "12:5",
   // Ultra-WideScreen
-  "3.6:1",
+  "18:5",
 ] as const;
 
 const proportions = ASPECT_RATIOS.map((ratio) => {

--- a/packages/@atjson/offset-annotations/test/aspect-ratio-test.ts
+++ b/packages/@atjson/offset-annotations/test/aspect-ratio-test.ts
@@ -83,6 +83,6 @@ describe("getClosestAspectRatio", () => {
   });
 
   test("super wide video", () => {
-    expect(getClosestAspectRatio(50, 2)).toBe("3.6:1");
+    expect(getClosestAspectRatio(50, 2)).toBe("18:5");
   });
 });


### PR DESCRIPTION
Some data formats have difficulty with decimal-valued aspect
ratios, so this PR replaces these with their whole-number
equivalent:

1.85:1 -> 37:20
1.9:1 -> 19:10
2.2:1 -> 11:5
2.4:1 -> 12:5
3.6:1 -> 18:5