### PR TITLE
Stop reifying slices in renderers

### DIFF
--- a/packages/@atjson/hir/src/hir.ts
+++ b/packages/@atjson/hir/src/hir.ts
@@ -21,7 +21,7 @@ function compareAnnotations(a: Annotation, b: Annotation) {
 
 export default class HIR {
   rootNode: HIRNode;
-  slices: Record<string, { node: HIRNode; document: Document }>;
+  slices: Record<string, Document>;
   document: Document;
 
   constructor(doc: Document) {
@@ -36,11 +36,11 @@ export default class HIR {
       }
     }
 
-    let slices: Record<string, Document> = {};
+    this.slices = {};
     let sliceRanges: { start: number; end: number }[] = [];
     let sliceAnnotations = this.document.where((a) => is(a, SliceAnnotation));
     for (let annotation of sliceAnnotations) {
-      slices[annotation.id] = this.document.slice(
+      this.slices[annotation.id] = this.document.slice(
         annotation.start,
         annotation.end,
         (a) =>
@@ -59,28 +59,6 @@ export default class HIR {
       sliceRanges.push({ start: annotation.start, end: annotation.end });
     }
     this.document.deleteTextRanges(sliceRanges);
-
-    this.slices = {};
-    for (let id in slices) {
-      let slice = slices[id];
-      let sliceNode = new HIRNode(
-        new Root({
-          start: 0,
-          end: slice.content.length,
-          attributes: {},
-        })
-      );
-
-      for (let annotation of slice.annotations.sort(compareAnnotations)) {
-        sliceNode.insertAnnotation(annotation);
-      }
-
-      sliceNode.insertText(slice.content);
-      this.slices[id] = {
-        node: sliceNode,
-        document: slice,
-      };
-    }
 
     this.rootNode = new HIRNode(
       new Root({

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -75,18 +75,15 @@ function isTextAnnotation(a: Annotation<any>): a is TextAnnotation {
   return a.vendorPrefix === "atjson" && a.type === "text";
 }
 
-function attrs<T>(
-  attributes: TJSON | undefined,
-  transformer: (annotation: HIRNode, document: Document) => T
-): any {
+function attrs(attributes: TJSON | undefined): any {
   if (attributes == null) {
     return attributes;
   } else if (Array.isArray(attributes)) {
-    return attributes.map((item) => attrs(item, transformer));
+    return attributes.map((item) => attrs(item));
   } else if (typeof attributes === "object") {
     let props: TJSON = {};
     for (let key in attributes) {
-      props[key] = attrs(attributes[key], transformer);
+      props[key] = attrs(attributes[key]);
     }
     return props;
   }
@@ -106,10 +103,7 @@ function compile(
   if (context.parent == null) {
     generator = renderer.root();
   } else {
-    annotation.attributes = attrs(
-      annotation.attributes,
-      (sliceNode, document) => compile(renderer, sliceNode, { document })
-    );
+    annotation.attributes = attrs(annotation.attributes);
     generator = renderer.renderAnnotation(annotation, {
       ...context,
       children: childAnnotations,

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -249,7 +249,7 @@ export default class Renderer {
    * @param sliceId The id of the slice to return
    * @returns The slice document or null if there's no slices that match
    */
-  slice(sliceId: string) {
+  getSlice(sliceId: string) {
     return this.slices[sliceId] ?? null;
   }
 

--- a/packages/@atjson/renderer-hir/test/renderer-hir-test.ts
+++ b/packages/@atjson/renderer-hir/test/renderer-hir-test.ts
@@ -289,7 +289,7 @@ describe("@atjson/renderer-hir", () => {
           return `<blockquote>${words.join("")}${
             blockquote.attributes.credit
               ? `<cite>${HTMLRenderer.render(
-                  this.slice(blockquote.attributes.credit)
+                  this.getSlice(blockquote.attributes.credit)
                 )}</cite>`
               : ""
           }</blockquote>`;
@@ -407,7 +407,7 @@ describe("@atjson/renderer-hir", () => {
                   .map(
                     (citation, index) =>
                       `<li id="cite-${index + 1}">${HTMLRenderer.render(
-                        this.slice(citation)
+                        this.getSlice(citation)
                       )}</li>`
                   )
                   .join("")}</ol>`
@@ -451,8 +451,9 @@ describe("@atjson/renderer-hir", () => {
         }
         *Spoiler(spoiler, context) {
           let spoilerText =
-            ConcreteRenderer.render(this.slice(spoiler.attributes.spoiler)) ??
-            "";
+            ConcreteRenderer.render(
+              this.getSlice(spoiler.attributes.spoiler)
+            ) ?? "";
           expect(context.document.content).toEqual(
             "This document has a spoiler:\n"
           );

--- a/packages/@atjson/renderer-hir/test/renderer-hir-test.ts
+++ b/packages/@atjson/renderer-hir/test/renderer-hir-test.ts
@@ -288,7 +288,9 @@ describe("@atjson/renderer-hir", () => {
           let words = yield;
           return `<blockquote>${words.join("")}${
             blockquote.attributes.credit
-              ? `<cite>${blockquote.attributes.credit}</cite>`
+              ? `<cite>${HTMLRenderer.render(
+                  this.slice(blockquote.attributes.credit)
+                )}</cite>`
               : ""
           }</blockquote>`;
         }
@@ -404,7 +406,9 @@ describe("@atjson/renderer-hir", () => {
               ? `\n<ol>${this.citations
                   .map(
                     (citation, index) =>
-                      `<li id="cite-${index + 1}">${citation}</li>`
+                      `<li id="cite-${index + 1}">${HTMLRenderer.render(
+                        this.slice(citation)
+                      )}</li>`
                   )
                   .join("")}</ol>`
               : ""
@@ -446,12 +450,13 @@ describe("@atjson/renderer-hir", () => {
           return (yield).join("");
         }
         *Spoiler(spoiler, context) {
+          let spoilerText =
+            ConcreteRenderer.render(this.slice(spoiler.attributes.spoiler)) ??
+            "";
           expect(context.document.content).toEqual(
             "This document has a spoiler:\n"
           );
-          return (
-            (yield).join("") + "X".repeat(spoiler.attributes.spoiler.length - 1)
-          );
+          return (yield).join("") + "X".repeat(spoilerText.length - 1);
         }
         *Bold(_, context) {
           expect(context.document.content).toEqual("This is it!");

--- a/packages/@atjson/renderer-react/test/react-renderer-test.tsx
+++ b/packages/@atjson/renderer-react/test/react-renderer-test.tsx
@@ -13,11 +13,11 @@ import OffsetSource, {
 import * as React from "react";
 import { createElement, Fragment, ReactNode } from "react";
 import * as ReactDOMServer from "react-dom/server";
-import ReactRenderer, { PropsOf, ReactRendererProvider } from "../src";
+import ReactRenderer, { PropsOf, ReactRendererProvider, Slice } from "../src";
 
 function renderDocument(
   doc: OffsetSource,
-  components: { [key: string]: React.StatelessComponent<any> }
+  components: { [key: string]: React.ComponentType<any> }
 ) {
   return ReactDOMServer.renderToStaticMarkup(
     <ReactRendererProvider value={components}>
@@ -100,7 +100,9 @@ function IframeComponent(props: PropsOf<IframeEmbed>) {
   return (
     <figure>
       <iframe src={props.url} />
-      <figcaption>{props.caption}</figcaption>
+      <figcaption>
+        <Slice value={props.caption} fallback={props.caption} />
+      </figcaption>
     </figure>
   );
 }
@@ -114,7 +116,9 @@ function IframeComponentWithProvider(props: PropsOf<IframeEmbed>) {
     <figure>
       <iframe src={props.url} />
       <ReactRendererProvider value={{ Bold: CaptionBold }}>
-        <figcaption>{props.caption}</figcaption>
+        <figcaption>
+          <Slice value={props.caption} fallback={props.caption} />
+        </figcaption>
       </ReactRendererProvider>
     </figure>
   );


### PR DESCRIPTION
Some code reviews and discussions have brought up that there's quite a bit of magic going on with slices. To address this, I have a suggestion for an approach that is considerably less magical and requires more explicit interventions to get it working.

tldr;
I've added a function called `slice` on the `renderer-hir` which will return the slice document for that id. If none is returned, it's up to the client to figure out what to do. Previously, this would be handled behind the scenes. To preemptively address some annoying developer experience, I've made renderers accept `null` documents, which will return nothing. This makes code a bit easier to read, since you can do some nullish coalescing to resolve in these cases.

For `renderer-react`, I've introduced a new component called `Slice`, which takes a `value` and `fallback`, which will render the value of the slice if found using the existing providers, and if the slice doesn't exist, it'll render the fallback.

