### PR TITLE
Fix slice document context

### DIFF
--- a/packages/@atjson/hir/src/hir.ts
+++ b/packages/@atjson/hir/src/hir.ts
@@ -21,7 +21,7 @@ function compareAnnotations(a: Annotation, b: Annotation) {
 
 export default class HIR {
   rootNode: HIRNode;
-  sliceNodes: Record<string, HIRNode>;
+  slices: Record<string, { node: HIRNode; document: Document }>;
   document: Document;
 
   constructor(doc: Document) {
@@ -60,7 +60,7 @@ export default class HIR {
     }
     this.document.deleteTextRanges(sliceRanges);
 
-    this.sliceNodes = {};
+    this.slices = {};
     for (let id in slices) {
       let slice = slices[id];
       let sliceNode = new HIRNode(
@@ -76,7 +76,10 @@ export default class HIR {
       }
 
       sliceNode.insertText(slice.content);
-      this.sliceNodes[id] = sliceNode;
+      this.slices[id] = {
+        node: sliceNode,
+        document: slice,
+      };
     }
 
     this.rootNode = new HIRNode(

--- a/packages/@atjson/renderer-react/src/index.ts
+++ b/packages/@atjson/renderer-react/src/index.ts
@@ -65,7 +65,7 @@ export type PropsOf<AnnotationClass> = AnnotationClass extends Annotation<
 
 function propsOf(
   attributes: JSON | undefined,
-  slices: Record<string, HIRNode>,
+  slices: Record<string, { node: HIRNode; document: Document }>,
   subdocuments: Record<string, typeof Document>,
   id: string,
   transformer: (annotation: HIRNode, key: string) => unknown
@@ -95,10 +95,10 @@ function propsOf(
     return props;
   } else if (typeof attributes === "string") {
     if (attributes in slices) {
-      let node = slices[attributes];
+      let slice = slices[attributes];
       // Only work on slices that are in the document
-      if (node != null) {
-        return transformer(node, `${id}-${attributes}`);
+      if (slice != null) {
+        return transformer(slice.node, `${id}-${attributes}`);
       }
     }
   }
@@ -108,7 +108,7 @@ function propsOf(
 function renderNode(props: {
   node: HIRNode;
   includeParseTokens: boolean;
-  slices: Record<string, HIRNode>;
+  slices: Record<string, { node: HIRNode; document: Document }>;
   key: string;
 }): ReactNode {
   let { node, includeParseTokens, slices, key } = props;
@@ -213,7 +213,7 @@ function render(
         renderNode({
           node,
           includeParseTokens: props.includeParseTokens === true,
-          slices: hir.sliceNodes,
+          slices: hir.slices,
           key: `${node.id}-${index}`,
         })
       )


### PR DESCRIPTION
This is the same category of bug as #1307, where the document being passed along to the context object was pointing to an out of date (and in this case, completely incorrect document). This caused context specific errors with subclasses of the commonmark renderer, as it uses the document to do backtracking to automatically correct categories of errors that may be produced by using a rich text editor to write markdown.