### PR TITLE
Pass altered document to hir-renderer

### DIFF
--- a/packages/@atjson/renderer-commonmark/test/slice-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/slice-test.ts
@@ -1,0 +1,66 @@
+jest.unmock("uuid-random");
+
+import OffsetSource, {
+  IframeEmbed,
+  Italic,
+  Link,
+  Paragraph,
+} from "@atjson/offset-annotations";
+import { ParseAnnotation, SliceAnnotation } from "@atjson/document";
+import CommonmarkRenderer from "../src";
+import uuid from "uuid-random";
+
+describe("commonmark", () => {
+  test("correct handling of slices and delimiter runs", () => {
+    let captionId = uuid();
+    let doc = new OffsetSource({
+      content: "\uFFFC\nPop tarts\nAnd an emphasized link",
+      annotations: [
+        new IframeEmbed({
+          start: 0,
+          end: 1,
+          attributes: {
+            url: "https://www.youtube.com/embed/jYqRiKu7gY0",
+            caption: captionId,
+          },
+        }),
+        new ParseAnnotation({
+          start: 0,
+          end: 1,
+        }),
+        new ParseAnnotation({
+          start: 1,
+          end: 2,
+        }),
+        new SliceAnnotation({
+          id: captionId,
+          start: 2,
+          end: 11,
+        }),
+        new ParseAnnotation({
+          start: 11,
+          end: 12,
+        }),
+        new Paragraph({
+          start: 12,
+          end: 34,
+        }),
+        new Italic({
+          start: 19,
+          end: 34,
+        }),
+        new Link({
+          start: 19,
+          end: 34,
+          attributes: {
+            url: "https://www.bonappetit.com",
+          },
+        }),
+      ],
+    });
+
+    expect(CommonmarkRenderer.render(doc)).toBe(
+      "And an *[emphasized link](https://www.bonappetit.com)*\n\n"
+    );
+  });
+});

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -220,7 +220,9 @@ export default class Renderer {
     let document = params[0];
     let renderer = new this(document, ...params.slice(1));
     let hir = new HIR(document);
-    return compile(renderer, hir.rootNode, hir.sliceNodes, { document });
+    return compile(renderer, hir.rootNode, hir.sliceNodes, {
+      document: hir.document,
+    });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function


### PR DESCRIPTION
This fixes a bug with the commonmark renderer that was incorrectly looking at outdated text and inferring incorrect behavior. By passing the altered document down from the hir to the renderer, we have similar behavior prior to introducing slices (it should be similar to subdocuments).

This is causing issues upstream with the contrived test I've included. Prior to this change, it would mess up the italics and mangle the document:

```md
And an [*emphasized link](https://www.bonappetit.com*)
```

When it should correctly place the emphasis marks outside the link:

```md
And an *[emphasized link](https://www.bonappetit.com)*
```