### PR TITLE
Guard against object replacement characters

### DIFF
--- a/packages/@atjson/document/src/annotations/slice.ts
+++ b/packages/@atjson/document/src/annotations/slice.ts
@@ -16,6 +16,6 @@ export class SliceAnnotation extends Annotation<{
   static type = "slice";
 
   get rank() {
-    return 10000;
+    return 5;
   }
 }

--- a/packages/@atjson/document/src/serialize.ts
+++ b/packages/@atjson/document/src/serialize.ts
@@ -446,7 +446,11 @@ export function serialize(
   lastIndex = 0;
   for (let token of tokens) {
     if (parseTokens.length === 0) {
-      text += doc.content.slice(lastIndex, token.index);
+      let chunk = doc.content.slice(lastIndex, token.index);
+      if (chunk.indexOf("\uFFFC") !== -1) {
+        throw new Error("Text contains reserved character \uFFFC.");
+      }
+      text += chunk;
     }
     lastIndex = token.index;
 

--- a/packages/@atjson/document/src/serialize.ts
+++ b/packages/@atjson/document/src/serialize.ts
@@ -451,16 +451,16 @@ export function serialize(
       let chunk = doc.content.slice(lastIndex, token.index);
       let reservedCharacterIndex = chunk.indexOf("\uFFFC");
       if (reservedCharacterIndex !== -1) {
+        let index = lastIndex + reservedCharacterIndex;
+        let start = Math.max(0, index - 25);
+        let end = Math.min(index + 25, doc.content.length);
+
+        // Provides some context when throwing an error to make it easier to
+        // find where the object replacement character is in a larger document
         throw new Error(
           `Text contains reserved character +uFFFC at index ${
             lastIndex + reservedCharacterIndex
-          }.\n\n${doc.content.slice(
-            Math.max(0, lastIndex + reservedCharacterIndex - 25),
-            Math.min(
-              lastIndex + reservedCharacterIndex + 25,
-              doc.content.length
-            )
-          )}`
+          }.\n\n${doc.content.slice(start, end)}\n${" ".repeat(index - start)}^`
         );
       }
       text += chunk;

--- a/packages/@atjson/document/test/__snapshots__/with-stable-ids-test.ts.snap
+++ b/packages/@atjson/document/test/__snapshots__/with-stable-ids-test.ts.snap
@@ -60,7 +60,7 @@ exports[`Document#withStableId annotations by id reference are equal (even when 
     {
       "attributes": {
         "-test-citation": "00000006",
-        "-test-credit": "00000004",
+        "-test-credit": "00000003",
       },
       "end": 187,
       "id": "00000001",
@@ -75,22 +75,22 @@ exports[`Document#withStableId annotations by id reference are equal (even when 
       "type": "-atjson-parse-token",
     },
     {
-      "attributes": {},
-      "end": 202,
-      "id": "00000003",
-      "start": 190,
-      "type": "-test-italic",
-    },
-    {
       "attributes": {
         "-atjson-refs": [
           "00000001",
         ],
       },
       "end": 202,
-      "id": "00000004",
+      "id": "00000003",
       "start": 190,
       "type": "-atjson-slice",
+    },
+    {
+      "attributes": {},
+      "end": 202,
+      "id": "00000004",
+      "start": 190,
+      "type": "-test-italic",
     },
     {
       "attributes": {},

--- a/packages/@atjson/document/test/serialize-test.ts
+++ b/packages/@atjson/document/test/serialize-test.ts
@@ -22,16 +22,37 @@ describe("serialize", () => {
     expect(() => {
       serialize(
         new TestSource({
-          content: "\uFFFC",
+          content:
+            "<p>There's text that wasn't wrapped in a ParseAnnotation!</p>\uFFFC",
           annotations: [
-            new Instagram({
+            new ParseAnnotation({
               start: 0,
-              end: 1,
+              end: 3,
+            }),
+
+            new Paragraph({
+              start: 0,
+              end: 61,
+            }),
+
+            new ParseAnnotation({
+              start: 57,
+              end: 61,
+            }),
+
+            new Instagram({
+              start: 61,
+              end: 62,
             }),
           ],
         })
       );
-    }).toThrowError();
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "Text contains reserved character +uFFFC at index 61.
+
+      in a ParseAnnotation!</p>￼
+                               ^"
+    `);
   });
 
   describe("blocks", () => {

--- a/packages/@atjson/document/test/serialize-test.ts
+++ b/packages/@atjson/document/test/serialize-test.ts
@@ -14,9 +14,26 @@ import TestSource, {
   ListItem,
   LineBreak,
   Quote,
+  Instagram,
 } from "./test-source";
 
 describe("serialize", () => {
+  test("errors are thrown if uFFFC is included in text", () => {
+    expect(() => {
+      serialize(
+        new TestSource({
+          content: "\uFFFC",
+          annotations: [
+            new Instagram({
+              start: 0,
+              end: 1,
+            }),
+          ],
+        })
+      );
+    }).toThrowError();
+  });
+
   describe("blocks", () => {
     test("single block", () => {
       expect(

--- a/packages/@atjson/hir/src/hir-node.ts
+++ b/packages/@atjson/hir/src/hir-node.ts
@@ -315,6 +315,9 @@ export default class HIRNode {
           start: newStart,
           end: newEnd,
         });
+    if (this.child) {
+      partial.insertChild(this.child);
+    }
 
     if (partial.start === partial.end) return;
 

--- a/packages/@atjson/offset-annotations/src/annotations/iframe-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/iframe-embed.ts
@@ -1,6 +1,6 @@
-import { ObjectAnnotation } from "@atjson/document";
+import { BlockAnnotation } from "@atjson/document";
 
-export class IframeEmbed extends ObjectAnnotation<{
+export class IframeEmbed extends BlockAnnotation<{
   url: string;
   width?: string;
   height?: string;

--- a/packages/@atjson/offset-annotations/src/annotations/video-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/video-embed.ts
@@ -1,7 +1,7 @@
-import { ObjectAnnotation } from "@atjson/document";
+import { BlockAnnotation } from "@atjson/document";
 import { getClosestAspectRatio, VideoURLs } from "../utils";
 
-export class VideoEmbed extends ObjectAnnotation<{
+export class VideoEmbed extends BlockAnnotation<{
   /**
    * The embed URL of the video
    */

--- a/packages/@atjson/renderer-react/src/index.ts
+++ b/packages/@atjson/renderer-react/src/index.ts
@@ -178,7 +178,9 @@ function render(
     propsOrDocument instanceof Document
       ? { document: propsOrDocument }
       : propsOrDocument;
+
   let hir = new HIR(props.document);
+
   let rootNode = hir.rootNode;
   return createElement(
     SliceContext.Provider,

--- a/packages/@atjson/renderer-react/test/react-renderer-test.tsx
+++ b/packages/@atjson/renderer-react/test/react-renderer-test.tsx
@@ -1,4 +1,8 @@
-import { ObjectAnnotation, SliceAnnotation } from "@atjson/document";
+import {
+  ObjectAnnotation,
+  ParseAnnotation,
+  SliceAnnotation,
+} from "@atjson/document";
 import OffsetSource, {
   Bold,
   CaptionSource,
@@ -143,27 +147,25 @@ describe("ReactRenderer", () => {
   });
 
   it("renders nested components", () => {
-    let video = new VideoEmbed({
-      start: 9,
-      end: 10,
-      attributes: {
-        url: "https://www.youtube-nocookie.com/embed/U8x85EY03vY?controls=0&showinfo=0&rel=0",
-        provider: VideoURLs.Provider.YOUTUBE,
-      },
-    });
-
     let doc = new OffsetSource({
-      content: "Good boy\n ",
+      content: "Good boy ",
       annotations: [
         new Link({
           start: 0,
-          end: 10,
+          end: 8,
           attributes: {
             url: "https://www.youtube.com/watch?v=U8x85EY03vY",
           },
         }),
-        new LineBreak({ start: 8, end: 9 }),
-        video,
+        new LineBreak({ start: 4, end: 5 }),
+        new VideoEmbed({
+          start: 8,
+          end: 9,
+          attributes: {
+            url: "https://www.youtube-nocookie.com/embed/U8x85EY03vY?controls=0&showinfo=0&rel=0",
+            provider: VideoURLs.Provider.YOUTUBE,
+          },
+        }),
       ],
     });
 
@@ -175,30 +177,31 @@ describe("ReactRenderer", () => {
         LineBreak: LineBreakComponent,
         VideoEmbed: VideoEmbedComponent,
       })
-    ).toBe(
-      `<a href="https://www.youtube.com/watch?v=U8x85EY03vY" target="__blank" rel="noreferrer noopener">Good boy<br/><iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/U8x85EY03vY?controls=0&amp;showinfo=0&amp;rel=0" frameBorder="0" allowfullscreen=""></iframe></a>`
+    ).toMatchInlineSnapshot(
+      `"<a href="https://www.youtube.com/watch?v=U8x85EY03vY" target="__blank" rel="noreferrer noopener">Good<br/>boy</a><iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/U8x85EY03vY?controls=0&amp;showinfo=0&amp;rel=0" frameBorder="0" allowfullscreen=""></iframe>"`
     );
   });
 
   it("reuses renderers", () => {
     let doc = new OffsetSource({
-      content: "Another good boy\n ",
+      content: "Another good boy ",
       annotations: [
         new Link({
           start: 0,
-          end: 19,
+          end: 16,
           attributes: {
             url: "https://giphy.com/gifs/dog-chair-good-boy-26FmRLBRZfpMNwWdy",
           },
         }),
-        new LineBreak({ start: 16, end: 17 }),
+        new LineBreak({ start: 7, end: 8 }),
         new GiphyEmbed({
-          start: 17,
-          end: 18,
+          start: 16,
+          end: 17,
           attributes: {
             url: "https://giphy.com/gifs/dog-chair-good-boy-26FmRLBRZfpMNwWdy",
           },
         }),
+        new ParseAnnotation({ start: 16, end: 17 }),
       ],
     });
 
@@ -208,8 +211,8 @@ describe("ReactRenderer", () => {
         Link: LinkComponent,
         GiphyEmbed: GiphyEmbedComponent,
       })
-    ).toBe(
-      `<a href=\"https://giphy.com/gifs/dog-chair-good-boy-26FmRLBRZfpMNwWdy\" target=\"__blank\" rel=\"noreferrer noopener\">Another good boy<br/><img src=\"https://media.giphy.com/media/26FmRLBRZfpMNwWdy/giphy.gif\"/></a>`
+    ).toMatchInlineSnapshot(
+      `"<a href="https://giphy.com/gifs/dog-chair-good-boy-26FmRLBRZfpMNwWdy" target="__blank" rel="noreferrer noopener">Another<br/>good boy</a><img src="https://media.giphy.com/media/26FmRLBRZfpMNwWdy/giphy.gif"/>"`
     );
   });
 

--- a/packages/@atjson/source-html/src/converter/index.ts
+++ b/packages/@atjson/source-html/src/converter/index.ts
@@ -1,6 +1,6 @@
 import Document, { Annotation } from "@atjson/document";
 import OffsetSource, {
-  Code,
+  CodeBlock,
   List,
   IframeEmbed,
 } from "@atjson/offset-annotations";
@@ -154,12 +154,9 @@ HTMLSource.defineConverterTo(OffsetSource, function HTMLToOffset(doc) {
 
       doc.replaceAnnotation(
         code,
-        new Code({
+        new CodeBlock({
           start: code.start,
           end: code.end,
-          attributes: {
-            style: "block",
-          },
         })
       );
       doc.removeAnnotation(pre);
@@ -167,11 +164,11 @@ HTMLSource.defineConverterTo(OffsetSource, function HTMLToOffset(doc) {
 
   doc
     .where({ type: "-html-code" })
-    .set({ type: "-offset-code", attributes: { "-offset-style": "inline" } });
+    .set({ type: "-offset-code", attributes: {} });
 
   doc.where({ type: "-html-section" }).set({ type: "-offset-section" });
 
-  doc.where(isSmallCaps).set({ type: "-offset-small-caps" });
+  doc.where(isSmallCaps).set({ type: "-offset-small-caps", attributes: {} });
 
   return doc;
 });

--- a/packages/@atjson/source-html/src/converter/video-embeds.ts
+++ b/packages/@atjson/source-html/src/converter/video-embeds.ts
@@ -75,7 +75,7 @@ export default function (doc: Document) {
       }
     )
     .update(function convertVimeoVideos({ video, paragraph, links }) {
-      let captionId = uuid();
+      let caption: SliceAnnotation | undefined = undefined;
       let src = video.attributes.src;
       if (src?.indexOf("//") === 0) {
         src = `https:${src}`;
@@ -87,17 +87,14 @@ export default function (doc: Document) {
       );
 
       if (paragraph.length === 1 && links.length > 0) {
-        doc.replaceAnnotation(
-          paragraph[0],
-          new SliceAnnotation({
-            id: captionId,
-            start: paragraph[0].start,
-            end: paragraph[0].end,
-            attributes: {
-              refs: [video.id],
-            },
-          })
-        );
+        caption = new SliceAnnotation({
+          start: paragraph[0].start,
+          end: paragraph[0].end,
+          attributes: {
+            refs: [video.id],
+          },
+        });
+        doc.replaceAnnotation(paragraph[0], caption);
       }
 
       let width = getSize(video, "width");
@@ -116,7 +113,7 @@ export default function (doc: Document) {
               width && height
                 ? getClosestAspectRatio(width, height)
                 : undefined,
-            caption: captionId,
+            caption: caption?.id,
             anchorName: video.attributes.id,
           },
         })

--- a/packages/@atjson/source-html/src/converter/video-embeds.ts
+++ b/packages/@atjson/source-html/src/converter/video-embeds.ts
@@ -1,5 +1,4 @@
 import Document, { Annotation, is, SliceAnnotation } from "@atjson/document";
-import uuid from "uuid-random";
 import {
   getClosestAspectRatio,
   VideoEmbed,

--- a/packages/@atjson/source-html/test/blockquote-test.ts
+++ b/packages/@atjson/source-html/test/blockquote-test.ts
@@ -1,3 +1,4 @@
+import { serialize } from "@atjson/document";
 import OffsetSource from "@atjson/offset-annotations";
 import HTMLSource from "../src";
 
@@ -6,15 +7,16 @@ describe("blockquote", () => {
     let doc = HTMLSource.fromRaw(
       "<blockquote>This is a quote</blockquote>"
     ).convertTo(OffsetSource);
-    expect(doc.where({ type: `-offset-blockquote` }).annotations).toMatchObject(
-      [
+    expect(serialize(doc)).toMatchObject({
+      text: "\uFFFCThis is a quote",
+      blocks: [
         {
-          start: 0,
-          end: 40,
+          type: "blockquote",
           attributes: {},
         },
-      ]
-    );
+      ],
+      marks: [],
+    });
   });
 
   test("fragment ids", () => {
@@ -22,16 +24,15 @@ describe("blockquote", () => {
       `<blockquote id="test">This is a quote</blockquote>`
     ).convertTo(OffsetSource);
 
-    expect(doc.where({ type: `-offset-blockquote` }).annotations).toMatchObject(
-      [
+    expect(serialize(doc)).toMatchObject({
+      text: "\uFFFCThis is a quote",
+      blocks: [
         {
-          start: 0,
-          end: 50,
-          attributes: {
-            anchorName: "test",
-          },
+          type: "blockquote",
+          attributes: { anchorName: "test" },
         },
-      ]
-    );
+      ],
+      marks: [],
+    });
   });
 });

--- a/packages/@atjson/source-html/test/converter-test.ts
+++ b/packages/@atjson/source-html/test/converter-test.ts
@@ -851,21 +851,21 @@ describe("@atjson/source-html", () => {
               "marks": [
                 {
                   "attributes": {
-                    "url": "https://vimeo.com/156254412",
-                  },
-                  "id": "M00000001",
-                  "range": "(2..24)",
-                  "type": "link",
-                },
-                {
-                  "attributes": {
                     "refs": [
                       "B00000000",
                     ],
                   },
                   "id": "M00000000",
-                  "range": "(2..55]",
+                  "range": "(1..55]",
                   "type": "slice",
+                },
+                {
+                  "attributes": {
+                    "url": "https://vimeo.com/156254412",
+                  },
+                  "id": "M00000001",
+                  "range": "(2..24)",
+                  "type": "link",
                 },
                 {
                   "attributes": {

--- a/packages/@atjson/source-html/test/converter-test.ts
+++ b/packages/@atjson/source-html/test/converter-test.ts
@@ -1,3 +1,4 @@
+import { serialize } from "@atjson/document";
 import { HIR } from "@atjson/hir";
 import OffsetSource, { VideoURLs } from "@atjson/offset-annotations";
 import HTMLSource from "../src";
@@ -5,46 +6,40 @@ import HTMLSource from "../src";
 describe("@atjson/source-html", () => {
   describe("converter", () => {
     test("bold, strong", () => {
-      let doc = HTMLSource.fromRaw("This <b>text</b> is <strong>bold</strong>");
-      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
-          "This ",
+      let doc = HTMLSource.fromRaw(
+        "This <b>text</b> is <strong>bold</strong>"
+      ).convertTo(OffsetSource);
+      expect(serialize(doc)).toMatchObject({
+        text: "\uFFFCThis text is bold",
+        blocks: [{ type: "text" }],
+        marks: [
           {
             type: "bold",
-            attributes: {},
-            children: ["text"],
+            range: "(6..10]",
           },
-          " is ",
           {
             type: "bold",
-            attributes: {},
-            children: ["bold"],
+            range: "(14..18]",
           },
         ],
       });
     });
 
     test("i, em", () => {
-      let doc = HTMLSource.fromRaw("This <i>text</i> is <em>italic</em>");
-      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
-          "This ",
+      let doc = HTMLSource.fromRaw(
+        "This <i>text</i> is <em>italic</em>"
+      ).convertTo(OffsetSource);
+      expect(serialize(doc)).toMatchObject({
+        text: "\uFFFCThis text is italic",
+        blocks: [{ type: "text" }],
+        marks: [
           {
             type: "italic",
-            attributes: {},
-            children: ["text"],
+            range: "(6..10]",
           },
-          " is ",
           {
             type: "italic",
-            attributes: {},
-            children: ["italic"],
+            range: "(14..20]",
           },
         ],
       });
@@ -53,25 +48,19 @@ describe("@atjson/source-html", () => {
     test("s, del", () => {
       let doc = HTMLSource.fromRaw(
         "This is some <del>deleted</del> and <s>struck</s> text"
-      );
-      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
-          "This is some ",
+      ).convertTo(OffsetSource);
+      expect(serialize(doc)).toMatchObject({
+        text: "\uFFFCThis is some deleted and struck text",
+        blocks: [{ type: "text" }],
+        marks: [
           {
             type: "strikethrough",
-            attributes: {},
-            children: ["deleted"],
+            range: "(14..21]",
           },
-          " and ",
           {
             type: "strikethrough",
-            attributes: {},
-            children: ["struck"],
+            range: "(26..32]",
           },
-          " text",
         ],
       });
     });
@@ -79,170 +68,252 @@ describe("@atjson/source-html", () => {
     test("h1, h2, h3, h4, h5, h6", () => {
       let doc = HTMLSource.fromRaw(
         "<h1>Title</h1><h2>Byline</h2><h3>Section</h3><h4>Normal heading</h4><h5>Small heading</h5><h6>Tiny heading</h6>"
-      );
-      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
-          {
-            type: "heading",
-            attributes: { level: 1 },
-            children: ["Title"],
-          },
-          {
-            type: "heading",
-            attributes: { level: 2 },
-            children: ["Byline"],
-          },
-          {
-            type: "heading",
-            attributes: { level: 3 },
-            children: ["Section"],
-          },
-          {
-            type: "heading",
-            attributes: { level: 4 },
-            children: ["Normal heading"],
-          },
-          {
-            type: "heading",
-            attributes: { level: 5 },
-            children: ["Small heading"],
-          },
-          {
-            type: "heading",
-            attributes: { level: 6 },
-            children: ["Tiny heading"],
-          },
-        ],
-      });
+      ).convertTo(OffsetSource);
+      expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+        {
+          "blocks": [
+            {
+              "attributes": {
+                "level": 1,
+              },
+              "id": "B00000000",
+              "parents": [],
+              "selfClosing": false,
+              "type": "heading",
+            },
+            {
+              "attributes": {
+                "level": 2,
+              },
+              "id": "B00000001",
+              "parents": [],
+              "selfClosing": false,
+              "type": "heading",
+            },
+            {
+              "attributes": {
+                "level": 3,
+              },
+              "id": "B00000002",
+              "parents": [],
+              "selfClosing": false,
+              "type": "heading",
+            },
+            {
+              "attributes": {
+                "level": 4,
+              },
+              "id": "B00000003",
+              "parents": [],
+              "selfClosing": false,
+              "type": "heading",
+            },
+            {
+              "attributes": {
+                "level": 5,
+              },
+              "id": "B00000004",
+              "parents": [],
+              "selfClosing": false,
+              "type": "heading",
+            },
+            {
+              "attributes": {
+                "level": 6,
+              },
+              "id": "B00000005",
+              "parents": [],
+              "selfClosing": false,
+              "type": "heading",
+            },
+          ],
+          "marks": [],
+          "text": "￼Title￼Byline￼Section￼Normal heading￼Small heading￼Tiny heading",
+        }
+      `);
     });
 
     test("p, br", () => {
-      let doc = HTMLSource.fromRaw("<p>This paragraph has a<br>line break</p>");
-      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
-          {
-            type: "paragraph",
-            attributes: {},
-            children: [
-              "This paragraph has a",
-              {
-                type: "line-break",
-                attributes: {},
-                children: [],
-              },
-              "line break",
-            ],
-          },
-        ],
-      });
+      let doc = HTMLSource.fromRaw(
+        "<p>This paragraph has a<br>line break</p>"
+      ).convertTo(OffsetSource);
+      expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+        {
+          "blocks": [
+            {
+              "attributes": {},
+              "id": "B00000000",
+              "parents": [],
+              "selfClosing": false,
+              "type": "paragraph",
+            },
+            {
+              "attributes": {},
+              "id": "B00000001",
+              "parents": [
+                "paragraph",
+              ],
+              "selfClosing": true,
+              "type": "line-break",
+            },
+          ],
+          "marks": [],
+          "text": "￼This paragraph has a￼line break",
+        }
+      `);
     });
 
     test("a", () => {
       let doc = HTMLSource.fromRaw(
         'This <a href="https://condenast.com" rel="nofollow" target="_blank" title="Condé Nast">is a link</a>'
-      );
-      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
-          "This ",
-          {
-            type: "link",
-            attributes: {
-              url: "https://condenast.com",
-              rel: "nofollow",
-              target: "_blank",
-              title: "Condé Nast",
+      ).convertTo(OffsetSource);
+      expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+        {
+          "blocks": [
+            {
+              "attributes": {},
+              "id": "B00000000",
+              "parents": [],
+              "selfClosing": false,
+              "type": "text",
             },
-            children: ["is a link"],
-          },
-        ],
-      });
+          ],
+          "marks": [
+            {
+              "attributes": {
+                "rel": "nofollow",
+                "target": "_blank",
+                "title": "Condé Nast",
+                "url": "https://condenast.com",
+              },
+              "id": "M00000000",
+              "range": "(6..15)",
+              "type": "link",
+            },
+          ],
+          "text": "￼This is a link",
+        }
+      `);
     });
 
     test("hr", () => {
-      let doc = HTMLSource.fromRaw("Horizontal <hr> rules!");
-      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
-          "Horizontal ",
-          {
-            type: "horizontal-rule",
-            attributes: {},
-            children: [],
-          },
-          " rules!",
-        ],
-      });
+      let doc = HTMLSource.fromRaw("Horizontal <hr> rules!").convertTo(
+        OffsetSource
+      );
+      expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+        {
+          "blocks": [
+            {
+              "attributes": {},
+              "id": "B00000000",
+              "parents": [],
+              "selfClosing": false,
+              "type": "text",
+            },
+            {
+              "attributes": {},
+              "id": "B00000001",
+              "parents": [
+                "text",
+              ],
+              "selfClosing": true,
+              "type": "horizontal-rule",
+            },
+          ],
+          "marks": [],
+          "text": "￼Horizontal ￼ rules!",
+        }
+      `);
     });
 
     test("img", () => {
       let doc = HTMLSource.fromRaw(
         '<img src="https://pbs.twimg.com/media/DXiMcM9X4AEhR3u.jpg" alt="Miles Davis came out, blond, in gold lamé, and he plays really terrific music. High heels. 4/6/86" title="Miles Davis & Andy Warhol">'
-      );
-      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
-          {
-            type: "image",
-            attributes: {
-              url: "https://pbs.twimg.com/media/DXiMcM9X4AEhR3u.jpg",
-              description:
-                "Miles Davis came out, blond, in gold lamé, and he plays really terrific music. High heels. 4/6/86",
-              title: "Miles Davis & Andy Warhol",
+      ).convertTo(OffsetSource);
+      expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+        {
+          "blocks": [
+            {
+              "attributes": {
+                "description": "Miles Davis came out, blond, in gold lamé, and he plays really terrific music. High heels. 4/6/86",
+                "title": "Miles Davis & Andy Warhol",
+                "url": "https://pbs.twimg.com/media/DXiMcM9X4AEhR3u.jpg",
+              },
+              "id": "B00000000",
+              "parents": [],
+              "selfClosing": true,
+              "type": "image",
             },
-            children: [],
-          },
-        ],
-      });
+          ],
+          "marks": [],
+          "text": "￼",
+        }
+      `);
     });
 
     test("code", () => {
-      let doc = HTMLSource.fromRaw(`<code>console.log('wowowowow');</code>`);
-      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
-          {
-            type: "code",
-            attributes: { style: "inline" },
-            children: [`console.log('wowowowow');`],
-          },
-        ],
-      });
+      let doc = HTMLSource.fromRaw(
+        `<code>console.log('wowowowow');</code>`
+      ).convertTo(OffsetSource);
+      expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+        {
+          "blocks": [
+            {
+              "attributes": {},
+              "id": "B00000000",
+              "parents": [],
+              "selfClosing": false,
+              "type": "text",
+            },
+          ],
+          "marks": [
+            {
+              "attributes": {},
+              "id": "M00000000",
+              "range": "(1..26]",
+              "type": "code",
+            },
+          ],
+          "text": "￼console.log('wowowowow');",
+        }
+      `);
     });
 
     describe("code blocks", () => {
       test("pre code", () => {
         let doc = HTMLSource.fromRaw(
           `<pre> <code>console.log('wowowowow');</code>\n</pre>`
-        );
-        let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
-        expect(hir).toMatchObject({
-          type: "root",
-          attributes: {},
-          children: [
-            " ",
-            {
-              type: "code",
-              attributes: { style: "block" },
-              children: [`console.log('wowowowow');`],
-            },
-            "\n",
-          ],
-        });
+        ).convertTo(OffsetSource);
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {},
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "text",
+              },
+              {
+                "attributes": {},
+                "id": "B00000001",
+                "parents": [],
+                "selfClosing": false,
+                "type": "code-block",
+              },
+              {
+                "attributes": {},
+                "id": "B00000002",
+                "parents": [],
+                "selfClosing": false,
+                "type": "text",
+              },
+            ],
+            "marks": [],
+            "text": "￼ ￼console.log('wowowowow');￼
+          ",
+          }
+        `);
       });
 
       test("multiple code blocks inside of pre", () => {
@@ -251,23 +322,34 @@ describe("@atjson/source-html", () => {
         ).convertTo(OffsetSource);
         doc.where((a) => a.type === "unknown").remove();
 
-        let hir = new HIR(doc).toJSON();
-        expect(hir).toMatchObject({
-          type: "root",
-          attributes: {},
-          children: [
-            {
-              type: "code",
-              attributes: { style: "inline" },
-              children: [`console.log('wow');`],
-            },
-            {
-              type: "code",
-              attributes: { style: "inline" },
-              children: [`console.log('wowowow');`],
-            },
-          ],
-        });
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {},
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "text",
+              },
+            ],
+            "marks": [
+              {
+                "attributes": {},
+                "id": "M00000000",
+                "range": "(1..20]",
+                "type": "code",
+              },
+              {
+                "attributes": {},
+                "id": "M00000001",
+                "range": "(20..43]",
+                "type": "code",
+              },
+            ],
+            "text": "￼console.log('wow');console.log('wowowow');",
+          }
+        `);
       });
 
       test("text inside of pre, but not code", () => {
@@ -276,70 +358,98 @@ describe("@atjson/source-html", () => {
         ).convertTo(OffsetSource);
         doc.where((a) => a.type === "unknown").remove();
 
-        let hir = new HIR(doc).toJSON();
-        expect(hir).toMatchObject({
-          type: "root",
-          attributes: {},
-          children: [
-            "hi",
-            {
-              type: "code",
-              attributes: { style: "inline" },
-              children: [`console.log('wowowow');`],
-            },
-          ],
-        });
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {},
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "text",
+              },
+            ],
+            "marks": [
+              {
+                "attributes": {},
+                "id": "M00000000",
+                "range": "(3..26]",
+                "type": "code",
+              },
+            ],
+            "text": "￼hiconsole.log('wowowow');",
+          }
+        `);
       });
     });
 
     test("ul, ol, li", () => {
       let doc = HTMLSource.fromRaw(
         '<ol start="2"><li>Second</li><li>Third</li></ol><ul><li>First</li><li>Second</li></ul>'
-      );
-      let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
-          {
-            type: "list",
-            attributes: {
-              type: "numbered",
-              startsAt: 2,
+      ).convertTo(OffsetSource);
+      expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+        {
+          "blocks": [
+            {
+              "attributes": {
+                "startsAt": 2,
+                "type": "numbered",
+              },
+              "id": "B00000000",
+              "parents": [],
+              "selfClosing": false,
+              "type": "list",
             },
-            children: [
-              {
-                type: "list-item",
-                attributes: {},
-                children: ["Second"],
-              },
-              {
-                type: "list-item",
-                attributes: {},
-                children: ["Third"],
-              },
-            ],
-          },
-          {
-            type: "list",
-            attributes: {
-              type: "bulleted",
+            {
+              "attributes": {},
+              "id": "B00000001",
+              "parents": [
+                "list",
+              ],
+              "selfClosing": false,
+              "type": "list-item",
             },
-            children: [
-              {
-                type: "list-item",
-                attributes: {},
-                children: ["First"],
+            {
+              "attributes": {},
+              "id": "B00000002",
+              "parents": [
+                "list",
+              ],
+              "selfClosing": false,
+              "type": "list-item",
+            },
+            {
+              "attributes": {
+                "type": "bulleted",
               },
-              {
-                type: "list-item",
-                attributes: {},
-                children: ["Second"],
-              },
-            ],
-          },
-        ],
-      });
+              "id": "B00000003",
+              "parents": [],
+              "selfClosing": false,
+              "type": "list",
+            },
+            {
+              "attributes": {},
+              "id": "B00000004",
+              "parents": [
+                "list",
+              ],
+              "selfClosing": false,
+              "type": "list-item",
+            },
+            {
+              "attributes": {},
+              "id": "B00000005",
+              "parents": [
+                "list",
+              ],
+              "selfClosing": false,
+              "type": "list-item",
+            },
+          ],
+          "marks": [],
+          "text": "￼￼Second￼Third￼￼First￼Second",
+        }
+      `);
     });
 
     test("section", () => {
@@ -347,21 +457,30 @@ describe("@atjson/source-html", () => {
         `<section><p>Paragraph in a section.</p></section>`
       ).convertTo(OffsetSource);
 
-      let hir = new HIR(doc).toJSON();
-      expect(hir).toMatchObject({
-        type: "root",
-        children: [
-          {
-            type: "section",
-            children: [
-              {
-                type: "paragraph",
-                children: ["Paragraph in a section."],
-              },
-            ],
-          },
-        ],
-      });
+      expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+        {
+          "blocks": [
+            {
+              "attributes": {},
+              "id": "B00000000",
+              "parents": [],
+              "selfClosing": false,
+              "type": "section",
+            },
+            {
+              "attributes": {},
+              "id": "B00000001",
+              "parents": [
+                "section",
+              ],
+              "selfClosing": false,
+              "type": "paragraph",
+            },
+          ],
+          "marks": [],
+          "text": "￼￼Paragraph in a section.",
+        }
+      `);
     });
 
     test("smallcaps", () => {
@@ -369,22 +488,30 @@ describe("@atjson/source-html", () => {
         `<p><span class="smallcaps">SmallCaps</span> in a paragraph.</p>`
       ).convertTo(OffsetSource);
 
-      let hir = new HIR(doc).toJSON();
-      expect(hir).toMatchObject({
-        type: "root",
-        children: [
-          {
-            type: "paragraph",
-            children: [
-              {
-                type: "small-caps",
-                children: ["SmallCaps"],
+      expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+        {
+          "blocks": [
+            {
+              "attributes": {},
+              "id": "B00000000",
+              "parents": [],
+              "selfClosing": false,
+              "type": "paragraph",
+            },
+          ],
+          "marks": [
+            {
+              "attributes": {
+                "-html-class": "smallcaps",
               },
-              " in a paragraph.",
-            ],
-          },
-        ],
-      });
+              "id": "M00000000",
+              "range": "(1..10]",
+              "type": "small-caps",
+            },
+          ],
+          "text": "￼SmallCaps in a paragraph.",
+        }
+      `);
     });
 
     test("protocol-relative iframe embeds", () => {
@@ -392,21 +519,25 @@ describe("@atjson/source-html", () => {
         `<iframe src="//example.com"
             scrolling="no" frameborder="0"
             allowTransparency="true" allow="encrypted-media"></iframe>`
-      )
-        .convertTo(OffsetSource)
-        .canonical();
+      ).convertTo(OffsetSource);
 
-      expect(doc).toMatchObject({
-        content: "",
-        annotations: [
-          {
-            type: "iframe-embed",
-            attributes: {
-              url: "//example.com",
+      expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+        {
+          "blocks": [
+            {
+              "attributes": {
+                "url": "//example.com",
+              },
+              "id": "B00000000",
+              "parents": [],
+              "selfClosing": false,
+              "type": "iframe-embed",
             },
-          },
-        ],
-      });
+          ],
+          "marks": [],
+          "text": "￼",
+        }
+      `);
     });
 
     describe("social embeds", () => {
@@ -419,21 +550,25 @@ describe("@atjson/source-html", () => {
             allowTransparency="true" allow="encrypted-media"></iframe>`
         ).convertTo(OffsetSource);
 
-        let hir = new HIR(doc).toJSON();
-        expect(hir).toMatchObject({
-          type: "root",
-          children: [
-            {
-              type: "facebook-embed",
-              attributes: {
-                url: "https://www.facebook.com/BeethovenOfficialPage/posts/2923157684380743",
-                height: "633",
-                width: "500",
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {
+                  "height": "633",
+                  "url": "https://www.facebook.com/BeethovenOfficialPage/posts/2923157684380743",
+                  "width": "500",
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "facebook-embed",
               },
-              children: [],
-            },
-          ],
-        });
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
 
       test("Facebook div embed", () => {
@@ -441,19 +576,23 @@ describe("@atjson/source-html", () => {
           `<div class="fb-post" data-href="https://www.facebook.com/BeethovenOfficialPage/posts/2923157684380743" data-width="500" data-show-text="true"><blockquote cite="https://developers.facebook.com/BeethovenOfficialPage/posts/2923157684380743" class="fb-xfbml-parse-ignore"><p>Next stop of the exhibition &quot;BTHVN on Tour&quot; is in Boston!</p>Posted by <a href="https://www.facebook.com/BeethovenOfficialPage/">Ludwig van Beethoven</a> on&nbsp;<a href="https://developers.facebook.com/BeethovenOfficialPage/posts/2923157684380743">Thursday, October 24, 2019</a></blockquote></div>`
         ).convertTo(OffsetSource);
 
-        let hir = new HIR(doc).toJSON();
-        expect(hir).toMatchObject({
-          type: "root",
-          children: [
-            {
-              type: "facebook-embed",
-              attributes: {
-                url: "https://www.facebook.com/BeethovenOfficialPage/posts/2923157684380743",
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {
+                  "url": "https://www.facebook.com/BeethovenOfficialPage/posts/2923157684380743",
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "facebook-embed",
               },
-              children: [],
-            },
-          ],
-        });
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
 
       test("Instagram blockquote embed", () => {
@@ -461,19 +600,23 @@ describe("@atjson/source-html", () => {
           `<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/B37oY9WgHP7/?utm_source=ig_embed&amp;utm_campaign=loading" data-instgrm-version="12" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:540px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:16px;"> <a href="https://www.instagram.com/p/B37oY9WgHP7/?utm_source=ig_embed&amp;utm_campaign=loading" style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;" target="_blank"> <div style=" display: flex; flex-direction: row; align-items: center;"> <div style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;"></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"></div></div></div><div style="padding: 19% 0;"></div> <div style="display:block; height:50px; margin:0 auto 12px; width:50px;"><svg width="50px" height="50px" viewBox="0 0 60 60" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(-511.000000, -20.000000)" fill="#000000"><g><path d="M556.869,30.41 C554.814,30.41 553.148,32.076 553.148,34.131 C553.148,36.186 554.814,37.852 556.869,37.852 C558.924,37.852 560.59,36.186 560.59,34.131 C560.59,32.076 558.924,30.41 556.869,30.41 M541,60.657 C535.114,60.657 530.342,55.887 530.342,50 C530.342,44.114 535.114,39.342 541,39.342 C546.887,39.342 551.658,44.114 551.658,50 C551.658,55.887 546.887,60.657 541,60.657 M541,33.886 C532.1,33.886 524.886,41.1 524.886,50 C524.886,58.899 532.1,66.113 541,66.113 C549.9,66.113 557.115,58.899 557.115,50 C557.115,41.1 549.9,33.886 541,33.886 M565.378,62.101 C565.244,65.022 564.756,66.606 564.346,67.663 C563.803,69.06 563.154,70.057 562.106,71.106 C561.058,72.155 560.06,72.803 558.662,73.347 C557.607,73.757 556.021,74.244 553.102,74.378 C549.944,74.521 548.997,74.552 541,74.552 C533.003,74.552 532.056,74.521 528.898,74.378 C525.979,74.244 524.393,73.757 523.338,73.347 C521.94,72.803 520.942,72.155 519.894,71.106 C518.846,70.057 518.197,69.06 517.654,67.663 C517.244,66.606 516.755,65.022 516.623,62.101 C516.479,58.943 516.448,57.996 516.448,50 C516.448,42.003 516.479,41.056 516.623,37.899 C516.755,34.978 517.244,33.391 517.654,32.338 C518.197,30.938 518.846,29.942 519.894,28.894 C520.942,27.846 521.94,27.196 523.338,26.654 C524.393,26.244 525.979,25.756 528.898,25.623 C532.057,25.479 533.004,25.448 541,25.448 C548.997,25.448 549.943,25.479 553.102,25.623 C556.021,25.756 557.607,26.244 558.662,26.654 C560.06,27.196 561.058,27.846 562.106,28.894 C563.154,29.942 563.803,30.938 564.346,32.338 C564.756,33.391 565.244,34.978 565.378,37.899 C565.522,41.056 565.552,42.003 565.552,50 C565.552,57.996 565.522,58.943 565.378,62.101 M570.82,37.631 C570.674,34.438 570.167,32.258 569.425,30.349 C568.659,28.377 567.633,26.702 565.965,25.035 C564.297,23.368 562.623,22.342 560.652,21.575 C558.743,20.834 556.562,20.326 553.369,20.18 C550.169,20.033 549.148,20 541,20 C532.853,20 531.831,20.033 528.631,20.18 C525.438,20.326 523.257,20.834 521.349,21.575 C519.376,22.342 517.703,23.368 516.035,25.035 C514.368,26.702 513.342,28.377 512.574,30.349 C511.834,32.258 511.326,34.438 511.181,37.631 C511.035,40.831 511,41.851 511,50 C511,58.147 511.035,59.17 511.181,62.369 C511.326,65.562 511.834,67.743 512.574,69.651 C513.342,71.625 514.368,73.296 516.035,74.965 C517.703,76.634 519.376,77.658 521.349,78.425 C523.257,79.167 525.438,79.673 528.631,79.82 C531.831,79.965 532.853,80.001 541,80.001 C549.148,80.001 550.169,79.965 553.369,79.82 C556.562,79.673 558.743,79.167 560.652,78.425 C562.623,77.658 564.297,76.634 565.965,74.965 C567.633,73.296 568.659,71.625 569.425,69.651 C570.167,67.743 570.674,65.562 570.82,62.369 C570.966,59.17 571,58.147 571,50 C571,41.851 570.966,40.831 570.82,37.631"></path></g></g></g></svg></div><div style="padding-top: 8px;"> <div style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;"> View this post on Instagram</div></div><div style="padding: 12.5% 0;"></div> <div style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;"><div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);"></div> <div style="background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;"></div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);"></div></div><div style="margin-left: 8px;"> <div style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"></div> <div style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"></div></div><div style="margin-left: auto;"> <div style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"></div> <div style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"></div> <div style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"></div></div></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center; margin-bottom: 24px;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 224px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 144px;"></div></div></a><p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;"><a href="https://www.instagram.com/p/B37oY9WgHP7/?utm_source=ig_embed&amp;utm_campaign=loading" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none;" target="_blank">A post shared by WTF Bach (@wtfbach)</a> on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2019-10-22T19:12:41+00:00">Oct 22, 2019 at 12:12pm PDT</time></p></div></blockquote> <script async src="//www.instagram.com/embed.js"></script>`
         ).convertTo(OffsetSource);
 
-        let hir = new HIR(doc).toJSON();
-        expect(hir).toMatchObject({
-          type: "root",
-          children: [
-            {
-              type: "instagram-embed",
-              attributes: {
-                url: "https://www.instagram.com/p/B37oY9WgHP7",
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {
+                  "url": "https://www.instagram.com/p/B37oY9WgHP7",
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "instagram-embed",
               },
-              children: [],
-            },
-          ],
-        });
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
 
       test("Instagram TV blockquote embed", () => {
@@ -481,19 +624,23 @@ describe("@atjson/source-html", () => {
           `<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="https://www.instagram.com/tv/B95M4kNhbzz/?utm_source=ig_embed&amp;utm_campaign=loading" data-instgrm-version="12" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:540px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:16px;"> <a href="https://www.instagram.com/tv/B95M4kNhbzz/?utm_source=ig_embed&amp;utm_campaign=loading" style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;" target="_blank"> <div style=" display: flex; flex-direction: row; align-items: center;"> <div style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;"></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"></div></div></div><div style="padding: 19% 0;"></div> <div style="display:block; height:50px; margin:0 auto 12px; width:50px;"><svg width="50px" height="50px" viewBox="0 0 60 60" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(-511.000000, -20.000000)" fill="#000000"><g><path d="M556.869,30.41 C554.814,30.41 553.148,32.076 553.148,34.131 C553.148,36.186 554.814,37.852 556.869,37.852 C558.924,37.852 560.59,36.186 560.59,34.131 C560.59,32.076 558.924,30.41 556.869,30.41 M541,60.657 C535.114,60.657 530.342,55.887 530.342,50 C530.342,44.114 535.114,39.342 541,39.342 C546.887,39.342 551.658,44.114 551.658,50 C551.658,55.887 546.887,60.657 541,60.657 M541,33.886 C532.1,33.886 524.886,41.1 524.886,50 C524.886,58.899 532.1,66.113 541,66.113 C549.9,66.113 557.115,58.899 557.115,50 C557.115,41.1 549.9,33.886 541,33.886 M565.378,62.101 C565.244,65.022 564.756,66.606 564.346,67.663 C563.803,69.06 563.154,70.057 562.106,71.106 C561.058,72.155 560.06,72.803 558.662,73.347 C557.607,73.757 556.021,74.244 553.102,74.378 C549.944,74.521 548.997,74.552 541,74.552 C533.003,74.552 532.056,74.521 528.898,74.378 C525.979,74.244 524.393,73.757 523.338,73.347 C521.94,72.803 520.942,72.155 519.894,71.106 C518.846,70.057 518.197,69.06 517.654,67.663 C517.244,66.606 516.755,65.022 516.623,62.101 C516.479,58.943 516.448,57.996 516.448,50 C516.448,42.003 516.479,41.056 516.623,37.899 C516.755,34.978 517.244,33.391 517.654,32.338 C518.197,30.938 518.846,29.942 519.894,28.894 C520.942,27.846 521.94,27.196 523.338,26.654 C524.393,26.244 525.979,25.756 528.898,25.623 C532.057,25.479 533.004,25.448 541,25.448 C548.997,25.448 549.943,25.479 553.102,25.623 C556.021,25.756 557.607,26.244 558.662,26.654 C560.06,27.196 561.058,27.846 562.106,28.894 C563.154,29.942 563.803,30.938 564.346,32.338 C564.756,33.391 565.244,34.978 565.378,37.899 C565.522,41.056 565.552,42.003 565.552,50 C565.552,57.996 565.522,58.943 565.378,62.101 M570.82,37.631 C570.674,34.438 570.167,32.258 569.425,30.349 C568.659,28.377 567.633,26.702 565.965,25.035 C564.297,23.368 562.623,22.342 560.652,21.575 C558.743,20.834 556.562,20.326 553.369,20.18 C550.169,20.033 549.148,20 541,20 C532.853,20 531.831,20.033 528.631,20.18 C525.438,20.326 523.257,20.834 521.349,21.575 C519.376,22.342 517.703,23.368 516.035,25.035 C514.368,26.702 513.342,28.377 512.574,30.349 C511.834,32.258 511.326,34.438 511.181,37.631 C511.035,40.831 511,41.851 511,50 C511,58.147 511.035,59.17 511.181,62.369 C511.326,65.562 511.834,67.743 512.574,69.651 C513.342,71.625 514.368,73.296 516.035,74.965 C517.703,76.634 519.376,77.658 521.349,78.425 C523.257,79.167 525.438,79.673 528.631,79.82 C531.831,79.965 532.853,80.001 541,80.001 C549.148,80.001 550.169,79.965 553.369,79.82 C556.562,79.673 558.743,79.167 560.652,78.425 C562.623,77.658 564.297,76.634 565.965,74.965 C567.633,73.296 568.659,71.625 569.425,69.651 C570.167,67.743 570.674,65.562 570.82,62.369 C570.966,59.17 571,58.147 571,50 C571,41.851 570.966,40.831 570.82,37.631"></path></g></g></g></svg></div><div style="padding-top: 8px;"> <div style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;"> View this post on Instagram</div></div><div style="padding: 12.5% 0;"></div> <div style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;"><div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);"></div> <div style="background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;"></div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);"></div></div><div style="margin-left: 8px;"> <div style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"></div> <div style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"></div></div><div style="margin-left: auto;"> <div style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"></div> <div style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"></div> <div style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"></div></div></div></a> <p style=" margin:8px 0 0 0; padding:0 4px;"> <a href="https://www.instagram.com/tv/B95M4kNhbzz/?utm_source=ig_embed&amp;utm_campaign=loading" style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;" target="_blank">We are in this together, we will get through it together. Let’s imagine together. Sing with us ❤ All love to you, from me and my dear friends. #WeAreOne ....... #KristenWiig #JamieDornan @labrinth @james_marsden @sarahkatesilverman @eddiebenjamin @jimmyfallon @natalieportman @zoeisabellakravitz @siamusic @reallyndacarter @amyadams @leslieodomjr @pascalispunk @chrisodowd @hotpatooties #WillFerrell @markruffalo @norahjones @ashleybenson @kaiagerber @caradelevingne @anniemumolo @princesstagramslam</a></p> <p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;">A post shared by <a href="https://www.instagram.com/gal_gadot/?utm_source=ig_embed&amp;utm_campaign=loading" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px;" target="_blank"> Gal Gadot</a> (@gal_gadot) on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2020-03-18T23:49:48+00:00">Mar 18, 2020 at 4:49pm PDT</time></p></div></blockquote> <script async src="//www.instagram.com/embed.js"></script>`
         ).convertTo(OffsetSource);
 
-        let hir = new HIR(doc).toJSON();
-        expect(hir).toMatchObject({
-          type: "root",
-          children: [
-            {
-              type: "instagram-embed",
-              attributes: {
-                url: "https://www.instagram.com/tv/B95M4kNhbzz",
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {
+                  "url": "https://www.instagram.com/tv/B95M4kNhbzz",
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "instagram-embed",
               },
-              children: [],
-            },
-          ],
-        });
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
 
       test("Instagram Reel blockquote embed", () => {
@@ -501,19 +648,23 @@ describe("@atjson/source-html", () => {
           `<blockquote class="instagram-media" data-instgrm-captioned data-instgrm-permalink="https://www.instagram.com/reel/CDt37vzFw3f/?utm_source=ig_web_copy_link" data-instgrm-version="12" style=" background:#FFF; border:0; border-radius:3px; box-shadow:0 0 1px 0 rgba(0,0,0,0.5),0 1px 10px 0 rgba(0,0,0,0.15); margin: 1px; max-width:540px; min-width:326px; padding:0; width:99.375%; width:-webkit-calc(100% - 2px); width:calc(100% - 2px);"><div style="padding:16px;"> <a href="CDt37vzFw3f" style=" background:#FFFFFF; line-height:0; padding:0 0; text-align:center; text-decoration:none; width:100%;" target="_blank"> <div style=" display: flex; flex-direction: row; align-items: center;"> <div style="background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 40px; margin-right: 14px; width: 40px;"></div> <div style="display: flex; flex-direction: column; flex-grow: 1; justify-content: center;"> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; margin-bottom: 6px; width: 100px;"></div> <div style=" background-color: #F4F4F4; border-radius: 4px; flex-grow: 0; height: 14px; width: 60px;"></div></div></div><div style="padding: 19% 0;"></div> <div style="display:block; height:50px; margin:0 auto 12px; width:50px;"><svg width="50px" height="50px" viewBox="0 0 60 60" version="1.1" xmlns="https://www.w3.org/2000/svg" xmlns:xlink="https://www.w3.org/1999/xlink"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(-511.000000, -20.000000)" fill="#000000"><g><path d="M556.869,30.41 C554.814,30.41 553.148,32.076 553.148,34.131 C553.148,36.186 554.814,37.852 556.869,37.852 C558.924,37.852 560.59,36.186 560.59,34.131 C560.59,32.076 558.924,30.41 556.869,30.41 M541,60.657 C535.114,60.657 530.342,55.887 530.342,50 C530.342,44.114 535.114,39.342 541,39.342 C546.887,39.342 551.658,44.114 551.658,50 C551.658,55.887 546.887,60.657 541,60.657 M541,33.886 C532.1,33.886 524.886,41.1 524.886,50 C524.886,58.899 532.1,66.113 541,66.113 C549.9,66.113 557.115,58.899 557.115,50 C557.115,41.1 549.9,33.886 541,33.886 M565.378,62.101 C565.244,65.022 564.756,66.606 564.346,67.663 C563.803,69.06 563.154,70.057 562.106,71.106 C561.058,72.155 560.06,72.803 558.662,73.347 C557.607,73.757 556.021,74.244 553.102,74.378 C549.944,74.521 548.997,74.552 541,74.552 C533.003,74.552 532.056,74.521 528.898,74.378 C525.979,74.244 524.393,73.757 523.338,73.347 C521.94,72.803 520.942,72.155 519.894,71.106 C518.846,70.057 518.197,69.06 517.654,67.663 C517.244,66.606 516.755,65.022 516.623,62.101 C516.479,58.943 516.448,57.996 516.448,50 C516.448,42.003 516.479,41.056 516.623,37.899 C516.755,34.978 517.244,33.391 517.654,32.338 C518.197,30.938 518.846,29.942 519.894,28.894 C520.942,27.846 521.94,27.196 523.338,26.654 C524.393,26.244 525.979,25.756 528.898,25.623 C532.057,25.479 533.004,25.448 541,25.448 C548.997,25.448 549.943,25.479 553.102,25.623 C556.021,25.756 557.607,26.244 558.662,26.654 C560.06,27.196 561.058,27.846 562.106,28.894 C563.154,29.942 563.803,30.938 564.346,32.338 C564.756,33.391 565.244,34.978 565.378,37.899 C565.522,41.056 565.552,42.003 565.552,50 C565.552,57.996 565.522,58.943 565.378,62.101 M570.82,37.631 C570.674,34.438 570.167,32.258 569.425,30.349 C568.659,28.377 567.633,26.702 565.965,25.035 C564.297,23.368 562.623,22.342 560.652,21.575 C558.743,20.834 556.562,20.326 553.369,20.18 C550.169,20.033 549.148,20 541,20 C532.853,20 531.831,20.033 528.631,20.18 C525.438,20.326 523.257,20.834 521.349,21.575 C519.376,22.342 517.703,23.368 516.035,25.035 C514.368,26.702 513.342,28.377 512.574,30.349 C511.834,32.258 511.326,34.438 511.181,37.631 C511.035,40.831 511,41.851 511,50 C511,58.147 511.035,59.17 511.181,62.369 C511.326,65.562 511.834,67.743 512.574,69.651 C513.342,71.625 514.368,73.296 516.035,74.965 C517.703,76.634 519.376,77.658 521.349,78.425 C523.257,79.167 525.438,79.673 528.631,79.82 C531.831,79.965 532.853,80.001 541,80.001 C549.148,80.001 550.169,79.965 553.369,79.82 C556.562,79.673 558.743,79.167 560.652,78.425 C562.623,77.658 564.297,76.634 565.965,74.965 C567.633,73.296 568.659,71.625 569.425,69.651 C570.167,67.743 570.674,65.562 570.82,62.369 C570.966,59.17 571,58.147 571,50 C571,41.851 570.966,40.831 570.82,37.631"></path></g></g></g></svg></div><div style="padding-top: 8px;"> <div style=" color:#3897f0; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:550; line-height:18px;"> View this post on Instagram</div></div><div style="padding: 12.5% 0;"></div> <div style="display: flex; flex-direction: row; margin-bottom: 14px; align-items: center;"><div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(0px) translateY(7px);"></div> <div style="background-color: #F4F4F4; height: 12.5px; transform: rotate(-45deg) translateX(3px) translateY(1px); width: 12.5px; flex-grow: 0; margin-right: 14px; margin-left: 2px;"></div> <div style="background-color: #F4F4F4; border-radius: 50%; height: 12.5px; width: 12.5px; transform: translateX(9px) translateY(-18px);"></div></div><div style="margin-left: 8px;"> <div style=" background-color: #F4F4F4; border-radius: 50%; flex-grow: 0; height: 20px; width: 20px;"></div> <div style=" width: 0; height: 0; border-top: 2px solid transparent; border-left: 6px solid #f4f4f4; border-bottom: 2px solid transparent; transform: translateX(16px) translateY(-4px) rotate(30deg)"></div></div><div style="margin-left: auto;"> <div style=" width: 0px; border-top: 8px solid #F4F4F4; border-right: 8px solid transparent; transform: translateY(16px);"></div> <div style=" background-color: #F4F4F4; flex-grow: 0; height: 12px; width: 16px; transform: translateY(-4px);"></div> <div style=" width: 0; height: 0; border-top: 8px solid #F4F4F4; border-left: 8px solid transparent; transform: translateY(-4px) translateX(8px);"></div></div></div></a> <p style=" margin:8px 0 0 0; padding:0 4px;"> <a href="https://www.instagram.com/reel/CDt37vzFw3f/?utm_source=ig_web_copy_link" style=" color:#000; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px; text-decoration:none; word-wrap:break-word;" target="_blank">We are in this together, we will get through it together. Let’s imagine together. Sing with us ❤ All love to you, from me and my dear friends. #WeAreOne ....... #KristenWiig #JamieDornan @labrinth @james_marsden @sarahkatesilverman @eddiebenjamin @jimmyfallon @natalieportman @zoeisabellakravitz @siamusic @reallyndacarter @amyadams @leslieodomjr @pascalispunk @chrisodowd @hotpatooties #WillFerrell @markruffalo @norahjones @ashleybenson @kaiagerber @caradelevingne @anniemumolo @princesstagramslam</a></p> <p style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; line-height:17px; margin-bottom:0; margin-top:8px; overflow:hidden; padding:8px 0 7px; text-align:center; text-overflow:ellipsis; white-space:nowrap;">A post shared by <a href="https://www.instagram.com/gal_gadot/?utm_source=ig_embed&amp;utm_campaign=loading" style=" color:#c9c8cd; font-family:Arial,sans-serif; font-size:14px; font-style:normal; font-weight:normal; line-height:17px;" target="_blank"> Gal Gadot</a> (@gal_gadot) on <time style=" font-family:Arial,sans-serif; font-size:14px; line-height:17px;" datetime="2020-03-18T23:49:48+00:00">Mar 18, 2020 at 4:49pm PDT</time></p></div></blockquote> <script async src="//www.instagram.com/embed.js"></script>`
         ).convertTo(OffsetSource);
 
-        let hir = new HIR(doc).toJSON();
-        expect(hir).toMatchObject({
-          type: "root",
-          children: [
-            {
-              type: "instagram-embed",
-              attributes: {
-                url: "https://www.instagram.com/reel/CDt37vzFw3f",
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {
+                  "url": "https://www.instagram.com/reel/CDt37vzFw3f",
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "instagram-embed",
               },
-              children: [],
-            },
-          ],
-        });
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
 
       test("Twitter blockquote embed", () => {
@@ -521,19 +672,23 @@ describe("@atjson/source-html", () => {
           `<blockquote class="twitter-tweet"><p lang="en" dir="ltr">Hope you had a great start to your week, New York City! <a href="https://t.co/9skas4Bady">pic.twitter.com/9skas4Bady</a></p>&mdash; City of New York (@nycgov) <a href="https://twitter.com/nycgov/status/1191528054608334848?ref_src=twsrc%5Etfw">November 5, 2019</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>`
         ).convertTo(OffsetSource);
 
-        let hir = new HIR(doc).toJSON();
-        expect(hir).toMatchObject({
-          type: "root",
-          children: [
-            {
-              type: "twitter-embed",
-              attributes: {
-                url: "https://twitter.com/nycgov/status/1191528054608334848",
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {
+                  "url": "https://twitter.com/nycgov/status/1191528054608334848",
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "twitter-embed",
               },
-              children: [],
-            },
-          ],
-        });
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
 
       test("Giphy embed", () => {
@@ -541,19 +696,25 @@ describe("@atjson/source-html", () => {
           `<iframe src="https://giphy.com/embed/13CoXDiaCcCoyk" width="480" height="398" frameBorder="0" class="giphy-embed" allowFullScreen></iframe><p><a href="https://giphy.com/gifs/wiggle-shaq-13CoXDiaCcCoyk">via GIPHY</a></p>`
         ).convertTo(OffsetSource);
 
-        expect(doc.canonical()).toMatchObject({
-          content: "",
-          annotations: [
-            {
-              type: "giphy-embed",
-              start: 0,
-              end: 0,
-              attributes: {
-                url: "https://giphy.com/embed/13CoXDiaCcCoyk",
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {
+                  "height": "398",
+                  "url": "https://giphy.com/embed/13CoXDiaCcCoyk",
+                  "width": "480",
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "giphy-embed",
               },
-            },
-          ],
-        });
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
 
       test("Spotify podcast show embed", () => {
@@ -566,21 +727,25 @@ describe("@atjson/source-html", () => {
             allow="encrypted-media"></iframe>`
         ).convertTo(OffsetSource);
 
-        let hir = new HIR(doc).toJSON();
-        expect(hir).toMatchObject({
-          type: "root",
-          children: [
-            {
-              type: "iframe-embed",
-              attributes: {
-                url: "https://open.spotify.com/embed-podcast/show/1iohmBNlRooIVtukKeavRa",
-                height: "232",
-                width: "100%",
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {
+                  "height": "232",
+                  "url": "https://open.spotify.com/embed-podcast/show/1iohmBNlRooIVtukKeavRa",
+                  "width": "100%",
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "iframe-embed",
               },
-              children: [],
-            },
-          ],
-        });
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
 
       test("Spotify track embed", () => {
@@ -593,21 +758,25 @@ describe("@atjson/source-html", () => {
             allow="encrypted-media"></iframe>`
         ).convertTo(OffsetSource);
 
-        let hir = new HIR(doc).toJSON();
-        expect(hir).toMatchObject({
-          type: "root",
-          children: [
-            {
-              type: "iframe-embed",
-              attributes: {
-                url: "https://open.spotify.com/embed/track/1QY4TdhuNIOX2SHLdElzd5",
-                height: "380",
-                width: "300",
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {
+                  "height": "380",
+                  "url": "https://open.spotify.com/embed/track/1QY4TdhuNIOX2SHLdElzd5",
+                  "width": "300",
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "iframe-embed",
               },
-              children: [],
-            },
-          ],
-        });
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
     });
 
@@ -626,13 +795,12 @@ describe("@atjson/source-html", () => {
             allowfullscreen></iframe>`
           ).convertTo(OffsetSource);
 
-          let hir = new HIR(doc).toJSON();
           if (url.startsWith("//")) {
             url = `https:${url}`;
           }
-          expect(hir).toMatchObject({
-            type: "root",
-            children: [
+          expect(serialize(doc)).toMatchObject({
+            text: "\uFFFC",
+            blocks: [
               {
                 type: "video-embed",
                 attributes: {
@@ -642,7 +810,7 @@ describe("@atjson/source-html", () => {
                   height: 315,
                   aspectRatio: "16:9",
                 },
-                children: [],
+                parents: [],
               },
             ],
           });
@@ -651,70 +819,150 @@ describe("@atjson/source-html", () => {
 
       describe("Vimeo", () => {
         test("default embed code (with caption)", () => {
-          let html = `<iframe src="https://player.vimeo.com/video/156254412" width="640" height="480" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
-<p><a href="https://vimeo.com/156254412">TSVETOK - Vogue Italia</a> from <a href="https://vimeo.com/karimandreotti">Karim Andreotti</a> on <a href="https://vimeo.com">Vimeo</a>.</p>`;
-          let doc = HTMLSource.fromRaw(html)
-            .convertTo(OffsetSource)
-            .canonical()
-            .withStableIds();
+          let html = `<iframe src="https://player.vimeo.com/video/156254412" width="640" height="480" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe><p><a href="https://vimeo.com/156254412">TSVETOK - Vogue Italia</a> from <a href="https://vimeo.com/karimandreotti">Karim Andreotti</a> on <a href="https://vimeo.com">Vimeo</a>.</p>`;
+          let doc = HTMLSource.fromRaw(html).convertTo(OffsetSource);
 
-          expect(doc.content).toBe(
-            "\nTSVETOK - Vogue Italia from Karim Andreotti on Vimeo."
-          );
-          // 1 embed, 1 slice, 3 links
-          expect(doc.annotations.length).toBe(5);
-          expect(doc.annotations[0]).toMatchObject({
-            type: "video-embed",
-            attributes: {
-              url: "https://player.vimeo.com/video/156254412",
-              provider: VideoURLs.Provider.VIMEO,
-              caption: "00000002",
-              width: 640,
-              height: 480,
-              aspectRatio: "4:3",
-            },
-          });
+          expect(serialize(doc, { withStableIds: true }))
+            .toMatchInlineSnapshot(`
+            {
+              "blocks": [
+                {
+                  "attributes": {
+                    "aspectRatio": "4:3",
+                    "caption": "M00000000",
+                    "height": 480,
+                    "provider": "VIMEO",
+                    "url": "https://player.vimeo.com/video/156254412",
+                    "width": 640,
+                  },
+                  "id": "B00000000",
+                  "parents": [],
+                  "selfClosing": false,
+                  "type": "video-embed",
+                },
+                {
+                  "attributes": {},
+                  "id": "B00000001",
+                  "parents": [],
+                  "selfClosing": false,
+                  "type": "text",
+                },
+              ],
+              "marks": [
+                {
+                  "attributes": {
+                    "url": "https://vimeo.com/156254412",
+                  },
+                  "id": "M00000001",
+                  "range": "(2..24)",
+                  "type": "link",
+                },
+                {
+                  "attributes": {
+                    "refs": [
+                      "B00000000",
+                    ],
+                  },
+                  "id": "M00000000",
+                  "range": "(2..55]",
+                  "type": "slice",
+                },
+                {
+                  "attributes": {
+                    "url": "https://vimeo.com/karimandreotti",
+                  },
+                  "id": "M00000002",
+                  "range": "(30..45)",
+                  "type": "link",
+                },
+                {
+                  "attributes": {
+                    "url": "https://vimeo.com",
+                  },
+                  "id": "M00000003",
+                  "range": "(49..54)",
+                  "type": "link",
+                },
+              ],
+              "text": "￼￼TSVETOK - Vogue Italia from Karim Andreotti on Vimeo.",
+            }
+          `);
         });
 
         test("protocol-relative URLs https", () => {
           let doc = HTMLSource.fromRaw(
             `<iframe src="//player.vimeo.com/video/156254412" width="640" height="480" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>`
-          )
-            .convertTo(OffsetSource)
-            .canonical();
+          ).convertTo(OffsetSource);
 
-          expect(doc.annotations.length).toBe(1);
-          expect(doc.annotations[0]).toMatchObject({
-            type: "video-embed",
-            attributes: {
-              url: "https://player.vimeo.com/video/156254412",
-              provider: VideoURLs.Provider.VIMEO,
-              width: 640,
-              height: 480,
-              aspectRatio: "4:3",
-            },
-          });
+          expect(serialize(doc, { withStableIds: true }))
+            .toMatchInlineSnapshot(`
+            {
+              "blocks": [
+                {
+                  "attributes": {
+                    "aspectRatio": "4:3",
+                    "height": 480,
+                    "provider": "VIMEO",
+                    "url": "https://player.vimeo.com/video/156254412",
+                    "width": 640,
+                  },
+                  "id": "B00000000",
+                  "parents": [],
+                  "selfClosing": false,
+                  "type": "video-embed",
+                },
+              ],
+              "marks": [],
+              "text": "￼",
+            }
+          `);
         });
 
         test("embed code with trailing paragraph that isn't from Vimeo", () => {
           let doc = HTMLSource.fromRaw(
             `<iframe src="https://player.vimeo.com/video/156254412" width="640" height="480" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
 <p>Hello, this is something from <a href="https://vogue.it">Vogue Italia</a>!</p>`
-          )
-            .convertTo(OffsetSource)
-            .canonical();
+          ).convertTo(OffsetSource);
 
-          expect(doc.annotations.length).toBe(3);
-          expect(doc.annotations[0]).toMatchObject({
-            type: "video-embed",
-            attributes: {
-              url: "https://player.vimeo.com/video/156254412",
-              provider: VideoURLs.Provider.VIMEO,
-              width: 640,
-              height: 480,
-              aspectRatio: "4:3",
-            },
-          });
+          expect(serialize(doc, { withStableIds: true }))
+            .toMatchInlineSnapshot(`
+            {
+              "blocks": [
+                {
+                  "attributes": {
+                    "aspectRatio": "4:3",
+                    "height": 480,
+                    "provider": "VIMEO",
+                    "url": "https://player.vimeo.com/video/156254412",
+                    "width": 640,
+                  },
+                  "id": "B00000000",
+                  "parents": [],
+                  "selfClosing": false,
+                  "type": "video-embed",
+                },
+                {
+                  "attributes": {},
+                  "id": "B00000001",
+                  "parents": [],
+                  "selfClosing": false,
+                  "type": "paragraph",
+                },
+              ],
+              "marks": [
+                {
+                  "attributes": {
+                    "url": "https://vogue.it",
+                  },
+                  "id": "M00000000",
+                  "range": "(33..45)",
+                  "type": "link",
+                },
+              ],
+              "text": "￼
+            ￼Hello, this is something from Vogue Italia!",
+            }
+          `);
         });
 
         test("embed code without caption", () => {
@@ -722,45 +970,57 @@ describe("@atjson/source-html", () => {
             `<iframe src="https://player.vimeo.com/video/156254412" width="640" height="480" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>`
           ).convertTo(OffsetSource);
 
-          let hir = new HIR(doc).toJSON();
-          expect(hir).toMatchObject({
-            type: "root",
-            children: [
-              {
-                type: "video-embed",
-                attributes: {
-                  url: "https://player.vimeo.com/video/156254412",
-                  provider: VideoURLs.Provider.VIMEO,
-                  width: 640,
-                  height: 480,
-                  aspectRatio: "4:3",
+          expect(serialize(doc, { withStableIds: true }))
+            .toMatchInlineSnapshot(`
+            {
+              "blocks": [
+                {
+                  "attributes": {
+                    "aspectRatio": "4:3",
+                    "height": 480,
+                    "provider": "VIMEO",
+                    "url": "https://player.vimeo.com/video/156254412",
+                    "width": 640,
+                  },
+                  "id": "B00000000",
+                  "parents": [],
+                  "selfClosing": false,
+                  "type": "video-embed",
                 },
-                children: [],
-              },
-            ],
-          });
+              ],
+              "marks": [],
+              "text": "￼",
+            }
+          `);
         });
       });
 
       test("Dailymotion", () => {
         let doc = HTMLSource.fromRaw(
           `<iframe frameborder="0" width="480" height="270" src="https://www.dailymotion.com/embed/video/x6gmvnp" allowfullscreen allow="autoplay"></iframe>`
-        )
-          .convertTo(OffsetSource)
-          .canonical();
+        ).convertTo(OffsetSource);
 
-        expect(doc.annotations).toMatchObject([
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
           {
-            type: "video-embed",
-            attributes: {
-              url: "https://www.dailymotion.com/embed/video/x6gmvnp",
-              provider: VideoURLs.Provider.DAILYMOTION,
-              width: 480,
-              height: 270,
-              aspectRatio: "16:9",
-            },
-          },
-        ]);
+            "blocks": [
+              {
+                "attributes": {
+                  "aspectRatio": "16:9",
+                  "height": 270,
+                  "provider": "DAILYMOTION",
+                  "url": "https://www.dailymotion.com/embed/video/x6gmvnp",
+                  "width": 480,
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "video-embed",
+              },
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
 
       test("Brightcove", () => {
@@ -775,83 +1035,132 @@ describe("@atjson/source-html", () => {
     </iframe>
   </div>
 </div>`
-        )
-          .convertTo(OffsetSource)
-          .canonical();
+        ).convertTo(OffsetSource);
 
-        expect(doc.annotations).toMatchObject([
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
           {
-            type: "video-embed",
-            attributes: {
-              url: "https://players.brightcove.net/1752604059001/default_default/index.html?videoId=5802784116001",
-              provider: VideoURLs.Provider.BRIGHTCOVE,
-              width: 640,
-              height: 360,
-              aspectRatio: "16:9",
-            },
-          },
-        ]);
+            "blocks": [
+              {
+                "attributes": {},
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "text",
+              },
+              {
+                "attributes": {
+                  "aspectRatio": "16:9",
+                  "height": 360,
+                  "provider": "BRIGHTCOVE",
+                  "url": "https://players.brightcove.net/1752604059001/default_default/index.html?videoId=5802784116001",
+                  "width": 640,
+                },
+                "id": "B00000001",
+                "parents": [],
+                "selfClosing": false,
+                "type": "video-embed",
+              },
+              {
+                "attributes": {},
+                "id": "B00000002",
+                "parents": [],
+                "selfClosing": false,
+                "type": "text",
+              },
+            ],
+            "marks": [],
+            "text": "￼
+            
+              ￼
+              ￼
+            
+          ",
+          }
+        `);
       });
 
       test("Twitch videos", () => {
         let doc = HTMLSource.fromRaw(
           `<iframe src="https://player.twitch.tv/?video=956002196&parent=www.example.com" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620"></iframe>`
-        )
-          .convertTo(OffsetSource)
-          .canonical();
+        ).convertTo(OffsetSource);
 
-        expect(doc.annotations).toMatchObject([
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
           {
-            type: "video-embed",
-            attributes: {
-              url: "https://player.twitch.tv/?video=956002196&parent=www.example.com",
-              provider: VideoURLs.Provider.TWITCH,
-              width: 620,
-              height: 378,
-              aspectRatio: "5:3",
-            },
-          },
-        ]);
+            "blocks": [
+              {
+                "attributes": {
+                  "aspectRatio": "5:3",
+                  "height": 378,
+                  "provider": "TWITCH",
+                  "url": "https://player.twitch.tv/?video=956002196&parent=www.example.com",
+                  "width": 620,
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "video-embed",
+              },
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
 
       test("Twitch clips", () => {
         let doc = HTMLSource.fromRaw(
           `<iframe src="https://clips.twitch.tv/embed?clip=StrongBlueWaterDoubleRainbow&parent=www.example.com" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620"></iframe>`
-        )
-          .convertTo(OffsetSource)
-          .canonical();
+        ).convertTo(OffsetSource);
 
-        expect(doc.annotations).toMatchObject([
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
           {
-            type: "video-embed",
-            attributes: {
-              url: "https://clips.twitch.tv/embed?clip=StrongBlueWaterDoubleRainbow&parent=www.example.com",
-              provider: VideoURLs.Provider.TWITCH,
-              width: 620,
-              height: 378,
-              aspectRatio: "5:3",
-            },
-          },
-        ]);
+            "blocks": [
+              {
+                "attributes": {
+                  "aspectRatio": "5:3",
+                  "height": 378,
+                  "provider": "TWITCH",
+                  "url": "https://clips.twitch.tv/embed?clip=StrongBlueWaterDoubleRainbow&parent=www.example.com",
+                  "width": 620,
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "video-embed",
+              },
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
 
       test("Wirewax", () => {
         let doc = HTMLSource.fromRaw(
           `<iframe style="position: absolute; top: 0; left: 0;" width="100%" height="100%" src="https://embedder.wirewax.com/8203724/" frameborder="0" scrolling="yes" allowfullscreen></iframe>`
-        )
-          .convertTo(OffsetSource)
-          .canonical();
+        ).convertTo(OffsetSource);
 
-        expect(doc.annotations).toMatchObject([
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
           {
-            type: "video-embed",
-            attributes: {
-              url: "https://embedder.wirewax.com/8203724",
-              provider: VideoURLs.Provider.WIREWAX,
-              aspectRatio: "1:1",
-            },
-          },
-        ]);
+            "blocks": [
+              {
+                "attributes": {
+                  "aspectRatio": "1:1",
+                  "height": 100,
+                  "provider": "WIREWAX",
+                  "url": "https://embedder.wirewax.com/8203724",
+                  "width": 100,
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "video-embed",
+              },
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
     });
 
@@ -862,22 +1171,26 @@ describe("@atjson/source-html", () => {
             `<div style="position: relative;width: auto;padding: 0 0 50%;height: 0;top: 0;left: 0;bottom: 0;right: 0;margin: 0;border: 0 none" id="experience-test" data-aspectRatio="2.01" data-mobile-aspectRatio="3.2"><iframe allowfullscreen src="//view.ceros.com/ceros-inspire/carousel-3" style="position: absolute;top: 0;left: 0;bottom: 0;right: 0;margin: 0;padding: 0;border: 0 none;height: 1px;width: 1px;min-height: 100%;min-width: 100%" frameborder="0" class="ceros-experience" scrolling="no"></iframe></div><script type="text/javascript" src="//view.ceros.com/scroll-proxy.min.js"></script>`
           ).convertTo(OffsetSource);
 
-          expect(doc.canonical()).toMatchObject({
-            content: "",
-            annotations: [
-              {
-                id: "test",
-                type: "ceros-embed",
-                start: 0,
-                end: 0,
-                attributes: {
-                  url: "//view.ceros.com/ceros-inspire/carousel-3",
-                  aspectRatio: 2.01,
-                  mobileAspectRatio: 3.2,
+          expect(serialize(doc, { withStableIds: true }))
+            .toMatchInlineSnapshot(`
+            {
+              "blocks": [
+                {
+                  "attributes": {
+                    "aspectRatio": 2.01,
+                    "mobileAspectRatio": 3.2,
+                    "url": "//view.ceros.com/ceros-inspire/carousel-3",
+                  },
+                  "id": "B00000000",
+                  "parents": [],
+                  "selfClosing": true,
+                  "type": "ceros-embed",
                 },
-              },
-            ],
-          });
+              ],
+              "marks": [],
+              "text": "￼",
+            }
+          `);
         });
 
         test("without mobileAspectRatio", () => {
@@ -885,21 +1198,25 @@ describe("@atjson/source-html", () => {
             `<div style="position: relative;width: auto;padding: 0 0 50%;height: 0;top: 0;left: 0;bottom: 0;right: 0;margin: 0;border: 0 none" id="experience-test" data-aspectRatio="2"><iframe allowfullscreen src="//view.ceros.com/ceros-inspire/carousel-3" style="position: absolute;top: 0;left: 0;bottom: 0;right: 0;margin: 0;padding: 0;border: 0 none;height: 1px;width: 1px;min-height: 100%;min-width: 100%" frameborder="0" class="ceros-experience" scrolling="no"></iframe></div><script type="text/javascript" src="//view.ceros.com/scroll-proxy.min.js"></script>`
           ).convertTo(OffsetSource);
 
-          expect(doc.canonical()).toMatchObject({
-            content: "",
-            annotations: [
-              {
-                id: "test",
-                type: "ceros-embed",
-                start: 0,
-                end: 0,
-                attributes: {
-                  url: "//view.ceros.com/ceros-inspire/carousel-3",
-                  aspectRatio: 2,
+          expect(serialize(doc, { withStableIds: true }))
+            .toMatchInlineSnapshot(`
+            {
+              "blocks": [
+                {
+                  "attributes": {
+                    "aspectRatio": 2,
+                    "url": "//view.ceros.com/ceros-inspire/carousel-3",
+                  },
+                  "id": "B00000000",
+                  "parents": [],
+                  "selfClosing": true,
+                  "type": "ceros-embed",
                 },
-              },
-            ],
-          });
+              ],
+              "marks": [],
+              "text": "￼",
+            }
+          `);
         });
 
         test("with a trailing blank script tag", () => {
@@ -915,22 +1232,35 @@ describe("@atjson/source-html", () => {
             `<div style="position: relative;width: auto;padding: 0 0 50%;height: 0;top: 0;left: 0;bottom: 0;right: 0;margin: 0;border: 0 none" id="experience-test" data-aspectRatio="2"><iframe allowfullscreen src="//view.ceros.com/ceros-inspire/carousel-3" style="position: absolute;top: 0;left: 0;bottom: 0;right: 0;margin: 0;padding: 0;border: 0 none;height: 1px;width: 1px;min-height: 100%;min-width: 100%" frameborder="0" class="ceros-experience" scrolling="no"></iframe></div><script type="text/javascript" src="https://www.example.com/my-script.js"></script>`
           ).convertTo(OffsetSource);
 
-          expect(doc.canonical()).toMatchObject({
-            content: "",
-            annotations: [
-              {
-                id: "test",
-                type: "ceros-embed",
-                start: 0,
-                end: 0,
-                attributes: {
-                  url: "//view.ceros.com/ceros-inspire/carousel-3",
-                  aspectRatio: 2,
+          expect(serialize(doc, { withStableIds: true }))
+            .toMatchInlineSnapshot(`
+            {
+              "blocks": [
+                {
+                  "attributes": {
+                    "aspectRatio": 2,
+                    "url": "//view.ceros.com/ceros-inspire/carousel-3",
+                  },
+                  "id": "B00000000",
+                  "parents": [],
+                  "selfClosing": true,
+                  "type": "ceros-embed",
                 },
-              },
-              {},
-            ],
-          });
+              ],
+              "marks": [
+                {
+                  "attributes": {
+                    "-html-src": "https://www.example.com/my-script.js",
+                    "-html-type": "text/javascript",
+                  },
+                  "id": "M00000000",
+                  "range": "(1..1]",
+                  "type": "-html-script",
+                },
+              ],
+              "text": "￼",
+            }
+          `);
         });
       });
     });
@@ -945,17 +1275,27 @@ describe("@atjson/source-html", () => {
           scrolling="no"></iframe>`
         ).convertTo(OffsetSource);
 
-        expect([...doc.where({ type: "-offset-iframe-embed" })]).toMatchObject([
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
           {
-            type: "iframe-embed",
-            attributes: {
-              url: "https://www.redditmedia.com/r/IndianDankMemes/comments/qlndlm/average_indian_family/?ref_source=embed&ref=share&embed=true&showmedia=false",
-              height: "476",
-              width: "640",
-              sandbox: "allow-scripts allow-same-origin allow-popups",
-            },
-          },
-        ]);
+            "blocks": [
+              {
+                "attributes": {
+                  "anchorName": "reddit-embed",
+                  "height": "476",
+                  "sandbox": "allow-scripts allow-same-origin allow-popups",
+                  "url": "https://www.redditmedia.com/r/IndianDankMemes/comments/qlndlm/average_indian_family/?ref_source=embed&ref=share&embed=true&showmedia=false",
+                  "width": "640",
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "iframe-embed",
+              },
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
 
       test("Reddit Embed code", () => {
@@ -969,17 +1309,27 @@ describe("@atjson/source-html", () => {
           scrolling="no"></iframe>`
         ).convertTo(OffsetSource);
 
-        expect([...doc.where({ type: "-offset-iframe-embed" })]).toMatchObject([
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
           {
-            type: "iframe-embed",
-            attributes: {
-              url: "https://www.redditmedia.com/r/HollywoodUndead/comments/qoozk2/danny_solo_projecttreading_water/?ref_source=embed&ref=share&embed=true&showmedia=false&showedits=false&created=2021-11-08T13%3A42%3A20.393Z",
-              height: "126",
-              width: "640",
-              sandbox: "allow-scripts allow-same-origin allow-popups",
-            },
-          },
-        ]);
+            "blocks": [
+              {
+                "attributes": {
+                  "anchorName": "reddit-embed",
+                  "height": "126",
+                  "sandbox": "allow-scripts allow-same-origin allow-popups",
+                  "url": "https://www.redditmedia.com/r/HollywoodUndead/comments/qoozk2/danny_solo_projecttreading_water/?ref_source=embed&ref=share&embed=true&showmedia=false&showedits=false&created=2021-11-08T13%3A42%3A20.393Z",
+                  "width": "640",
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "iframe-embed",
+              },
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
     });
     describe("TikTok", () => {
@@ -988,17 +1338,23 @@ describe("@atjson/source-html", () => {
           `<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@teenvogue/video/292170367534714880" data-video-id="292170367534714880" style="max-width: 605px;min-width: 325px;" > <section> <a target="_blank" title="@teenvogue" href="https://www.tiktok.com/@teenvogue">@teenvogue</a> <p>When officialayoteo ask to hold your phone 🕴🏾🕴🏾</p> <a target="_blank" title="♬ Better Off Alone - Ayo & Teo" href="https://www.tiktok.com/music/Better-Off-Alone-264491379257659392">♬ Better Off Alone - Ayo & Teo</a> </section> </blockquote> <script async src="https://www.tiktok.com/embed.js"></script>`
         ).convertTo(OffsetSource);
 
-        expect(doc.canonical()).toMatchObject({
-          content: "",
-          annotations: [
-            {
-              type: "tiktok-embed",
-              attributes: {
-                url: "https://www.tiktok.com/@teenvogue/video/292170367534714880",
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {
+                  "url": "https://www.tiktok.com/@teenvogue/video/292170367534714880",
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "tiktok-embed",
               },
-            },
-          ],
-        });
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
 
       test("from html rendered output", () => {
@@ -1006,17 +1362,23 @@ describe("@atjson/source-html", () => {
           `<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@teenvogue/video/292170367534714880" data-video-id="292170367534714880" style="max-width: 605px;min-width: 325px;"><section><a target="_blank" title="@teenvogue" href="https://www.tiktok.com/@teenvogue">@teenvogue</a></section></blockquote><script async src="https://www.tiktok.com/embed.js"></script>`
         ).convertTo(OffsetSource);
 
-        expect(doc.canonical()).toMatchObject({
-          content: "",
-          annotations: [
-            {
-              type: "tiktok-embed",
-              attributes: {
-                url: "https://www.tiktok.com/@teenvogue/video/292170367534714880",
+        expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {
+                  "url": "https://www.tiktok.com/@teenvogue/video/292170367534714880",
+                },
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "tiktok-embed",
               },
-            },
-          ],
-        });
+            ],
+            "marks": [],
+            "text": "￼",
+          }
+        `);
       });
     });
   });

--- a/packages/@atjson/source-mobiledoc/src/parser.ts
+++ b/packages/@atjson/source-mobiledoc/src/parser.ts
@@ -66,25 +66,41 @@ export default class Parser {
   processCard(section: CardSection, start: number) {
     let [, cardIndex] = section;
     let card = this.mobiledoc.cards[cardIndex];
-    this.annotations.push({
-      type: `-mobiledoc-${card[0]}-card`,
-      start,
-      end: start + 1,
-      attributes: prefix(card[1]),
-    });
+    this.annotations.push(
+      {
+        type: `-mobiledoc-${card[0]}-card`,
+        start,
+        end: start + 1,
+        attributes: prefix(card[1]),
+      },
+      {
+        type: "-atjson-parse-token",
+        start,
+        end: start + 1,
+        attributes: {},
+      }
+    );
     return "\uFFFC";
   }
 
   processImage(section: ImageSection, start: number) {
     let [, src] = section;
-    this.annotations.push({
-      type: `-mobiledoc-img`,
-      start,
-      end: start + 1,
-      attributes: {
-        "-mobiledoc-src": src,
+    this.annotations.push(
+      {
+        type: `-mobiledoc-img`,
+        start,
+        end: start + 1,
+        attributes: {
+          "-mobiledoc-src": src,
+        },
       },
-    });
+      {
+        type: "-atjson-parse-token",
+        start,
+        end: start + 1,
+        attributes: {},
+      }
+    );
     return "\uFFFC";
   }
 

--- a/packages/@atjson/source-mobiledoc/test/source-mobiledoc-test.ts
+++ b/packages/@atjson/source-mobiledoc/test/source-mobiledoc-test.ts
@@ -1,9 +1,8 @@
-import { InlineAnnotation } from "@atjson/document";
-import { HIR } from "@atjson/hir";
+import { BlockAnnotation, InlineAnnotation, serialize } from "@atjson/document";
 import MobiledocSource from "../src";
 import { ListSection } from "../src/parser";
 
-describe("@atjson/source-Mobiledoc", () => {
+describe("@atjson/source-mobiledoc", () => {
   describe("sections", () => {
     describe.each([
       "p",
@@ -25,16 +24,11 @@ describe("@atjson/source-Mobiledoc", () => {
           markups: [],
           sections: [[1, type.toUpperCase(), [[0, [], 0, "hello"]]]],
         });
-        let hir = new HIR(doc).toJSON();
-
-        expect(hir).toMatchObject({
-          type: "root",
-          attributes: {},
-          children: [
+        expect(serialize(doc)).toMatchObject({
+          text: "\uFFFChello",
+          blocks: [
             {
               type,
-              attributes: {},
-              children: ["hello"],
             },
           ],
         });
@@ -48,16 +42,11 @@ describe("@atjson/source-Mobiledoc", () => {
           markups: [],
           sections: [[1, type.toUpperCase(), [[0, [], 0, ""]]]],
         });
-        let hir = new HIR(doc).toJSON();
-
-        expect(hir).toMatchObject({
-          type: "root",
-          attributes: {},
-          children: [
+        expect(serialize(doc)).toMatchObject({
+          text: "\uFFFC",
+          blocks: [
             {
               type,
-              attributes: {},
-              children: [],
             },
           ],
         });
@@ -77,22 +66,17 @@ describe("@atjson/source-Mobiledoc", () => {
           sections: [[1, "P", [[0, [0], 1, "hello"]]]],
         });
 
-        let hir = new HIR(doc).toJSON();
-
-        expect(hir).toMatchObject({
-          type: "root",
-          attributes: {},
-          children: [
+        expect(serialize(doc)).toMatchObject({
+          text: "\uFFFChello",
+          blocks: [
             {
               type: "p",
-              attributes: {},
-              children: [
-                {
-                  type,
-                  attributes: {},
-                  children: ["hello"],
-                },
-              ],
+            },
+          ],
+          marks: [
+            {
+              type,
+              range: "(1..6]",
             },
           ],
         });
@@ -118,30 +102,22 @@ describe("@atjson/source-Mobiledoc", () => {
         ],
       });
 
-      let hir = new HIR(doc).toJSON();
-
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
+      expect(serialize(doc)).toMatchObject({
+        text: "\uFFFChello brave new world",
+        blocks: [
           {
             type: "p",
-            attributes: {},
-            children: [
-              {
-                type: "a",
-                attributes: { href: "google.com" },
-                children: [
-                  "hello ",
-                  {
-                    type: "b",
-                    attributes: {},
-                    children: ["brave new"],
-                  },
-                  " world",
-                ],
-              },
-            ],
+          },
+        ],
+        marks: [
+          {
+            type: "a",
+            attributes: { href: "google.com" },
+            range: "(1..22]",
+          },
+          {
+            type: "b",
+            range: "(7..16]",
           },
         ],
       });
@@ -156,28 +132,21 @@ describe("@atjson/source-Mobiledoc", () => {
         sections: [[1, "P", [[0, [0, 1], 2, "test"]]]],
       });
 
-      let hir = new HIR(doc).toJSON();
-
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
+      expect(serialize(doc)).toMatchObject({
+        text: "\uFFFCtest",
+        blocks: [
           {
             type: "p",
-            attributes: {},
-            children: [
-              {
-                type: "sub",
-                attributes: {},
-                children: [
-                  {
-                    type: "strong",
-                    attributes: {},
-                    children: ["test"],
-                  },
-                ],
-              },
-            ],
+          },
+        ],
+        marks: [
+          {
+            type: "strong",
+            range: "(1..5]",
+          },
+          {
+            type: "sub",
+            range: "(1..5]",
           },
         ],
       });
@@ -204,38 +173,25 @@ describe("@atjson/source-Mobiledoc", () => {
         ],
       });
 
-      let hir = new HIR(doc).toJSON();
-
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
+      expect(serialize(doc)).toMatchObject({
+        text: "\uFFFCtext that is bold, underlined, and italicized plus some text after",
+        blocks: [
           {
             type: "p",
-            attributes: {},
-            children: [
-              {
-                type: "em",
-                attributes: {},
-                children: [
-                  "text that is ",
-                  {
-                    type: "strong",
-                    attributes: {},
-                    children: [
-                      "bold, ",
-                      {
-                        type: "u",
-                        attributes: {},
-                        children: ["underlined"],
-                      },
-                    ],
-                  },
-                  ", and italicized",
-                ],
-              },
-              " plus some text after",
-            ],
+          },
+        ],
+        marks: [
+          {
+            type: "em",
+            range: "(1..46]",
+          },
+          {
+            type: "strong",
+            range: "(14..30]",
+          },
+          {
+            type: "u",
+            range: "(20..30]",
           },
         ],
       });
@@ -251,7 +207,10 @@ describe("@atjson/source-Mobiledoc", () => {
     }
 
     class MentionSource extends MobiledocSource {
-      static schema = [...MobiledocSource.schema, Mention];
+      static schema = [
+        ...MobiledocSource.schema,
+        Mention,
+      ] as typeof MobiledocSource.schema;
     }
 
     let doc = MentionSource.fromRaw({
@@ -262,29 +221,25 @@ describe("@atjson/source-Mobiledoc", () => {
       sections: [[1, "P", [[1, [], 0, 0]]]],
     });
 
-    let hir = new HIR(doc).toJSON();
-
-    expect(hir).toMatchObject({
-      type: "root",
-      attributes: {},
-      children: [
+    expect(serialize(doc)).toMatchObject({
+      text: "\uFFFC@bob",
+      blocks: [
         {
           type: "p",
-          attributes: {},
-          children: [
-            {
-              type: "mention-atom",
-              attributes: { id: 42 },
-              children: ["@bob"],
-            },
-          ],
+        },
+      ],
+      marks: [
+        {
+          type: "mention-atom",
+          range: "(1..5]",
+          attributes: { id: 42 },
         },
       ],
     });
   });
 
   test("card", () => {
-    class Gallery extends InlineAnnotation<{
+    class Gallery extends BlockAnnotation<{
       style: "mosaic" | "slideshow" | "list";
       ids: number[];
     }> {
@@ -293,7 +248,10 @@ describe("@atjson/source-Mobiledoc", () => {
     }
 
     class GallerySource extends MobiledocSource {
-      static schema = [...MobiledocSource.schema, Gallery];
+      static schema = [
+        ...MobiledocSource.schema,
+        Gallery,
+      ] as typeof MobiledocSource.schema;
     }
 
     let doc = GallerySource.fromRaw({
@@ -314,12 +272,9 @@ describe("@atjson/source-Mobiledoc", () => {
       sections: [[10, 0]],
     });
 
-    let hir = new HIR(doc).toJSON();
-
-    expect(hir).toMatchObject({
-      type: "root",
-      attributes: {},
-      children: [
+    expect(serialize(doc)).toMatchObject({
+      text: "\uFFFC",
+      blocks: [
         {
           type: "gallery-card",
           attributes: {
@@ -341,18 +296,14 @@ describe("@atjson/source-Mobiledoc", () => {
       sections: [[2, "https://example.com/example.png"]],
     });
 
-    let hir = new HIR(doc).toJSON();
-
-    expect(hir).toMatchObject({
-      type: "root",
-      attributes: {},
-      children: [
+    expect(serialize(doc)).toMatchObject({
+      text: "\uFFFC",
+      blocks: [
         {
           type: "img",
           attributes: {
             src: "https://example.com/example.png",
           },
-          children: [],
         },
       ],
     });
@@ -383,41 +334,27 @@ describe("@atjson/source-Mobiledoc", () => {
         ],
       });
 
-      let hir = new HIR(doc).toJSON();
-
-      expect(hir).toMatchObject({
-        type: "root",
-        attributes: {},
-        children: [
+      expect(serialize(doc)).toMatchObject({
+        text: "\uFFFC\uFFFCfirst item with italic text\uFFFCsecond item with struck-through text",
+        blocks: [
+          { type },
           {
-            type,
-            attributes: {},
-            children: [
-              {
-                type: "li",
-                attributes: {},
-                children: [
-                  "first item ",
-                  {
-                    type: "em",
-                    attributes: {},
-                    children: ["with italic text"],
-                  },
-                ],
-              },
-              {
-                type: "li",
-                attributes: {},
-                children: [
-                  "second item ",
-                  {
-                    type: "s",
-                    attributes: {},
-                    children: ["with struck-through text"],
-                  },
-                ],
-              },
-            ],
+            type: "li",
+            parents: [type],
+          },
+          {
+            type: "li",
+            parents: [type],
+          },
+        ],
+        marks: [
+          {
+            type: "em",
+            range: "(13..29]",
+          },
+          {
+            type: "s",
+            range: "(42..66]",
           },
         ],
       });

--- a/packages/@atjson/source-prism/test/__snapshots__/prism-test.ts.snap
+++ b/packages/@atjson/source-prism/test/__snapshots__/prism-test.ts.snap
@@ -2,8994 +2,5224 @@
 
 exports[`@atjson/source-prism prism snapshots parses gq-fresh-paint.xml 1`] = `
 {
-  "attributes": {},
-  "children": [
-    "
-",
+  "blocks": [
+    {
+      "attributes": {},
+      "id": "B00000000",
+      "parents": [],
+      "selfClosing": false,
+      "type": "text",
+    },
     {
       "attributes": {
         "xmlns": "http://www.w3.org/1999/xhtml",
       },
-      "children": [
-        "
-",
-        {
-          "attributes": {},
-          "children": [
-            "
-",
-            {
-              "attributes": {},
-              "children": [
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-identifier",
-                  },
-                  "children": [
-                    "XXXXXXX",
-                  ],
-                  "id": "00000008",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Fresh Paint",
-                  ],
-                  "id": "0000000b",
-                  "type": "title",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-creator",
-                  },
-                  "children": [
-                    "XXXXXXX",
-                  ],
-                  "id": "0000000e",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-contributor",
-                  },
-                  "children": [
-                    "XXXXXXX",
-                  ],
-                  "id": "00000011",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-contributor",
-                  },
-                  "children": [
-                    "XXXXXXX",
-                  ],
-                  "id": "00000014",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-contributor",
-                  },
-                  "children": [
-                    "XXXXXXX",
-                  ],
-                  "id": "00000017",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-publicationname",
-                  },
-                  "children": [
-                    "GQ",
-                  ],
-                  "id": "0000001a",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-issn",
-                  },
-                  "children": [
-                    "2471-5393",
-                  ],
-                  "id": "0000001d",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-publisher",
-                  },
-                  "children": [
-                    "Condé Nast",
-                  ],
-                  "id": "00000020",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-coverdate",
-                  },
-                  "children": [
-                    "2018-11-13",
-                  ],
-                  "id": "00000023",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-coverdisplaydate",
-                  },
-                  "children": [
-                    "GQ Style Holiday 2018",
-                  ],
-                  "id": "00000026",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-volume",
-                  },
-                  "children": [
-                    "3",
-                  ],
-                  "id": "00000029",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-number",
-                  },
-                  "children": [
-                    "3",
-                  ],
-                  "id": "0000002c",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-startingpage",
-                  },
-                  "children": [
-                    "90",
-                  ],
-                  "id": "0000002f",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-section",
-                  },
-                  "children": [
-                    "Art",
-                  ],
-                  "id": "00000032",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-subject",
-                  },
-                  "children": [
-                    " ",
-                  ],
-                  "id": "00000035",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "FOR A WHILE THERE, PAINTING FELL OUT OF STYLE IN AN ART WORLD THAT FAVORED PERFORMANCE, VIDEO, AND INSTALLATIONS. BUT ACRYLIC ON CANVAS IS BACK, BABY—SO WE VISITED FOUR HIGHLY ORIGINAL PAINTERS, PHOTOGRAPHED THEM IN THEIR STUDIOS, THEN ASKED THEM TO COMPLETE AN E-MAIL QUESTIONNAIRE—AND DOODLE US A SELF-PORTRAIT.",
-                  ],
-                  "id": "00000038",
-                  "type": "description",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-wordcount",
-                  },
-                  "children": [
-                    "2424",
-                  ],
-                  "id": "0000003b",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-copyright",
-                  },
-                  "children": [
-                    "COPYRIGHT ©2018 THE CONDÉ NAST PUBLICATIONS. ALL RIGHTS RESERVED.",
-                  ],
-                  "id": "0000003e",
-                  "type": "unknown",
-                },
-                "
-",
-              ],
-              "id": "00000006",
-              "type": "head",
-            },
-            "
-",
-            {
-              "attributes": {},
-              "children": [
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "FRESH PAINT",
-                  ],
-                  "id": "00000044",
-                  "type": "h1",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "class": "byline",
-                  },
-                  "children": [
-                    "By XXXXXXX",
-                    {
-                      "attributes": {},
-                      "children": [],
-                      "id": "00000049",
-                      "type": "br",
-                    },
-                    "Photographs by XXXXXXX",
-                    {
-                      "attributes": {},
-                      "children": [],
-                      "id": "0000004b",
-                      "type": "br",
-                    },
-                    "Photographs by XXXXXXX",
-                    {
-                      "attributes": {},
-                      "children": [],
-                      "id": "0000004d",
-                      "type": "br",
-                    },
-                    "Photographs by XXXXXXX",
-                  ],
-                  "id": "00000047",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "class": "deck",
-                  },
-                  "children": [
-                    "FOR A WHILE THERE, PAINTING FELL OUT OF STYLE IN AN ART WORLD THAT FAVORED PERFORMANCE, VIDEO, AND INSTALLATIONS. BUT ACRYLIC ON CANVAS IS BACK, BABY—SO WE VISITED FOUR HIGHLY ORIGINAL PAINTERS, PHOTOGRAPHED THEM IN THEIR STUDIOS, THEN ASKED THEM TO COMPLETE AN E-MAIL QUESTIONNAIRE—AND DOODLE US A SELF-PORTRAIT.",
-                  ],
-                  "id": "00000050",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000055",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Photograph by XXXXXXX",
-                      ],
-                      "id": "0000005a",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000053",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000060",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Photograph by XXXXXXX",
-                      ],
-                      "id": "00000065",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "0000005e",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "0000006b",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Photograph by XXXXXXX",
-                      ],
-                      "id": "00000070",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000069",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000076",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Photograph by XXXXXXX",
-                      ],
-                      "id": "0000007b",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000074",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000081",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "XXXXXXX",
-                      ],
-                      "id": "00000086",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "0000007f",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Robert Nava",
-                  ],
-                  "id": "0000008a",
-                  "type": "h2",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "0000008f",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                  ],
-                  "id": "0000008d",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Five-Minute Self-Portrait,",
-                      ],
-                      "id": "00000097",
-                      "type": "i",
-                    },
-                    " 2018",
-                  ],
-                  "id": "00000095",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "BROOKLYN",
-                        {
-                          "attributes": {},
-                          "children": [],
-                          "id": "0000009f",
-                          "type": "br",
-                        },
-                        "b. 1985",
-                      ],
-                      "id": "0000009d",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "0000009b",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "000000a5",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "XXXXXXX",
-                      ],
-                      "id": "000000aa",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-caption",
-                      },
-                      "children": [
-                        "The East Williamsburg loft building where Nava lives and works is packed with musicians, filmmakers, and other artists. “I like that you can be loud here and the rooftop for the view and big sky,” he says.",
-                      ],
-                      "id": "000000ad",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "000000a3",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "000000b3",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "XXXXXXX. Robert Nava, Red Tooth, courtesy of Stan Narten/Sorry We're Closed, Brussels",
-                      ],
-                      "id": "000000b8",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "000000b1",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        {
-                          "attributes": {},
-                          "children": [
-                            "NAVA'S PAINTINGS OF PRIMORDIAL MONSTERS",
-                          ],
-                          "id": "000000c0",
-                          "type": "small",
-                        },
-                      ],
-                      "id": "000000be",
-                      "type": "b",
-                    },
-                    " and myths balance ceremonial seriousness with childlike play. Originally from East Chicago, Indiana, he received an M.F.A. from Yale University before moving to Brooklyn, where we caught up with him while at work in his studio.",
-                  ],
-                  "id": "000000bc",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        {
-                          "attributes": {},
-                          "children": [
-                            "GQ STYLE:",
-                          ],
-                          "id": "000000c9",
-                          "type": "small",
-                        },
-                        " How did you arrive at your painting style? What factors influenced your development most?",
-                      ],
-                      "id": "000000c7",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000000c5",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        {
-                          "attributes": {},
-                          "children": [
-                            "ROBERT NAVA:",
-                          ],
-                          "id": "000000d2",
-                          "type": "small",
-                        },
-                      ],
-                      "id": "000000d0",
-                      "type": "b",
-                    },
-                    " Drawing every morning, trying to keep up with my imagination. Looking at a lot of ancient art, mainly Sumerian, Egyptian, Mayan. The mandala. Cave painting. The older artworks have a big impact, and I'm able to see the amount of work put into them, and they feel like they are timeless to a degree. But also they contain so much mystery. There's another level of mindfulness to “care” in them.",
-                  ],
-                  "id": "000000ce",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What is your latest body of work all about?",
-                      ],
-                      "id": "000000d9",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000000d7",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Making new myths. Trying to make monsters, angels, ghosts, putting an energy into them.",
-                  ],
-                  "id": "000000dd",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What's something you'd like to do as an artist but haven't yet?",
-                      ],
-                      "id": "000000e2",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000000e0",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Make large sculpture with metal.",
-                  ],
-                  "id": "000000e6",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What do you do when you need a break from making art?",
-                      ],
-                      "id": "000000eb",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000000e9",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Hang with my cat, Jumanji. Go to rooftops. The beach. Find some live music to enjoy.",
-                  ],
-                  "id": "000000ef",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What do you wear when you paint?",
-                      ],
-                      "id": "000000f4",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000000f2",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Usually shorts and headphones. The less the better.",
-                  ],
-                  "id": "000000f8",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "If you're at a party and a new acquaintance asks what your work is like, what do you say?",
-                      ],
-                      "id": "000000fd",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000000fb",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "I try to show a web page or Instagram.",
-                  ],
-                  "id": "00000101",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Who was the first artist that really blew your mind? And who was the most recent?",
-                      ],
-                      "id": "00000106",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "00000104",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Van Gogh and Huma Bhabha. Van Gogh: The soul and application of paint. The fearlessness. The paint is very alive—those paintings have an honesty that cannot be denied. Huma Bhabha: An engagement with the realness in materials with immense weight and impact—her works are very “in your face,” with a raw energy.",
-                  ],
-                  "id": "0000010a",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Beyond the basic tools, what things do you need in order to paint?",
-                      ],
-                      "id": "0000010f",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "0000010d",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Loud music. There are so many artists and moods, but lately: electronic music, often techno, house, disco. Anything that takes you on a journey for hours on end.",
-                  ],
-                  "id": "00000113",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What's the best advice you've ever received from another artist?",
-                      ],
-                      "id": "00000118",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "00000116",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "“There are no mistakes,” from my first-grade art teacher, Mrs. Shaver.",
-                  ],
-                  "id": "0000011c",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Devan Shimoyama",
-                  ],
-                  "id": "0000011f",
-                  "type": "h2",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000124",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                  ],
-                  "id": "00000122",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Five-Minute Self-Portrait,",
-                      ],
-                      "id": "0000012c",
-                      "type": "i",
-                    },
-                    " 2018",
-                  ],
-                  "id": "0000012a",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "PITTSBURGH",
-                        {
-                          "attributes": {},
-                          "children": [],
-                          "id": "00000134",
-                          "type": "br",
-                        },
-                        "b. 1989",
-                      ],
-                      "id": "00000132",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "00000130",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        {
-                          "attributes": {},
-                          "children": [
-                            "PHILADELPHIA NATIVE",
-                          ],
-                          "id": "0000013c",
-                          "type": "small",
-                        },
-                      ],
-                      "id": "0000013a",
-                      "type": "b",
-                    },
-                    " Shimoyama—also a Yale M.F.A. graduate—is now based in Pittsburgh, where he teaches at Carnegie Mellon University. His paintings borrow materials from drag culture—glitter, feathers, and rhinestones—and explore issues related to race, masculinity, and illusions of wealth. His debut solo museum exhibition, ",
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Cry, Baby,",
-                      ],
-                      "id": "00000140",
-                      "type": "i",
-                    },
-                    " is at the Andy Warhol Museum through March 2019.",
-                  ],
-                  "id": "00000138",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        {
-                          "attributes": {},
-                          "children": [
-                            "GQ STYLE:",
-                          ],
-                          "id": "00000148",
-                          "type": "small",
-                        },
-                        " How did you arrive at your painting style? What factors influenced your development most?",
-                      ],
-                      "id": "00000146",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "00000144",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        {
-                          "attributes": {},
-                          "children": [
-                            "DEVAN SHIMOYAMA:",
-                          ],
-                          "id": "00000151",
-                          "type": "b",
-                        },
-                      ],
-                      "id": "0000014f",
-                      "type": "small",
-                    },
-                    " My painting style came about from my love of experimenting with all kinds of materials, drag culture, and fashion. I remember when I was first starting to paint, I was fascinated by how unconventional painting materials would mix together to create these psychedelic, shimmering encrusted spills. I'd play around with spray paint, quick-dry enamel, and fabric dye. Those eventually led to my interest in other unconventional painting materials that are much more in line with what drag performers use to get a look together, like rhinestones, glitter, feathers, et cetera, which they're using to create the illusion and fantasy of a wealthy, beautiful fictional character.",
-                  ],
-                  "id": "0000014d",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What is your latest body of work all about?",
-                      ],
-                      "id": "00000158",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "00000156",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "The last solo exhibition I had was titled ",
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Sweet,",
-                      ],
-                      "id": "0000015e",
-                      "type": "i",
-                    },
-                    " which was exploring the toxic masculinity of black barbershops. More recently, I've begun a body of work where I am depicting black individuals tending to their homes and thinking about the importance of black ownership, whether that ownership is businesses, properties, et cetera. I just have been thinking about the importance of people of color actually being able to have more agency and not become such easy targets for displacement and gentrification.",
-                  ],
-                  "id": "0000015c",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What's something you'd like to do as an artist but haven't yet?",
-                      ],
-                      "id": "00000164",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "00000162",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "I would love to actually collaborate with a fashion designer and create a line. I love fashion so much, and I would be completely invested in creating everything, even creating custom fabrics and accessories. I think that designers like Kerby Jean-Raymond from Pyer Moss have found a really nuanced way to intersect art, activism, and fashion in such a smart way.",
-                  ],
-                  "id": "00000168",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What do you do when you need a break from making art?",
-                      ],
-                      "id": "0000016d",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "0000016b",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "I need mindless activity. I hang out with my two dogs (two Cavalier King Charles spaniels, named River and Bowie), or I play mindless games like Stardew Valley or watch guilty-pleasure reality-TV shows.",
-                  ],
-                  "id": "00000171",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000176",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "XXXXXXX",
-                      ],
-                      "id": "0000017b",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-caption",
-                      },
-                      "children": [
-                        "Shimoyama's studio on campus at Carnegie Mellon is located down the hall from the university's woodshop, laser cutters, and printshop, which, he says, “allows me to be able to open up my multidisciplinary practice with ease.”",
-                      ],
-                      "id": "0000017e",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000174",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000184",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "XXXXXXX",
-                      ],
-                      "id": "00000189",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000182",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "0000018f",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "XXXXXXX",
-                      ],
-                      "id": "00000194",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "0000018d",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What do you wear when you paint?",
-                      ],
-                      "id": "0000019a",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "00000198",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "I normally wear either a pair of denim cutoff shorts and a tank top or my bright red Dickies short-sleeve coveralls. I also always wear my Blundstone Chelsea boots as my painting shoes. They're covered in all kinds of splattered paint and glitter.",
-                  ],
-                  "id": "0000019e",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Who was the first artist that really blew your mind? And who was the most recent?",
-                      ],
-                      "id": "000001a3",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000001a1",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Wangechi Mutu is the first artist that really blew my mind. I was completely fascinated by her use of ink and collage to make these explosive, hybridized characters that were so indomitable in spirit and strength. Most recently, my best friend, Haley Josephs, has blown my mind pretty consistently with her new work. The colors, the power in the women she's depicting, and the fantastical reality she creates never fail to impress me.",
-                  ],
-                  "id": "000001a7",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Beyond the basic tools, what things do you need in order to paint?",
-                      ],
-                      "id": "000001ac",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000001aa",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "I need to always have jewelry, glitter, rhinestones, and fabric, but also I need to listen to something while I'm working. Depending on what I'm working on, I need to play a good album that matches my mood—currently listening to Kelela, SZA, Blood Orange, and Aminé on rotation.",
-                  ],
-                  "id": "000001b0",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What's the best advice you've ever received from another artist?",
-                      ],
-                      "id": "000001b5",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000001b3",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Josephine Halvorson gave me some of my best studio visits while in grad school at Yale, and I remember her telling me that she could tell when my work was coming from a place of love and talking about love and that there was strength in that. I've kept that in mind ever since, always making sure to make art from something real and true and significant and from a place of love.",
-                  ],
-                  "id": "000001b9",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "If you're at a party and a new acquaintance asks what your work is like, what do you say?",
-                      ],
-                      "id": "000001be",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000001bc",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "I'd say that I make mythological, epic fantasy-figure paintings with drag-queen materials. That's my elevator pitch!",
-                  ],
-                  "id": "000001c2",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Emily Mae Smith",
-                  ],
-                  "id": "000001c5",
-                  "type": "h2",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "000001ca",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                  ],
-                  "id": "000001c8",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Five-Minute Self-Portrait,",
-                      ],
-                      "id": "000001d2",
-                      "type": "i",
-                    },
-                    " 2018",
-                  ],
-                  "id": "000001d0",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "BROOKLYN",
-                        {
-                          "attributes": {},
-                          "children": [],
-                          "id": "000001da",
-                          "type": "br",
-                        },
-                        "b. 1979",
-                      ],
-                      "id": "000001d8",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000001d6",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        {
-                          "attributes": {},
-                          "children": [
-                            "BORN IN AUSTIN,",
-                          ],
-                          "id": "000001e2",
-                          "type": "b",
-                        },
-                      ],
-                      "id": "000001e0",
-                      "type": "small",
-                    },
-                    " Smith paints cartoonish figures and surreal scenarios in photo-realistic detail, all of it oozing with sensuality and stark feminine energy. We caught up with Smith at her studio in Brooklyn as she prepared for a show at Galerie Perrotin in Manhattan and for her first solo museum show, which opens at Le Consortium in Dijon, France, in November.",
-                  ],
-                  "id": "000001de",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        {
-                          "attributes": {},
-                          "children": [
-                            "GQ STYLE:",
-                          ],
-                          "id": "000001eb",
-                          "type": "small",
-                        },
-                        " How did you arrive at your painting style? What factors influenced your development most?",
-                      ],
-                      "id": "000001e9",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000001e7",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        {
-                          "attributes": {},
-                          "children": [
-                            "EMILY MAE SMITH:",
-                          ],
-                          "id": "000001f4",
-                          "type": "small",
-                        },
-                      ],
-                      "id": "000001f2",
-                      "type": "b",
-                    },
-                    " Learning what to leave out and how to do just enough—to not over-do—was very important. That comes with experience and practice. I have been painting with the same materials for 20 years. A lot of people like to discuss their childhood as being formative, but I prefer to emphasize the experiences of my adult life. As a woman, my point of view has been radicalized during this time.",
-                  ],
-                  "id": "000001f0",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What is your latest body of work all about?",
-                      ],
-                      "id": "000001fb",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000001f9",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "An anthropomorphic broom appears in a lot of my paintings. Its figure forms a kind of totem: an object imbued with a special power beyond its literal form. These brooms are tools for new potentialities, occupying and distorting historical compositions, claiming space for feminine subjectivity.",
-                  ],
-                  "id": "000001ff",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What's something you'd like to do as an artist but haven't yet?",
-                      ],
-                      "id": "00000204",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "00000202",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "There are paintings I thought of two years ago that I'm just now able to execute—my mind has to slowly engineer them, sometimes silently behind the scenes, like a program running in the background. Then one day it's ready.",
-                  ],
-                  "id": "00000208",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Beyond the basic tools, what things do you need in order to paint?",
-                      ],
-                      "id": "0000020d",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "0000020b",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Discipline, will, time.",
-                  ],
-                  "id": "00000211",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What do you do when you need a break from making art?",
-                      ],
-                      "id": "00000216",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "00000214",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "I recently got a puppy, who forces me to take more breaks. I like the walks.",
-                  ],
-                  "id": "0000021a",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What do you wear when you paint?",
-                      ],
-                      "id": "0000021f",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "0000021d",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "My favorite piece of clothing to wear in the studio is a boy's ranger vest, which I bought from a thrift store in Aspen.",
-                  ],
-                  "id": "00000223",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Who was the first artist that really blew your mind? And who was the most recent?",
-                      ],
-                      "id": "00000228",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "00000226",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "When I was about 17, I saw Georges Seurat's ",
-                    {
-                      "attributes": {},
-                      "children": [
-                        "A Sunday Afternoon on the Island of La Grande Jatte",
-                      ],
-                      "id": "0000022e",
-                      "type": "i",
-                    },
-                    " at the Art Institute of Chicago. I knew of it from books, but seeing it in person blew my mind. At that moment I fell in love with painting down to the material level. It was the first time that I truly understood painting beyond image. I saw that it was conceptual, experiential, and that depth of meaning worked far beyond a picture. Recently I visited the Alte Nationalgalerie, in Berlin, which holds masterpiece paintings from the Romantic period. There I saw mind-blowing Arnold Böcklin paintings. I'm thinking about those a lot right now.",
-                  ],
-                  "id": "0000022c",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What's the best advice you've ever received from another artist?",
-                      ],
-                      "id": "00000234",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "00000232",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Hands-down best advice, from my partner: “Learn to make small paintings.” This came in a particularly rough patch in my life. I was deeply struggling at every level. Learning to paint in reduced scale with reduced materials was a painful but great crucible for my work.",
-                  ],
-                  "id": "00000238",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "If you're at a party and a new acquaintance asks what your work is like, what do you say?",
-                      ],
-                      "id": "0000023d",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "0000023b",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "“Good.”",
-                  ],
-                  "id": "00000241",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000246",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "XXXXXXX",
-                      ],
-                      "id": "0000024b",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-caption",
-                      },
-                      "children": [
-                        "Smith's studio, on the fourth floor of a Williamsburg loft building, has a wall of windows and an island full of brushes and supplies in the center. “It's an incredible luxury to paint with natural light in N.Y.C.,” she says.",
-                      ],
-                      "id": "0000024e",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000244",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000254",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "XXXXXXX",
-                      ],
-                      "id": "00000259",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000252",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "0000025f",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "XXXXXXX. XXXXXXX, XXXXXXX, courtesy of Dario Lasagni/ Simone Subal Gallery",
-                      ],
-                      "id": "00000264",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "0000025d",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Joe Roberts",
-                  ],
-                  "id": "00000268",
-                  "type": "h2",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "0000026d",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                  ],
-                  "id": "0000026b",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Five-Minute Self-Portrait,",
-                      ],
-                      "id": "00000275",
-                      "type": "i",
-                    },
-                    " 2018",
-                  ],
-                  "id": "00000273",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "SAN FRANCISCO",
-                        {
-                          "attributes": {},
-                          "children": [],
-                          "id": "0000027d",
-                          "type": "br",
-                        },
-                        "b. 1976",
-                      ],
-                      "id": "0000027b",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "00000279",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000283",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "XXXXXXX",
-                      ],
-                      "id": "00000288",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000281",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "0000028e",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "XXXXXXX",
-                      ],
-                      "id": "00000293",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-caption",
-                      },
-                      "children": [
-                        "“My studio is just a tiny room in my house in the Mission District,” Roberts says. “It's filled with old magazines and junk and half-finished projects. I like staring at the giant redwood tree that grows outside.”",
-                      ],
-                      "id": "00000296",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "0000028c",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "0000029c",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "XXXXXXX",
-                      ],
-                      "id": "000002a1",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "0000029a",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        {
-                          "attributes": {},
-                          "children": [
-                            "BORN IN MADISON, WISCONSIN,",
-                          ],
-                          "id": "000002a9",
-                          "type": "small",
-                        },
-                      ],
-                      "id": "000002a7",
-                      "type": "b",
-                    },
-                    " Roberts takes inspiration from comic books, skateboarding, space exploration, and his experiences with psychedelics. Roberts, a.k.a. LSD World Peace, has collaborated with Supreme and designed graphics for GX1000, a skate brand based in San Francisco, where he works and lives.",
-                  ],
-                  "id": "000002a5",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        {
-                          "attributes": {},
-                          "children": [
-                            "GQ STYLE:",
-                          ],
-                          "id": "000002b2",
-                          "type": "small",
-                        },
-                        " How did you arrive at your painting style? What factors influenced your development most?",
-                      ],
-                      "id": "000002b0",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000002ae",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        {
-                          "attributes": {},
-                          "children": [
-                            "JOE ROBERTS:",
-                          ],
-                          "id": "000002bb",
-                          "type": "b",
-                        },
-                      ],
-                      "id": "000002b9",
-                      "type": "small",
-                    },
-                    " I have been learning how to paint for a million years, and I'm still not very good at it. I don't really have any expectations when I paint. It's more fun that way.",
-                  ],
-                  "id": "000002b7",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What is your latest body of work all about?",
-                      ],
-                      "id": "000002c2",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000002c0",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Trips. I went camping once a month for a year, and I ate mushrooms every time. I made a bunch of paintings about these experiences. Kinda my way of integrating my trips with my life.",
-                  ],
-                  "id": "000002c6",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What's something you'd like to do as an artist but haven't yet?",
-                      ],
-                      "id": "000002cb",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000002c9",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "I have made blueprints for a wish machine, and I would like to build it.",
-                  ],
-                  "id": "000002cf",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What do you do when you need a break from making art?",
-                      ],
-                      "id": "000002d4",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000002d2",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "I go on a walk with my dog, Kevin. Or I go skateboarding. Or go camping.",
-                  ],
-                  "id": "000002d8",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What do you wear when you paint?",
-                      ],
-                      "id": "000002dd",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000002db",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Just whatever clothes I'm wearing that day. Everything I have has paint on it somewhere.",
-                  ],
-                  "id": "000002e1",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Who was the first artist that really blew your mind? And who was the most recent?",
-                      ],
-                      "id": "000002e6",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000002e4",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "The first was my grandfather, Steve Vasy. He made all sorts of art. He made collages. He was a printmaker. He made things out of found objects. He taught me all sorts of things about art and collecting junk and how to see. Most recently, Tahiti Pehrson. I am drawn to Tahiti's work because it's pretty amazing—he makes these paper cutouts that are incredibly detailed and meticulous.",
-                  ],
-                  "id": "000002ea",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Beyond the basic tools, what things do you need in order to paint?",
-                      ],
-                      "id": "000002ef",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000002ed",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Not much. Maybe a glass of water and some headphones.",
-                  ],
-                  "id": "000002f3",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "What's the best advice you've ever received from another artist?",
-                      ],
-                      "id": "000002f8",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000002f6",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "“Breathe.”",
-                  ],
-                  "id": "000002fc",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "Who gave you that advice?",
-                      ],
-                      "id": "00000301",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "000002ff",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "The photographer that came to my studio to shoot me for you guys [Damien Maloney]. I guess I was holding my breath.",
-                  ],
-                  "id": "00000305",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    {
-                      "attributes": {},
-                      "children": [
-                        "If you're at a party and a new acquaintance asks what your work is like, what do you say?",
-                      ],
-                      "id": "0000030a",
-                      "type": "b",
-                    },
-                  ],
-                  "id": "00000308",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "“Amateur landscape painting.”",
-                  ],
-                  "id": "0000030e",
-                  "type": "p",
-                },
-                "
-",
-              ],
-              "id": "00000042",
-              "type": "body",
-            },
-            "
-",
-          ],
-          "id": "00000004",
-          "type": "article",
-        },
-        "
-",
-      ],
-      "id": "00000002",
+      "id": "B00000001",
+      "parents": [],
+      "selfClosing": false,
       "type": "message",
     },
-    "
-",
+    {
+      "attributes": {},
+      "id": "B00000002",
+      "parents": [
+        "message",
+      ],
+      "selfClosing": false,
+      "type": "article",
+    },
+    {
+      "attributes": {},
+      "id": "B00000003",
+      "parents": [
+        "message",
+        "article",
+      ],
+      "selfClosing": false,
+      "type": "head",
+    },
+    {
+      "attributes": {},
+      "id": "B00000004",
+      "parents": [
+        "message",
+        "article",
+        "head",
+      ],
+      "selfClosing": false,
+      "type": "title",
+    },
+    {
+      "attributes": {},
+      "id": "B00000005",
+      "parents": [
+        "message",
+        "article",
+        "head",
+      ],
+      "selfClosing": false,
+      "type": "description",
+    },
+    {
+      "attributes": {},
+      "id": "B00000006",
+      "parents": [
+        "message",
+        "article",
+        "head",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
+      "id": "B00000007",
+      "parents": [
+        "message",
+        "article",
+      ],
+      "selfClosing": false,
+      "type": "body",
+    },
+    {
+      "attributes": {
+        "class": "byline",
+      },
+      "id": "B00000008",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000009",
+      "parents": [
+        "message",
+        "article",
+        "body",
+        "p",
+      ],
+      "selfClosing": true,
+      "type": "br",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000a",
+      "parents": [
+        "message",
+        "article",
+        "body",
+        "p",
+      ],
+      "selfClosing": true,
+      "type": "br",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000b",
+      "parents": [
+        "message",
+        "article",
+        "body",
+        "p",
+      ],
+      "selfClosing": true,
+      "type": "br",
+    },
+    {
+      "attributes": {
+        "class": "deck",
+      },
+      "id": "B0000000c",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000d",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000e",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000f",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000010",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000011",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000012",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000013",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000014",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000015",
+      "parents": [
+        "message",
+        "article",
+        "body",
+        "p",
+      ],
+      "selfClosing": true,
+      "type": "br",
+    },
+    {
+      "attributes": {},
+      "id": "B00000016",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000017",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000018",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000019",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000001a",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000001b",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000001c",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000001d",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000001e",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000001f",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000020",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000021",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000022",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000023",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000024",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000025",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000026",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000027",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000028",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000029",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000002a",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000002b",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000002c",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000002d",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000002e",
+      "parents": [
+        "message",
+        "article",
+        "body",
+        "p",
+      ],
+      "selfClosing": true,
+      "type": "br",
+    },
+    {
+      "attributes": {},
+      "id": "B0000002f",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000030",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000031",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000032",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000033",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000034",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000035",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000036",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000037",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000038",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000039",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000003a",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000003b",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000003c",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000003d",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000003e",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000003f",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000040",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000041",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000042",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000043",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000044",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000045",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000046",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000047",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000048",
+      "parents": [
+        "message",
+        "article",
+        "body",
+        "p",
+      ],
+      "selfClosing": true,
+      "type": "br",
+    },
+    {
+      "attributes": {},
+      "id": "B00000049",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000004a",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000004b",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000004c",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000004d",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000004e",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000004f",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000050",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000051",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000052",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000053",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000054",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000055",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000056",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000057",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000058",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000059",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000005a",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000005b",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000005c",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000005d",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000005e",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000005f",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000060",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000061",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000062",
+      "parents": [
+        "message",
+        "article",
+        "body",
+        "p",
+      ],
+      "selfClosing": true,
+      "type": "br",
+    },
+    {
+      "attributes": {},
+      "id": "B00000063",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000064",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000065",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000066",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000067",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000068",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000069",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000006a",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000006b",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000006c",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000006d",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000006e",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000006f",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000070",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000071",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000072",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000073",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000074",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000075",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000076",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000077",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000078",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000079",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000007a",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000007b",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
+      "id": "B0000007c",
+      "parents": [
+        "message",
+        "article",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
+      "id": "B0000007d",
+      "parents": [
+        "message",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
+      "id": "B0000007e",
+      "parents": [],
+      "selfClosing": false,
+      "type": "text",
+    },
   ],
-  "id": "00000000",
-  "type": "root",
+  "marks": [
+    {
+      "attributes": {},
+      "id": "M00000000",
+      "range": "(8..15]",
+      "type": "-dc-identifier",
+    },
+    {
+      "attributes": {},
+      "id": "M00000001",
+      "range": "(29..36]",
+      "type": "-dc-creator",
+    },
+    {
+      "attributes": {},
+      "id": "M00000002",
+      "range": "(37..44]",
+      "type": "-dc-contributor",
+    },
+    {
+      "attributes": {},
+      "id": "M00000003",
+      "range": "(45..52]",
+      "type": "-dc-contributor",
+    },
+    {
+      "attributes": {},
+      "id": "M00000004",
+      "range": "(53..60]",
+      "type": "-dc-contributor",
+    },
+    {
+      "attributes": {},
+      "id": "M00000005",
+      "range": "(61..63]",
+      "type": "-prism-publicationname",
+    },
+    {
+      "attributes": {},
+      "id": "M00000006",
+      "range": "(64..73]",
+      "type": "-prism-issn",
+    },
+    {
+      "attributes": {},
+      "id": "M00000007",
+      "range": "(74..84]",
+      "type": "-dc-publisher",
+    },
+    {
+      "attributes": {},
+      "id": "M00000008",
+      "range": "(85..95]",
+      "type": "-prism-coverdate",
+    },
+    {
+      "attributes": {},
+      "id": "M00000009",
+      "range": "(96..117]",
+      "type": "-prism-coverdisplaydate",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000a",
+      "range": "(118..119]",
+      "type": "-prism-volume",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000b",
+      "range": "(120..121]",
+      "type": "-prism-number",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000c",
+      "range": "(122..124]",
+      "type": "-prism-startingpage",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000d",
+      "range": "(125..128]",
+      "type": "-prism-section",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000e",
+      "range": "(129..130]",
+      "type": "-dc-subject",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000f",
+      "range": "(447..451]",
+      "type": "-prism-wordcount",
+    },
+    {
+      "attributes": {},
+      "id": "M00000010",
+      "range": "(452..517]",
+      "type": "-prism-copyright",
+    },
+    {
+      "attributes": {},
+      "id": "M00000011",
+      "range": "(521..532]",
+      "type": "h1",
+    },
+    {
+      "attributes": {},
+      "id": "M00000012",
+      "range": "(931..934]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000013",
+      "range": "(935..935]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000014",
+      "range": "(936..957]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000015",
+      "range": "(961..964]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000016",
+      "range": "(965..965]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000017",
+      "range": "(966..987]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000018",
+      "range": "(991..994]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000019",
+      "range": "(995..995]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001a",
+      "range": "(996..1017]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001b",
+      "range": "(1021..1024]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001c",
+      "range": "(1025..1025]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001d",
+      "range": "(1026..1047]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001e",
+      "range": "(1051..1054]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001f",
+      "range": "(1055..1055]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000020",
+      "range": "(1056..1063]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000021",
+      "range": "(1065..1076]",
+      "type": "h2",
+    },
+    {
+      "attributes": {},
+      "id": "M00000022",
+      "range": "(1079..1082]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000023",
+      "range": "(1083..1083]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000024",
+      "range": "(1086..1112]",
+      "type": "i",
+    },
+    {
+      "attributes": {},
+      "id": "M00000025",
+      "range": "(1119..1135]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000026",
+      "range": "(1138..1141]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000027",
+      "range": "(1142..1142]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000028",
+      "range": "(1143..1150]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000029",
+      "range": "(1151..1356]",
+      "type": "-pam-caption",
+    },
+    {
+      "attributes": {},
+      "id": "M0000002a",
+      "range": "(1360..1363]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M0000002b",
+      "range": "(1364..1364]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M0000002c",
+      "range": "(1365..1450]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M0000002d",
+      "range": "(1453..1492]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000002e",
+      "range": "(1453..1492]",
+      "type": "small",
+    },
+    {
+      "attributes": {},
+      "id": "M00000030",
+      "range": "(1722..1731]",
+      "type": "small",
+    },
+    {
+      "attributes": {},
+      "id": "M0000002f",
+      "range": "(1722..1821]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000031",
+      "range": "(1823..1835]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000032",
+      "range": "(1823..1835]",
+      "type": "small",
+    },
+    {
+      "attributes": {},
+      "id": "M00000033",
+      "range": "(2231..2274]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000034",
+      "range": "(2365..2428]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000035",
+      "range": "(2464..2517]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000036",
+      "range": "(2605..2637]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000037",
+      "range": "(2692..2781]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000038",
+      "range": "(2823..2904]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000039",
+      "range": "(3218..3284]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000003a",
+      "range": "(3449..3513]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000003b",
+      "range": "(3586..3601]",
+      "type": "h2",
+    },
+    {
+      "attributes": {},
+      "id": "M0000003c",
+      "range": "(3604..3607]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M0000003d",
+      "range": "(3608..3608]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M0000003e",
+      "range": "(3611..3637]",
+      "type": "i",
+    },
+    {
+      "attributes": {},
+      "id": "M0000003f",
+      "range": "(3644..3662]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000040",
+      "range": "(3664..3683]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000041",
+      "range": "(3664..3683]",
+      "type": "small",
+    },
+    {
+      "attributes": {},
+      "id": "M00000042",
+      "range": "(3990..4000]",
+      "type": "i",
+    },
+    {
+      "attributes": {},
+      "id": "M00000044",
+      "range": "(4051..4060]",
+      "type": "small",
+    },
+    {
+      "attributes": {},
+      "id": "M00000043",
+      "range": "(4051..4150]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000046",
+      "range": "(4152..4168]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000045",
+      "range": "(4152..4168]",
+      "type": "small",
+    },
+    {
+      "attributes": {},
+      "id": "M00000047",
+      "range": "(4843..4886]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000048",
+      "range": "(4930..4936]",
+      "type": "i",
+    },
+    {
+      "attributes": {},
+      "id": "M00000049",
+      "range": "(5396..5459]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000004a",
+      "range": "(5826..5879]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000004b",
+      "range": "(6086..6089]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M0000004c",
+      "range": "(6090..6090]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M0000004d",
+      "range": "(6091..6098]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M0000004e",
+      "range": "(6099..6324]",
+      "type": "-pam-caption",
+    },
+    {
+      "attributes": {},
+      "id": "M0000004f",
+      "range": "(6328..6331]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000050",
+      "range": "(6332..6332]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000051",
+      "range": "(6333..6340]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000052",
+      "range": "(6344..6347]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000053",
+      "range": "(6348..6348]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000054",
+      "range": "(6349..6356]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000055",
+      "range": "(6359..6391]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000056",
+      "range": "(6642..6723]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000057",
+      "range": "(7161..7227]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000058",
+      "range": "(7509..7573]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000059",
+      "range": "(7956..8045]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000005a",
+      "range": "(8164..8179]",
+      "type": "h2",
+    },
+    {
+      "attributes": {},
+      "id": "M0000005b",
+      "range": "(8182..8185]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M0000005c",
+      "range": "(8186..8186]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M0000005d",
+      "range": "(8189..8215]",
+      "type": "i",
+    },
+    {
+      "attributes": {},
+      "id": "M0000005e",
+      "range": "(8222..8238]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000060",
+      "range": "(8240..8255]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000005f",
+      "range": "(8240..8255]",
+      "type": "small",
+    },
+    {
+      "attributes": {},
+      "id": "M00000062",
+      "range": "(8604..8613]",
+      "type": "small",
+    },
+    {
+      "attributes": {},
+      "id": "M00000061",
+      "range": "(8604..8703]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000063",
+      "range": "(8705..8721]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000064",
+      "range": "(8705..8721]",
+      "type": "small",
+    },
+    {
+      "attributes": {},
+      "id": "M00000065",
+      "range": "(9107..9150]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000066",
+      "range": "(9448..9511]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000067",
+      "range": "(9737..9803]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000068",
+      "range": "(9830..9883]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000069",
+      "range": "(9963..9995]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000006a",
+      "range": "(10119..10200]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000006b",
+      "range": "(10246..10297]",
+      "type": "i",
+    },
+    {
+      "attributes": {},
+      "id": "M0000006c",
+      "range": "(10844..10908]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000006d",
+      "range": "(11181..11270]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000006e",
+      "range": "(11282..11285]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M0000006f",
+      "range": "(11286..11286]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000070",
+      "range": "(11287..11294]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000071",
+      "range": "(11295..11520]",
+      "type": "-pam-caption",
+    },
+    {
+      "attributes": {},
+      "id": "M00000072",
+      "range": "(11524..11527]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000073",
+      "range": "(11528..11528]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000074",
+      "range": "(11529..11536]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000075",
+      "range": "(11540..11543]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000076",
+      "range": "(11544..11544]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000077",
+      "range": "(11545..11619]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000078",
+      "range": "(11621..11632]",
+      "type": "h2",
+    },
+    {
+      "attributes": {},
+      "id": "M00000079",
+      "range": "(11635..11638]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M0000007a",
+      "range": "(11639..11639]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M0000007b",
+      "range": "(11642..11668]",
+      "type": "i",
+    },
+    {
+      "attributes": {},
+      "id": "M0000007c",
+      "range": "(11675..11696]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000007d",
+      "range": "(11699..11702]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M0000007e",
+      "range": "(11703..11703]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M0000007f",
+      "range": "(11704..11711]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000080",
+      "range": "(11715..11718]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000081",
+      "range": "(11719..11719]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000082",
+      "range": "(11720..11727]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000083",
+      "range": "(11728..11941]",
+      "type": "-pam-caption",
+    },
+    {
+      "attributes": {},
+      "id": "M00000084",
+      "range": "(11945..11948]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000085",
+      "range": "(11949..11949]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000086",
+      "range": "(11950..11957]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000087",
+      "range": "(11960..11987]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000088",
+      "range": "(11960..11987]",
+      "type": "small",
+    },
+    {
+      "attributes": {},
+      "id": "M0000008a",
+      "range": "(12267..12276]",
+      "type": "small",
+    },
+    {
+      "attributes": {},
+      "id": "M00000089",
+      "range": "(12267..12366]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000008c",
+      "range": "(12368..12380]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000008b",
+      "range": "(12368..12380]",
+      "type": "small",
+    },
+    {
+      "attributes": {},
+      "id": "M0000008d",
+      "range": "(12547..12590]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000008e",
+      "range": "(12776..12839]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M0000008f",
+      "range": "(12915..12968]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000090",
+      "range": "(13044..13076]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000091",
+      "range": "(13168..13249]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000092",
+      "range": "(13636..13702]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000093",
+      "range": "(13759..13823]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000094",
+      "range": "(13837..13862]",
+      "type": "b",
+    },
+    {
+      "attributes": {},
+      "id": "M00000095",
+      "range": "(13981..14070]",
+      "type": "b",
+    },
+  ],
+  "text": "￼
+￼
+￼
+￼
+XXXXXXX
+￼Fresh Paint
+XXXXXXX
+XXXXXXX
+XXXXXXX
+XXXXXXX
+GQ
+2471-5393
+Condé Nast
+2018-11-13
+GQ Style Holiday 2018
+3
+3
+90
+Art
+ 
+￼FOR A WHILE THERE, PAINTING FELL OUT OF STYLE IN AN ART WORLD THAT FAVORED PERFORMANCE, VIDEO, AND INSTALLATIONS. BUT ACRYLIC ON CANVAS IS BACK, BABY—SO WE VISITED FOUR HIGHLY ORIGINAL PAINTERS, PHOTOGRAPHED THEM IN THEIR STUDIOS, THEN ASKED THEM TO COMPLETE AN E-MAIL QUESTIONNAIRE—AND DOODLE US A SELF-PORTRAIT.￼
+2424
+COPYRIGHT ©2018 THE CONDÉ NAST PUBLICATIONS. ALL RIGHTS RESERVED.
+
+￼
+FRESH PAINT
+￼By XXXXXXX￼Photographs by XXXXXXX￼Photographs by XXXXXXX￼Photographs by XXXXXXX
+￼FOR A WHILE THERE, PAINTING FELL OUT OF STYLE IN AN ART WORLD THAT FAVORED PERFORMANCE, VIDEO, AND INSTALLATIONS. BUT ACRYLIC ON CANVAS IS BACK, BABY—SO WE VISITED FOUR HIGHLY ORIGINAL PAINTERS, PHOTOGRAPHED THEM IN THEIR STUDIOS, THEN ASKED THEM TO COMPLETE AN E-MAIL QUESTIONNAIRE—AND DOODLE US A SELF-PORTRAIT.
+￼
+psd
+
+Photograph by XXXXXXX
+
+￼
+psd
+
+Photograph by XXXXXXX
+
+￼
+psd
+
+Photograph by XXXXXXX
+
+￼
+psd
+
+Photograph by XXXXXXX
+
+￼
+psd
+
+XXXXXXX
+
+Robert Nava
+￼
+psd
+
+
+￼Five-Minute Self-Portrait, 2018
+￼BROOKLYN￼b. 1985
+￼
+psd
+
+XXXXXXX
+The East Williamsburg loft building where Nava lives and works is packed with musicians, filmmakers, and other artists. “I like that you can be loud here and the rooftop for the view and big sky,” he says.
+
+￼
+psd
+
+XXXXXXX. Robert Nava, Red Tooth, courtesy of Stan Narten/Sorry We're Closed, Brussels
+
+￼NAVA'S PAINTINGS OF PRIMORDIAL MONSTERS and myths balance ceremonial seriousness with childlike play. Originally from East Chicago, Indiana, he received an M.F.A. from Yale University before moving to Brooklyn, where we caught up with him while at work in his studio.
+￼GQ STYLE: How did you arrive at your painting style? What factors influenced your development most?
+￼ROBERT NAVA: Drawing every morning, trying to keep up with my imagination. Looking at a lot of ancient art, mainly Sumerian, Egyptian, Mayan. The mandala. Cave painting. The older artworks have a big impact, and I'm able to see the amount of work put into them, and they feel like they are timeless to a degree. But also they contain so much mystery. There's another level of mindfulness to “care” in them.
+￼What is your latest body of work all about?
+￼Making new myths. Trying to make monsters, angels, ghosts, putting an energy into them.
+￼What's something you'd like to do as an artist but haven't yet?
+￼Make large sculpture with metal.
+￼What do you do when you need a break from making art?
+￼Hang with my cat, Jumanji. Go to rooftops. The beach. Find some live music to enjoy.
+￼What do you wear when you paint?
+￼Usually shorts and headphones. The less the better.
+￼If you're at a party and a new acquaintance asks what your work is like, what do you say?
+￼I try to show a web page or Instagram.
+￼Who was the first artist that really blew your mind? And who was the most recent?
+￼Van Gogh and Huma Bhabha. Van Gogh: The soul and application of paint. The fearlessness. The paint is very alive—those paintings have an honesty that cannot be denied. Huma Bhabha: An engagement with the realness in materials with immense weight and impact—her works are very “in your face,” with a raw energy.
+￼Beyond the basic tools, what things do you need in order to paint?
+￼Loud music. There are so many artists and moods, but lately: electronic music, often techno, house, disco. Anything that takes you on a journey for hours on end.
+￼What's the best advice you've ever received from another artist?
+￼“There are no mistakes,” from my first-grade art teacher, Mrs. Shaver.
+Devan Shimoyama
+￼
+psd
+
+
+￼Five-Minute Self-Portrait, 2018
+￼PITTSBURGH￼b. 1989
+￼PHILADELPHIA NATIVE Shimoyama—also a Yale M.F.A. graduate—is now based in Pittsburgh, where he teaches at Carnegie Mellon University. His paintings borrow materials from drag culture—glitter, feathers, and rhinestones—and explore issues related to race, masculinity, and illusions of wealth. His debut solo museum exhibition, Cry, Baby, is at the Andy Warhol Museum through March 2019.
+￼GQ STYLE: How did you arrive at your painting style? What factors influenced your development most?
+￼DEVAN SHIMOYAMA: My painting style came about from my love of experimenting with all kinds of materials, drag culture, and fashion. I remember when I was first starting to paint, I was fascinated by how unconventional painting materials would mix together to create these psychedelic, shimmering encrusted spills. I'd play around with spray paint, quick-dry enamel, and fabric dye. Those eventually led to my interest in other unconventional painting materials that are much more in line with what drag performers use to get a look together, like rhinestones, glitter, feathers, et cetera, which they're using to create the illusion and fantasy of a wealthy, beautiful fictional character.
+￼What is your latest body of work all about?
+￼The last solo exhibition I had was titled Sweet, which was exploring the toxic masculinity of black barbershops. More recently, I've begun a body of work where I am depicting black individuals tending to their homes and thinking about the importance of black ownership, whether that ownership is businesses, properties, et cetera. I just have been thinking about the importance of people of color actually being able to have more agency and not become such easy targets for displacement and gentrification.
+￼What's something you'd like to do as an artist but haven't yet?
+￼I would love to actually collaborate with a fashion designer and create a line. I love fashion so much, and I would be completely invested in creating everything, even creating custom fabrics and accessories. I think that designers like Kerby Jean-Raymond from Pyer Moss have found a really nuanced way to intersect art, activism, and fashion in such a smart way.
+￼What do you do when you need a break from making art?
+￼I need mindless activity. I hang out with my two dogs (two Cavalier King Charles spaniels, named River and Bowie), or I play mindless games like Stardew Valley or watch guilty-pleasure reality-TV shows.
+￼
+psd
+
+XXXXXXX
+Shimoyama's studio on campus at Carnegie Mellon is located down the hall from the university's woodshop, laser cutters, and printshop, which, he says, “allows me to be able to open up my multidisciplinary practice with ease.”
+
+￼
+psd
+
+XXXXXXX
+
+￼
+psd
+
+XXXXXXX
+
+￼What do you wear when you paint?
+￼I normally wear either a pair of denim cutoff shorts and a tank top or my bright red Dickies short-sleeve coveralls. I also always wear my Blundstone Chelsea boots as my painting shoes. They're covered in all kinds of splattered paint and glitter.
+￼Who was the first artist that really blew your mind? And who was the most recent?
+￼Wangechi Mutu is the first artist that really blew my mind. I was completely fascinated by her use of ink and collage to make these explosive, hybridized characters that were so indomitable in spirit and strength. Most recently, my best friend, Haley Josephs, has blown my mind pretty consistently with her new work. The colors, the power in the women she's depicting, and the fantastical reality she creates never fail to impress me.
+￼Beyond the basic tools, what things do you need in order to paint?
+￼I need to always have jewelry, glitter, rhinestones, and fabric, but also I need to listen to something while I'm working. Depending on what I'm working on, I need to play a good album that matches my mood—currently listening to Kelela, SZA, Blood Orange, and Aminé on rotation.
+￼What's the best advice you've ever received from another artist?
+￼Josephine Halvorson gave me some of my best studio visits while in grad school at Yale, and I remember her telling me that she could tell when my work was coming from a place of love and talking about love and that there was strength in that. I've kept that in mind ever since, always making sure to make art from something real and true and significant and from a place of love.
+￼If you're at a party and a new acquaintance asks what your work is like, what do you say?
+￼I'd say that I make mythological, epic fantasy-figure paintings with drag-queen materials. That's my elevator pitch!
+Emily Mae Smith
+￼
+psd
+
+
+￼Five-Minute Self-Portrait, 2018
+￼BROOKLYN￼b. 1979
+￼BORN IN AUSTIN, Smith paints cartoonish figures and surreal scenarios in photo-realistic detail, all of it oozing with sensuality and stark feminine energy. We caught up with Smith at her studio in Brooklyn as she prepared for a show at Galerie Perrotin in Manhattan and for her first solo museum show, which opens at Le Consortium in Dijon, France, in November.
+￼GQ STYLE: How did you arrive at your painting style? What factors influenced your development most?
+￼EMILY MAE SMITH: Learning what to leave out and how to do just enough—to not over-do—was very important. That comes with experience and practice. I have been painting with the same materials for 20 years. A lot of people like to discuss their childhood as being formative, but I prefer to emphasize the experiences of my adult life. As a woman, my point of view has been radicalized during this time.
+￼What is your latest body of work all about?
+￼An anthropomorphic broom appears in a lot of my paintings. Its figure forms a kind of totem: an object imbued with a special power beyond its literal form. These brooms are tools for new potentialities, occupying and distorting historical compositions, claiming space for feminine subjectivity.
+￼What's something you'd like to do as an artist but haven't yet?
+￼There are paintings I thought of two years ago that I'm just now able to execute—my mind has to slowly engineer them, sometimes silently behind the scenes, like a program running in the background. Then one day it's ready.
+￼Beyond the basic tools, what things do you need in order to paint?
+￼Discipline, will, time.
+￼What do you do when you need a break from making art?
+￼I recently got a puppy, who forces me to take more breaks. I like the walks.
+￼What do you wear when you paint?
+￼My favorite piece of clothing to wear in the studio is a boy's ranger vest, which I bought from a thrift store in Aspen.
+￼Who was the first artist that really blew your mind? And who was the most recent?
+￼When I was about 17, I saw Georges Seurat's A Sunday Afternoon on the Island of La Grande Jatte at the Art Institute of Chicago. I knew of it from books, but seeing it in person blew my mind. At that moment I fell in love with painting down to the material level. It was the first time that I truly understood painting beyond image. I saw that it was conceptual, experiential, and that depth of meaning worked far beyond a picture. Recently I visited the Alte Nationalgalerie, in Berlin, which holds masterpiece paintings from the Romantic period. There I saw mind-blowing Arnold Böcklin paintings. I'm thinking about those a lot right now.
+￼What's the best advice you've ever received from another artist?
+￼Hands-down best advice, from my partner: “Learn to make small paintings.” This came in a particularly rough patch in my life. I was deeply struggling at every level. Learning to paint in reduced scale with reduced materials was a painful but great crucible for my work.
+￼If you're at a party and a new acquaintance asks what your work is like, what do you say?
+￼“Good.”
+￼
+psd
+
+XXXXXXX
+Smith's studio, on the fourth floor of a Williamsburg loft building, has a wall of windows and an island full of brushes and supplies in the center. “It's an incredible luxury to paint with natural light in N.Y.C.,” she says.
+
+￼
+psd
+
+XXXXXXX
+
+￼
+psd
+
+XXXXXXX. XXXXXXX, XXXXXXX, courtesy of Dario Lasagni/ Simone Subal Gallery
+
+Joe Roberts
+￼
+psd
+
+
+￼Five-Minute Self-Portrait, 2018
+￼SAN FRANCISCO￼b. 1976
+￼
+psd
+
+XXXXXXX
+
+￼
+psd
+
+XXXXXXX
+“My studio is just a tiny room in my house in the Mission District,” Roberts says. “It's filled with old magazines and junk and half-finished projects. I like staring at the giant redwood tree that grows outside.”
+
+￼
+psd
+
+XXXXXXX
+
+￼BORN IN MADISON, WISCONSIN, Roberts takes inspiration from comic books, skateboarding, space exploration, and his experiences with psychedelics. Roberts, a.k.a. LSD World Peace, has collaborated with Supreme and designed graphics for GX1000, a skate brand based in San Francisco, where he works and lives.
+￼GQ STYLE: How did you arrive at your painting style? What factors influenced your development most?
+￼JOE ROBERTS: I have been learning how to paint for a million years, and I'm still not very good at it. I don't really have any expectations when I paint. It's more fun that way.
+￼What is your latest body of work all about?
+￼Trips. I went camping once a month for a year, and I ate mushrooms every time. I made a bunch of paintings about these experiences. Kinda my way of integrating my trips with my life.
+￼What's something you'd like to do as an artist but haven't yet?
+￼I have made blueprints for a wish machine, and I would like to build it.
+￼What do you do when you need a break from making art?
+￼I go on a walk with my dog, Kevin. Or I go skateboarding. Or go camping.
+￼What do you wear when you paint?
+￼Just whatever clothes I'm wearing that day. Everything I have has paint on it somewhere.
+￼Who was the first artist that really blew your mind? And who was the most recent?
+￼The first was my grandfather, Steve Vasy. He made all sorts of art. He made collages. He was a printmaker. He made things out of found objects. He taught me all sorts of things about art and collecting junk and how to see. Most recently, Tahiti Pehrson. I am drawn to Tahiti's work because it's pretty amazing—he makes these paper cutouts that are incredibly detailed and meticulous.
+￼Beyond the basic tools, what things do you need in order to paint?
+￼Not much. Maybe a glass of water and some headphones.
+￼What's the best advice you've ever received from another artist?
+￼“Breathe.”
+￼Who gave you that advice?
+￼The photographer that came to my studio to shoot me for you guys [Damien Maloney]. I guess I was holding my breath.
+￼If you're at a party and a new acquaintance asks what your work is like, what do you say?
+￼“Amateur landscape painting.”￼
+￼
+￼
+￼
+",
 }
 `;
 
 exports[`@atjson/source-prism prism snapshots parses gq-fresh-paint.xml 2`] = `
 {
-  "annotations": [
+  "blocks": [
+    {
+      "attributes": {},
+      "id": "B00000000",
+      "parents": [],
+      "selfClosing": false,
+      "type": "text",
+    },
     {
       "attributes": {
-        "-atjson-reason": "<?xml>",
+        "level": 1,
       },
-      "end": 38,
-      "id": "00000001",
-      "start": 0,
-      "type": "-atjson-parse-token",
+      "id": "B00000001",
+      "parents": [],
+      "selfClosing": false,
+      "type": "heading",
     },
+    {
+      "attributes": {},
+      "id": "B00000002",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000003",
+      "parents": [
+        "paragraph",
+      ],
+      "selfClosing": true,
+      "type": "line-break",
+    },
+    {
+      "attributes": {},
+      "id": "B00000004",
+      "parents": [
+        "paragraph",
+      ],
+      "selfClosing": true,
+      "type": "line-break",
+    },
+    {
+      "attributes": {},
+      "id": "B00000005",
+      "parents": [
+        "paragraph",
+      ],
+      "selfClosing": true,
+      "type": "line-break",
+    },
+    {
+      "attributes": {},
+      "id": "B00000006",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {
+        "level": 2,
+      },
+      "id": "B00000007",
+      "parents": [],
+      "selfClosing": false,
+      "type": "heading",
+    },
+    {
+      "attributes": {},
+      "id": "B00000008",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000009",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000a",
+      "parents": [
+        "paragraph",
+      ],
+      "selfClosing": true,
+      "type": "line-break",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000b",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000c",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000d",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000e",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000f",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000010",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000011",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000012",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000013",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000014",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000015",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000016",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000017",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000018",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000019",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000001a",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000001b",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000001c",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000001d",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {
+        "level": 2,
+      },
+      "id": "B0000001e",
+      "parents": [],
+      "selfClosing": false,
+      "type": "heading",
+    },
+    {
+      "attributes": {},
+      "id": "B0000001f",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000020",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000021",
+      "parents": [
+        "paragraph",
+      ],
+      "selfClosing": true,
+      "type": "line-break",
+    },
+    {
+      "attributes": {},
+      "id": "B00000022",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000023",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000024",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000025",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000026",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000027",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000028",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000029",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000002a",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000002b",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000002c",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000002d",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000002e",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000002f",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000030",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000031",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000032",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000033",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000034",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {
+        "level": 2,
+      },
+      "id": "B00000035",
+      "parents": [],
+      "selfClosing": false,
+      "type": "heading",
+    },
+    {
+      "attributes": {},
+      "id": "B00000036",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000037",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000038",
+      "parents": [
+        "paragraph",
+      ],
+      "selfClosing": true,
+      "type": "line-break",
+    },
+    {
+      "attributes": {},
+      "id": "B00000039",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000003a",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000003b",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000003c",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000003d",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000003e",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000003f",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000040",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000041",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000042",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000043",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000044",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000045",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000046",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000047",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000048",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000049",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000004a",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000004b",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {
+        "level": 2,
+      },
+      "id": "B0000004c",
+      "parents": [],
+      "selfClosing": false,
+      "type": "heading",
+    },
+    {
+      "attributes": {},
+      "id": "B0000004d",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000004e",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000004f",
+      "parents": [
+        "paragraph",
+      ],
+      "selfClosing": true,
+      "type": "line-break",
+    },
+    {
+      "attributes": {},
+      "id": "B00000050",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000051",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000052",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000053",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000054",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000055",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000056",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000057",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000058",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000059",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000005a",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000005b",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000005c",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000005d",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000005e",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000005f",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000060",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000061",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000062",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000063",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000064",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000065",
+      "parents": [],
+      "selfClosing": false,
+      "type": "text",
+    },
+  ],
+  "marks": [
     {
       "attributes": {
         "-pam-xmlns": "http://www.w3.org/1999/xhtml",
       },
-      "end": 14096,
-      "id": "00000002",
-      "start": 39,
+      "id": "M00000000",
+      "range": "(2..12254]",
       "type": "-pam-message",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<pam:message>",
-      },
-      "end": 578,
-      "id": "00000003",
-      "start": 39,
-      "type": "-atjson-parse-token",
-    },
-    {
       "attributes": {},
-      "end": 14081,
-      "id": "00000004",
-      "start": 579,
+      "id": "M00000001",
+      "range": "(3..12253]",
       "type": "-pam-article",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<pam:article>",
-      },
-      "end": 609,
-      "id": "00000005",
-      "start": 579,
-      "type": "-atjson-parse-token",
-    },
-    {
       "attributes": {},
-      "end": 14066,
-      "id": "00000006",
-      "start": 611,
+      "id": "M00000002",
+      "range": "(5..12252]",
       "type": "-html-body",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<body>",
-      },
-      "end": 617,
-      "id": "00000007",
-      "start": 611,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-offset-level": 1,
-      },
-      "end": 638,
-      "id": "00000008",
-      "start": 618,
-      "type": "-offset-heading",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<h1>",
-      },
-      "end": 622,
-      "id": "00000009",
-      "start": 618,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</h1>",
-      },
-      "end": 638,
-      "id": "0000000a",
-      "start": 633,
-      "type": "-atjson-parse-token",
+      "attributes": {},
+      "id": "M00000003",
+      "range": "(435..461]",
+      "type": "italic",
     },
     {
       "attributes": {},
-      "end": 752,
-      "id": "0000000b",
-      "start": 639,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 657,
-      "id": "0000000c",
-      "start": 639,
-      "type": "-atjson-parse-token",
+      "id": "M00000004",
+      "range": "(468..484]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 672,
-      "id": "0000000d",
-      "start": 667,
-      "type": "-offset-line-break",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<br/>",
-      },
-      "end": 672,
-      "id": "0000000e",
-      "start": 667,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 699,
-      "id": "0000000f",
-      "start": 694,
-      "type": "-offset-line-break",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<br/>",
-      },
-      "end": 699,
-      "id": "00000010",
-      "start": 694,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 726,
-      "id": "00000011",
-      "start": 721,
-      "type": "-offset-line-break",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<br/>",
-      },
-      "end": 726,
-      "id": "00000012",
-      "start": 721,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 752,
-      "id": "00000013",
-      "start": 748,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1086,
-      "id": "00000014",
-      "start": 753,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 769,
-      "id": "00000015",
-      "start": 753,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 1086,
-      "id": "00000016",
-      "start": 1082,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-offset-level": 2,
-      },
-      "end": 1112,
-      "id": "00000017",
-      "start": 1092,
-      "type": "-offset-heading",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<h2>",
-      },
-      "end": 1096,
-      "id": "00000018",
-      "start": 1092,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</h2>",
-      },
-      "end": 1112,
-      "id": "00000019",
-      "start": 1107,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1159,
-      "id": "0000001a",
-      "start": 1114,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 1117,
-      "id": "0000001b",
-      "start": 1114,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1150,
-      "id": "0000001c",
-      "start": 1117,
-      "type": "-offset-italic",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<i>",
-      },
-      "end": 1120,
-      "id": "0000001d",
-      "start": 1117,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</i>",
-      },
-      "end": 1150,
-      "id": "0000001e",
-      "start": 1146,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 1159,
-      "id": "0000001f",
-      "start": 1155,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1194,
-      "id": "00000020",
-      "start": 1160,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 1163,
-      "id": "00000021",
-      "start": 1160,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1190,
-      "id": "00000022",
-      "start": 1163,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 1166,
-      "id": "00000023",
-      "start": 1163,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1179,
-      "id": "00000024",
-      "start": 1174,
-      "type": "-offset-line-break",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<br/>",
-      },
-      "end": 1179,
-      "id": "00000025",
-      "start": 1174,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 1190,
-      "id": "00000026",
-      "start": 1186,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 1194,
-      "id": "00000027",
-      "start": 1190,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1493,
-      "id": "00000028",
-      "start": 1197,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 1200,
-      "id": "00000029",
-      "start": 1197,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1261,
-      "id": "0000002a",
-      "start": 1200,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 1203,
-      "id": "0000002b",
-      "start": 1200,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1257,
-      "id": "0000002c",
-      "start": 1203,
+      "id": "M00000006",
+      "range": "(488..527]",
       "type": "-html-small",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<small>",
-      },
-      "end": 1210,
-      "id": "0000002d",
-      "start": 1203,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</small>",
-      },
-      "end": 1257,
-      "id": "0000002e",
-      "start": 1249,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 1261,
-      "id": "0000002f",
-      "start": 1257,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 1493,
-      "id": "00000030",
-      "start": 1489,
-      "type": "-atjson-parse-token",
+      "attributes": {},
+      "id": "M00000005",
+      "range": "(488..527]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 1622,
-      "id": "00000031",
-      "start": 1494,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 1497,
-      "id": "00000032",
-      "start": 1494,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1618,
-      "id": "00000033",
-      "start": 1497,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 1500,
-      "id": "00000034",
-      "start": 1497,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1524,
-      "id": "00000035",
-      "start": 1500,
+      "id": "M00000008",
+      "range": "(757..766]",
       "type": "-html-small",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<small>",
-      },
-      "end": 1507,
-      "id": "00000036",
-      "start": 1500,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</small>",
-      },
-      "end": 1524,
-      "id": "00000037",
-      "start": 1516,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 1618,
-      "id": "00000038",
-      "start": 1614,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 1622,
-      "id": "00000039",
-      "start": 1618,
-      "type": "-atjson-parse-token",
+      "attributes": {},
+      "id": "M00000007",
+      "range": "(757..856]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 2058,
-      "id": "0000003a",
-      "start": 1623,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 1626,
-      "id": "0000003b",
-      "start": 1623,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1660,
-      "id": "0000003c",
-      "start": 1626,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 1629,
-      "id": "0000003d",
-      "start": 1626,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1656,
-      "id": "0000003e",
-      "start": 1629,
+      "id": "M0000000a",
+      "range": "(858..870]",
       "type": "-html-small",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<small>",
-      },
-      "end": 1636,
-      "id": "0000003f",
-      "start": 1629,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</small>",
-      },
-      "end": 1656,
-      "id": "00000040",
-      "start": 1648,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 1660,
-      "id": "00000041",
-      "start": 1656,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2058,
-      "id": "00000042",
-      "start": 2054,
-      "type": "-atjson-parse-token",
+      "attributes": {},
+      "id": "M00000009",
+      "range": "(858..870]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 2116,
-      "id": "00000043",
-      "start": 2059,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2062,
-      "id": "00000044",
-      "start": 2059,
-      "type": "-atjson-parse-token",
+      "id": "M0000000b",
+      "range": "(1266..1309]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 2112,
-      "id": "00000045",
-      "start": 2062,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 2065,
-      "id": "00000046",
-      "start": 2062,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 2112,
-      "id": "00000047",
-      "start": 2108,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2116,
-      "id": "00000048",
-      "start": 2112,
-      "type": "-atjson-parse-token",
+      "id": "M0000000c",
+      "range": "(1400..1463]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 2211,
-      "id": "00000049",
-      "start": 2117,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2120,
-      "id": "0000004a",
-      "start": 2117,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2211,
-      "id": "0000004b",
-      "start": 2207,
-      "type": "-atjson-parse-token",
+      "id": "M0000000d",
+      "range": "(1499..1552]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 2289,
-      "id": "0000004c",
-      "start": 2212,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2215,
-      "id": "0000004d",
-      "start": 2212,
-      "type": "-atjson-parse-token",
+      "id": "M0000000e",
+      "range": "(1640..1672]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 2285,
-      "id": "0000004e",
-      "start": 2215,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 2218,
-      "id": "0000004f",
-      "start": 2215,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 2285,
-      "id": "00000050",
-      "start": 2281,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2289,
-      "id": "00000051",
-      "start": 2285,
-      "type": "-atjson-parse-token",
+      "id": "M0000000f",
+      "range": "(1727..1816]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 2329,
-      "id": "00000052",
-      "start": 2290,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2293,
-      "id": "00000053",
-      "start": 2290,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2329,
-      "id": "00000054",
-      "start": 2325,
-      "type": "-atjson-parse-token",
+      "id": "M00000010",
+      "range": "(1858..1939]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 2397,
-      "id": "00000055",
-      "start": 2330,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2333,
-      "id": "00000056",
-      "start": 2330,
-      "type": "-atjson-parse-token",
+      "id": "M00000011",
+      "range": "(2253..2319]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 2393,
-      "id": "00000057",
-      "start": 2333,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 2336,
-      "id": "00000058",
-      "start": 2333,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 2393,
-      "id": "00000059",
-      "start": 2389,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2397,
-      "id": "0000005a",
-      "start": 2393,
-      "type": "-atjson-parse-token",
+      "id": "M00000012",
+      "range": "(2484..2548]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 2489,
-      "id": "0000005b",
-      "start": 2398,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2401,
-      "id": "0000005c",
-      "start": 2398,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2489,
-      "id": "0000005d",
-      "start": 2485,
-      "type": "-atjson-parse-token",
+      "id": "M00000013",
+      "range": "(2640..2666]",
+      "type": "italic",
     },
     {
       "attributes": {},
-      "end": 2536,
-      "id": "0000005e",
-      "start": 2490,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2493,
-      "id": "0000005f",
-      "start": 2490,
-      "type": "-atjson-parse-token",
+      "id": "M00000014",
+      "range": "(2673..2691]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 2532,
-      "id": "00000060",
-      "start": 2493,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 2496,
-      "id": "00000061",
-      "start": 2493,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 2532,
-      "id": "00000062",
-      "start": 2528,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2536,
-      "id": "00000063",
-      "start": 2532,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 2595,
-      "id": "00000064",
-      "start": 2537,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2540,
-      "id": "00000065",
-      "start": 2537,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2595,
-      "id": "00000066",
-      "start": 2591,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 2699,
-      "id": "00000067",
-      "start": 2596,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2599,
-      "id": "00000068",
-      "start": 2596,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 2695,
-      "id": "00000069",
-      "start": 2599,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 2602,
-      "id": "0000006a",
-      "start": 2599,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 2695,
-      "id": "0000006b",
-      "start": 2691,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2699,
-      "id": "0000006c",
-      "start": 2695,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 2745,
-      "id": "0000006d",
-      "start": 2700,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2703,
-      "id": "0000006e",
-      "start": 2700,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2745,
-      "id": "0000006f",
-      "start": 2741,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 2841,
-      "id": "00000070",
-      "start": 2746,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2749,
-      "id": "00000071",
-      "start": 2746,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 2837,
-      "id": "00000072",
-      "start": 2749,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 2752,
-      "id": "00000073",
-      "start": 2749,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 2837,
-      "id": "00000074",
-      "start": 2833,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2841,
-      "id": "00000075",
-      "start": 2837,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3159,
-      "id": "00000076",
-      "start": 2842,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2845,
-      "id": "00000077",
-      "start": 2842,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 3159,
-      "id": "00000078",
-      "start": 3155,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3240,
-      "id": "00000079",
-      "start": 3160,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 3163,
-      "id": "0000007a",
-      "start": 3160,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3236,
-      "id": "0000007b",
-      "start": 3163,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 3166,
-      "id": "0000007c",
-      "start": 3163,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 3236,
-      "id": "0000007d",
-      "start": 3232,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 3240,
-      "id": "0000007e",
-      "start": 3236,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3409,
-      "id": "0000007f",
-      "start": 3241,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 3244,
-      "id": "00000080",
-      "start": 3241,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 3409,
-      "id": "00000081",
-      "start": 3405,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3488,
-      "id": "00000082",
-      "start": 3410,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 3413,
-      "id": "00000083",
-      "start": 3410,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3484,
-      "id": "00000084",
-      "start": 3413,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 3416,
-      "id": "00000085",
-      "start": 3413,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 3484,
-      "id": "00000086",
-      "start": 3480,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 3488,
-      "id": "00000087",
-      "start": 3484,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3566,
-      "id": "00000088",
-      "start": 3489,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 3492,
-      "id": "00000089",
-      "start": 3489,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 3566,
-      "id": "0000008a",
-      "start": 3562,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-offset-level": 2,
-      },
-      "end": 3591,
-      "id": "0000008b",
-      "start": 3567,
-      "type": "-offset-heading",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<h2>",
-      },
-      "end": 3571,
-      "id": "0000008c",
-      "start": 3567,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</h2>",
-      },
-      "end": 3591,
-      "id": "0000008d",
-      "start": 3586,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3638,
-      "id": "0000008e",
-      "start": 3593,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 3596,
-      "id": "0000008f",
-      "start": 3593,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3629,
-      "id": "00000090",
-      "start": 3596,
-      "type": "-offset-italic",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<i>",
-      },
-      "end": 3599,
-      "id": "00000091",
-      "start": 3596,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</i>",
-      },
-      "end": 3629,
-      "id": "00000092",
-      "start": 3625,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 3638,
-      "id": "00000093",
-      "start": 3634,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3675,
-      "id": "00000094",
-      "start": 3639,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 3642,
-      "id": "00000095",
-      "start": 3639,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3671,
-      "id": "00000096",
-      "start": 3642,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 3645,
-      "id": "00000097",
-      "start": 3642,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3660,
-      "id": "00000098",
-      "start": 3655,
-      "type": "-offset-line-break",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<br/>",
-      },
-      "end": 3660,
-      "id": "00000099",
-      "start": 3655,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 3671,
-      "id": "0000009a",
-      "start": 3667,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 3675,
-      "id": "0000009b",
-      "start": 3671,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 4097,
-      "id": "0000009c",
-      "start": 3676,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 3679,
-      "id": "0000009d",
-      "start": 3676,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3720,
-      "id": "0000009e",
-      "start": 3679,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 3682,
-      "id": "0000009f",
-      "start": 3679,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3716,
-      "id": "000000a0",
-      "start": 3682,
+      "id": "M00000016",
+      "range": "(2693..2712]",
       "type": "-html-small",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<small>",
-      },
-      "end": 3689,
-      "id": "000000a1",
-      "start": 3682,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</small>",
-      },
-      "end": 3716,
-      "id": "000000a2",
-      "start": 3708,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 3720,
-      "id": "000000a3",
-      "start": 3716,
-      "type": "-atjson-parse-token",
+      "attributes": {},
+      "id": "M00000015",
+      "range": "(2693..2712]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 4044,
-      "id": "000000a4",
-      "start": 4027,
-      "type": "-offset-italic",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<i>",
-      },
-      "end": 4030,
-      "id": "000000a5",
-      "start": 4027,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</i>",
-      },
-      "end": 4044,
-      "id": "000000a6",
-      "start": 4040,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 4097,
-      "id": "000000a7",
-      "start": 4093,
-      "type": "-atjson-parse-token",
+      "id": "M00000017",
+      "range": "(3019..3029]",
+      "type": "italic",
     },
     {
       "attributes": {},
-      "end": 4226,
-      "id": "000000a8",
-      "start": 4098,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 4101,
-      "id": "000000a9",
-      "start": 4098,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 4222,
-      "id": "000000aa",
-      "start": 4101,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 4104,
-      "id": "000000ab",
-      "start": 4101,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 4128,
-      "id": "000000ac",
-      "start": 4104,
+      "id": "M00000019",
+      "range": "(3080..3089]",
       "type": "-html-small",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<small>",
-      },
-      "end": 4111,
-      "id": "000000ad",
-      "start": 4104,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</small>",
-      },
-      "end": 4128,
-      "id": "000000ae",
-      "start": 4120,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 4222,
-      "id": "000000af",
-      "start": 4218,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 4226,
-      "id": "000000b0",
-      "start": 4222,
-      "type": "-atjson-parse-token",
+      "attributes": {},
+      "id": "M00000018",
+      "range": "(3080..3179]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 4945,
-      "id": "000000b1",
-      "start": 4227,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 4230,
-      "id": "000000b2",
-      "start": 4227,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 4268,
-      "id": "000000b3",
-      "start": 4230,
+      "id": "M0000001a",
+      "range": "(3181..3197]",
       "type": "-html-small",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<small>",
-      },
-      "end": 4237,
-      "id": "000000b4",
-      "start": 4230,
-      "type": "-atjson-parse-token",
+      "attributes": {},
+      "id": "M0000001b",
+      "range": "(3181..3197]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 4260,
-      "id": "000000b5",
-      "start": 4237,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 4240,
-      "id": "000000b6",
-      "start": 4237,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 4260,
-      "id": "000000b7",
-      "start": 4256,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</small>",
-      },
-      "end": 4268,
-      "id": "000000b8",
-      "start": 4260,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 4945,
-      "id": "000000b9",
-      "start": 4941,
-      "type": "-atjson-parse-token",
+      "id": "M0000001c",
+      "range": "(3872..3915]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 5003,
-      "id": "000000ba",
-      "start": 4946,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 4949,
-      "id": "000000bb",
-      "start": 4946,
-      "type": "-atjson-parse-token",
+      "id": "M0000001d",
+      "range": "(3959..3965]",
+      "type": "italic",
     },
     {
       "attributes": {},
-      "end": 4999,
-      "id": "000000bc",
-      "start": 4949,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 4952,
-      "id": "000000bd",
-      "start": 4949,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 4999,
-      "id": "000000be",
-      "start": 4995,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 5003,
-      "id": "000000bf",
-      "start": 4999,
-      "type": "-atjson-parse-token",
+      "id": "M0000001e",
+      "range": "(4425..4488]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 5524,
-      "id": "000000c0",
-      "start": 5004,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 5007,
-      "id": "000000c1",
-      "start": 5004,
-      "type": "-atjson-parse-token",
+      "id": "M0000001f",
+      "range": "(4855..4908]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 5062,
-      "id": "000000c2",
-      "start": 5049,
-      "type": "-offset-italic",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<i>",
-      },
-      "end": 5052,
-      "id": "000000c3",
-      "start": 5049,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</i>",
-      },
-      "end": 5062,
-      "id": "000000c4",
-      "start": 5058,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 5524,
-      "id": "000000c5",
-      "start": 5520,
-      "type": "-atjson-parse-token",
+      "id": "M00000020",
+      "range": "(5117..5149]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 5602,
-      "id": "000000c6",
-      "start": 5525,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 5528,
-      "id": "000000c7",
-      "start": 5525,
-      "type": "-atjson-parse-token",
+      "id": "M00000021",
+      "range": "(5400..5481]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 5598,
-      "id": "000000c8",
-      "start": 5528,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 5531,
-      "id": "000000c9",
-      "start": 5528,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 5598,
-      "id": "000000ca",
-      "start": 5594,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 5602,
-      "id": "000000cb",
-      "start": 5598,
-      "type": "-atjson-parse-token",
+      "id": "M00000022",
+      "range": "(5919..5985]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 5973,
-      "id": "000000cc",
-      "start": 5603,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 5606,
-      "id": "000000cd",
-      "start": 5603,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 5973,
-      "id": "000000ce",
-      "start": 5969,
-      "type": "-atjson-parse-token",
+      "id": "M00000023",
+      "range": "(6267..6331]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 6041,
-      "id": "000000cf",
-      "start": 5974,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 5977,
-      "id": "000000d0",
-      "start": 5974,
-      "type": "-atjson-parse-token",
+      "id": "M00000024",
+      "range": "(6714..6803]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 6037,
-      "id": "000000d1",
-      "start": 5977,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 5980,
-      "id": "000000d2",
-      "start": 5977,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 6037,
-      "id": "000000d3",
-      "start": 6033,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 6041,
-      "id": "000000d4",
-      "start": 6037,
-      "type": "-atjson-parse-token",
+      "id": "M00000025",
+      "range": "(6941..6967]",
+      "type": "italic",
     },
     {
       "attributes": {},
-      "end": 6251,
-      "id": "000000d5",
-      "start": 6042,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 6045,
-      "id": "000000d6",
-      "start": 6042,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 6251,
-      "id": "000000d7",
-      "start": 6247,
-      "type": "-atjson-parse-token",
+      "id": "M00000026",
+      "range": "(6974..6990]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 6301,
-      "id": "000000d8",
-      "start": 6255,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 6258,
-      "id": "000000d9",
-      "start": 6255,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 6297,
-      "id": "000000da",
-      "start": 6258,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 6261,
-      "id": "000000db",
-      "start": 6258,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 6297,
-      "id": "000000dc",
-      "start": 6293,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 6301,
-      "id": "000000dd",
-      "start": 6297,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 6556,
-      "id": "000000de",
-      "start": 6302,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 6305,
-      "id": "000000df",
-      "start": 6302,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 6556,
-      "id": "000000e0",
-      "start": 6552,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 6652,
-      "id": "000000e1",
-      "start": 6557,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 6560,
-      "id": "000000e2",
-      "start": 6557,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 6648,
-      "id": "000000e3",
-      "start": 6560,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 6563,
-      "id": "000000e4",
-      "start": 6560,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 6648,
-      "id": "000000e5",
-      "start": 6644,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 6652,
-      "id": "000000e6",
-      "start": 6648,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 7094,
-      "id": "000000e7",
-      "start": 6653,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 6656,
-      "id": "000000e8",
-      "start": 6653,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 7094,
-      "id": "000000e9",
-      "start": 7090,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 7175,
-      "id": "000000ea",
-      "start": 7095,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 7098,
-      "id": "000000eb",
-      "start": 7095,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 7171,
-      "id": "000000ec",
-      "start": 7098,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 7101,
-      "id": "000000ed",
-      "start": 7098,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 7171,
-      "id": "000000ee",
-      "start": 7167,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 7175,
-      "id": "000000ef",
-      "start": 7171,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 7461,
-      "id": "000000f0",
-      "start": 7176,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 7179,
-      "id": "000000f1",
-      "start": 7176,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 7461,
-      "id": "000000f2",
-      "start": 7457,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 7540,
-      "id": "000000f3",
-      "start": 7462,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 7465,
-      "id": "000000f4",
-      "start": 7462,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 7536,
-      "id": "000000f5",
-      "start": 7465,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 7468,
-      "id": "000000f6",
-      "start": 7465,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 7536,
-      "id": "000000f7",
-      "start": 7532,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 7540,
-      "id": "000000f8",
-      "start": 7536,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 7927,
-      "id": "000000f9",
-      "start": 7541,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 7544,
-      "id": "000000fa",
-      "start": 7541,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 7927,
-      "id": "000000fb",
-      "start": 7923,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8031,
-      "id": "000000fc",
-      "start": 7928,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 7931,
-      "id": "000000fd",
-      "start": 7928,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8027,
-      "id": "000000fe",
-      "start": 7931,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 7934,
-      "id": "000000ff",
-      "start": 7931,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 8027,
-      "id": "00000100",
-      "start": 8023,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 8031,
-      "id": "00000101",
-      "start": 8027,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8155,
-      "id": "00000102",
-      "start": 8032,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 8035,
-      "id": "00000103",
-      "start": 8032,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 8155,
-      "id": "00000104",
-      "start": 8151,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-offset-level": 2,
-      },
-      "end": 8180,
-      "id": "00000105",
-      "start": 8156,
-      "type": "-offset-heading",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<h2>",
-      },
-      "end": 8160,
-      "id": "00000106",
-      "start": 8156,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</h2>",
-      },
-      "end": 8180,
-      "id": "00000107",
-      "start": 8175,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8227,
-      "id": "00000108",
-      "start": 8182,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 8185,
-      "id": "00000109",
-      "start": 8182,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8218,
-      "id": "0000010a",
-      "start": 8185,
-      "type": "-offset-italic",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<i>",
-      },
-      "end": 8188,
-      "id": "0000010b",
-      "start": 8185,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</i>",
-      },
-      "end": 8218,
-      "id": "0000010c",
-      "start": 8214,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 8227,
-      "id": "0000010d",
-      "start": 8223,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8262,
-      "id": "0000010e",
-      "start": 8228,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 8231,
-      "id": "0000010f",
-      "start": 8228,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8258,
-      "id": "00000110",
-      "start": 8231,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 8234,
-      "id": "00000111",
-      "start": 8231,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8247,
-      "id": "00000112",
-      "start": 8242,
-      "type": "-offset-line-break",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<br/>",
-      },
-      "end": 8247,
-      "id": "00000113",
-      "start": 8242,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 8258,
-      "id": "00000114",
-      "start": 8254,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 8262,
-      "id": "00000115",
-      "start": 8258,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8654,
-      "id": "00000116",
-      "start": 8263,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 8266,
-      "id": "00000117",
-      "start": 8263,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8303,
-      "id": "00000118",
-      "start": 8266,
+      "id": "M00000027",
+      "range": "(6992..7007]",
       "type": "-html-small",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<small>",
-      },
-      "end": 8273,
-      "id": "00000119",
-      "start": 8266,
-      "type": "-atjson-parse-token",
+      "attributes": {},
+      "id": "M00000028",
+      "range": "(6992..7007]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 8295,
-      "id": "0000011a",
-      "start": 8273,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 8276,
-      "id": "0000011b",
-      "start": 8273,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 8295,
-      "id": "0000011c",
-      "start": 8291,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</small>",
-      },
-      "end": 8303,
-      "id": "0000011d",
-      "start": 8295,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 8654,
-      "id": "0000011e",
-      "start": 8650,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8783,
-      "id": "0000011f",
-      "start": 8655,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 8658,
-      "id": "00000120",
-      "start": 8655,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8779,
-      "id": "00000121",
-      "start": 8658,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 8661,
-      "id": "00000122",
-      "start": 8658,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8685,
-      "id": "00000123",
-      "start": 8661,
+      "id": "M0000002a",
+      "range": "(7356..7365]",
       "type": "-html-small",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<small>",
-      },
-      "end": 8668,
-      "id": "00000124",
-      "start": 8661,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</small>",
-      },
-      "end": 8685,
-      "id": "00000125",
-      "start": 8677,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 8779,
-      "id": "00000126",
-      "start": 8775,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 8783,
-      "id": "00000127",
-      "start": 8779,
-      "type": "-atjson-parse-token",
+      "attributes": {},
+      "id": "M00000029",
+      "range": "(7356..7455]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 9213,
-      "id": "00000128",
-      "start": 8784,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 8787,
-      "id": "00000129",
-      "start": 8784,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8825,
-      "id": "0000012a",
-      "start": 8787,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 8790,
-      "id": "0000012b",
-      "start": 8787,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 8821,
-      "id": "0000012c",
-      "start": 8790,
+      "id": "M0000002c",
+      "range": "(7457..7473]",
       "type": "-html-small",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<small>",
-      },
-      "end": 8797,
-      "id": "0000012d",
-      "start": 8790,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</small>",
-      },
-      "end": 8821,
-      "id": "0000012e",
-      "start": 8813,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 8825,
-      "id": "0000012f",
-      "start": 8821,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 9213,
-      "id": "00000130",
-      "start": 9209,
-      "type": "-atjson-parse-token",
+      "attributes": {},
+      "id": "M0000002b",
+      "range": "(7457..7473]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 9271,
-      "id": "00000131",
-      "start": 9214,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 9217,
-      "id": "00000132",
-      "start": 9214,
-      "type": "-atjson-parse-token",
+      "id": "M0000002d",
+      "range": "(7859..7902]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 9267,
-      "id": "00000133",
-      "start": 9217,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 9220,
-      "id": "00000134",
-      "start": 9217,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 9267,
-      "id": "00000135",
-      "start": 9263,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 9271,
-      "id": "00000136",
-      "start": 9267,
-      "type": "-atjson-parse-token",
+      "id": "M0000002e",
+      "range": "(8200..8263]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 9573,
-      "id": "00000137",
-      "start": 9272,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 9275,
-      "id": "00000138",
-      "start": 9272,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 9573,
-      "id": "00000139",
-      "start": 9569,
-      "type": "-atjson-parse-token",
+      "id": "M0000002f",
+      "range": "(8489..8555]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 9651,
-      "id": "0000013a",
-      "start": 9574,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 9577,
-      "id": "0000013b",
-      "start": 9574,
-      "type": "-atjson-parse-token",
+      "id": "M00000030",
+      "range": "(8582..8635]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 9647,
-      "id": "0000013c",
-      "start": 9577,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 9580,
-      "id": "0000013d",
-      "start": 9577,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 9647,
-      "id": "0000013e",
-      "start": 9643,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 9651,
-      "id": "0000013f",
-      "start": 9647,
-      "type": "-atjson-parse-token",
+      "id": "M00000031",
+      "range": "(8715..8747]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 9881,
-      "id": "00000140",
-      "start": 9652,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 9655,
-      "id": "00000141",
-      "start": 9652,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 9881,
-      "id": "00000142",
-      "start": 9877,
-      "type": "-atjson-parse-token",
+      "id": "M00000032",
+      "range": "(8871..8952]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 9962,
-      "id": "00000143",
-      "start": 9882,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 9885,
-      "id": "00000144",
-      "start": 9882,
-      "type": "-atjson-parse-token",
+      "id": "M00000033",
+      "range": "(8998..9049]",
+      "type": "italic",
     },
     {
       "attributes": {},
-      "end": 9958,
-      "id": "00000145",
-      "start": 9885,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 9888,
-      "id": "00000146",
-      "start": 9885,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 9958,
-      "id": "00000147",
-      "start": 9954,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 9962,
-      "id": "00000148",
-      "start": 9958,
-      "type": "-atjson-parse-token",
+      "id": "M00000034",
+      "range": "(9596..9660]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 9993,
-      "id": "00000149",
-      "start": 9963,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 9966,
-      "id": "0000014a",
-      "start": 9963,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 9993,
-      "id": "0000014b",
-      "start": 9989,
-      "type": "-atjson-parse-token",
+      "id": "M00000035",
+      "range": "(9933..10022]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 10061,
-      "id": "0000014c",
-      "start": 9994,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 9997,
-      "id": "0000014d",
-      "start": 9994,
-      "type": "-atjson-parse-token",
+      "id": "M00000036",
+      "range": "(10050..10076]",
+      "type": "italic",
     },
     {
       "attributes": {},
-      "end": 10057,
-      "id": "0000014e",
-      "start": 9997,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 10000,
-      "id": "0000014f",
-      "start": 9997,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 10057,
-      "id": "00000150",
-      "start": 10053,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 10061,
-      "id": "00000151",
-      "start": 10057,
-      "type": "-atjson-parse-token",
+      "id": "M00000037",
+      "range": "(10083..10104]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 10145,
-      "id": "00000152",
-      "start": 10062,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 10065,
-      "id": "00000153",
-      "start": 10062,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 10145,
-      "id": "00000154",
-      "start": 10141,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 10192,
-      "id": "00000155",
-      "start": 10146,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 10149,
-      "id": "00000156",
-      "start": 10146,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 10188,
-      "id": "00000157",
-      "start": 10149,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 10152,
-      "id": "00000158",
-      "start": 10149,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 10188,
-      "id": "00000159",
-      "start": 10184,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 10192,
-      "id": "0000015a",
-      "start": 10188,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 10320,
-      "id": "0000015b",
-      "start": 10193,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 10196,
-      "id": "0000015c",
-      "start": 10193,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 10320,
-      "id": "0000015d",
-      "start": 10316,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 10416,
-      "id": "0000015e",
-      "start": 10321,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 10324,
-      "id": "0000015f",
-      "start": 10321,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 10412,
-      "id": "00000160",
-      "start": 10324,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 10327,
-      "id": "00000161",
-      "start": 10324,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 10412,
-      "id": "00000162",
-      "start": 10408,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 10416,
-      "id": "00000163",
-      "start": 10412,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11071,
-      "id": "00000164",
-      "start": 10417,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 10420,
-      "id": "00000165",
-      "start": 10417,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 10522,
-      "id": "00000166",
-      "start": 10464,
-      "type": "-offset-italic",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<i>",
-      },
-      "end": 10467,
-      "id": "00000167",
-      "start": 10464,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</i>",
-      },
-      "end": 10522,
-      "id": "00000168",
-      "start": 10518,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 11071,
-      "id": "00000169",
-      "start": 11067,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11150,
-      "id": "0000016a",
-      "start": 11072,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 11075,
-      "id": "0000016b",
-      "start": 11072,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11146,
-      "id": "0000016c",
-      "start": 11075,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 11078,
-      "id": "0000016d",
-      "start": 11075,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 11146,
-      "id": "0000016e",
-      "start": 11142,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 11150,
-      "id": "0000016f",
-      "start": 11146,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11427,
-      "id": "00000170",
-      "start": 11151,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 11154,
-      "id": "00000171",
-      "start": 11151,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 11427,
-      "id": "00000172",
-      "start": 11423,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11531,
-      "id": "00000173",
-      "start": 11428,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 11431,
-      "id": "00000174",
-      "start": 11428,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11527,
-      "id": "00000175",
-      "start": 11431,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 11434,
-      "id": "00000176",
-      "start": 11431,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 11527,
-      "id": "00000177",
-      "start": 11523,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 11531,
-      "id": "00000178",
-      "start": 11527,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11546,
-      "id": "00000179",
-      "start": 11532,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 11535,
-      "id": "0000017a",
-      "start": 11532,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 11546,
-      "id": "0000017b",
-      "start": 11542,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-offset-level": 2,
-      },
-      "end": 11570,
-      "id": "0000017c",
-      "start": 11550,
-      "type": "-offset-heading",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<h2>",
-      },
-      "end": 11554,
-      "id": "0000017d",
-      "start": 11550,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</h2>",
-      },
-      "end": 11570,
-      "id": "0000017e",
-      "start": 11565,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11617,
-      "id": "0000017f",
-      "start": 11572,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 11575,
-      "id": "00000180",
-      "start": 11572,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11608,
-      "id": "00000181",
-      "start": 11575,
-      "type": "-offset-italic",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<i>",
-      },
-      "end": 11578,
-      "id": "00000182",
-      "start": 11575,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</i>",
-      },
-      "end": 11608,
-      "id": "00000183",
-      "start": 11604,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 11617,
-      "id": "00000184",
-      "start": 11613,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11657,
-      "id": "00000185",
-      "start": 11618,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 11621,
-      "id": "00000186",
-      "start": 11618,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11653,
-      "id": "00000187",
-      "start": 11621,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 11624,
-      "id": "00000188",
-      "start": 11621,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11642,
-      "id": "00000189",
-      "start": 11637,
-      "type": "-offset-line-break",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<br/>",
-      },
-      "end": 11642,
-      "id": "0000018a",
-      "start": 11637,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 11653,
-      "id": "0000018b",
-      "start": 11649,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 11657,
-      "id": "0000018c",
-      "start": 11653,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11995,
-      "id": "0000018d",
-      "start": 11661,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 11664,
-      "id": "0000018e",
-      "start": 11661,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11713,
-      "id": "0000018f",
-      "start": 11664,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 11667,
-      "id": "00000190",
-      "start": 11664,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 11709,
-      "id": "00000191",
-      "start": 11667,
+      "id": "M00000039",
+      "range": "(10109..10136]",
       "type": "-html-small",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<small>",
-      },
-      "end": 11674,
-      "id": "00000192",
-      "start": 11667,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</small>",
-      },
-      "end": 11709,
-      "id": "00000193",
-      "start": 11701,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 11713,
-      "id": "00000194",
-      "start": 11709,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 11995,
-      "id": "00000195",
-      "start": 11991,
-      "type": "-atjson-parse-token",
+      "attributes": {},
+      "id": "M00000038",
+      "range": "(10109..10136]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 12124,
-      "id": "00000196",
-      "start": 11996,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 11999,
-      "id": "00000197",
-      "start": 11996,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 12120,
-      "id": "00000198",
-      "start": 11999,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 12002,
-      "id": "00000199",
-      "start": 11999,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 12026,
-      "id": "0000019a",
-      "start": 12002,
+      "id": "M0000003b",
+      "range": "(10416..10425]",
       "type": "-html-small",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<small>",
-      },
-      "end": 12009,
-      "id": "0000019b",
-      "start": 12002,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</small>",
-      },
-      "end": 12026,
-      "id": "0000019c",
-      "start": 12018,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 12120,
-      "id": "0000019d",
-      "start": 12116,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 12124,
-      "id": "0000019e",
-      "start": 12120,
-      "type": "-atjson-parse-token",
+      "attributes": {},
+      "id": "M0000003a",
+      "range": "(10416..10515]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 12331,
-      "id": "0000019f",
-      "start": 12125,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 12128,
-      "id": "000001a0",
-      "start": 12125,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 12162,
-      "id": "000001a1",
-      "start": 12128,
+      "id": "M0000003c",
+      "range": "(10517..10529]",
       "type": "-html-small",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<small>",
-      },
-      "end": 12135,
-      "id": "000001a2",
-      "start": 12128,
-      "type": "-atjson-parse-token",
+      "attributes": {},
+      "id": "M0000003d",
+      "range": "(10517..10529]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 12154,
-      "id": "000001a3",
-      "start": 12135,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 12138,
-      "id": "000001a4",
-      "start": 12135,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 12154,
-      "id": "000001a5",
-      "start": 12150,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</small>",
-      },
-      "end": 12162,
-      "id": "000001a6",
-      "start": 12154,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 12331,
-      "id": "000001a7",
-      "start": 12327,
-      "type": "-atjson-parse-token",
+      "id": "M0000003e",
+      "range": "(10696..10739]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 12389,
-      "id": "000001a8",
-      "start": 12332,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 12335,
-      "id": "000001a9",
-      "start": 12332,
-      "type": "-atjson-parse-token",
+      "id": "M0000003f",
+      "range": "(10925..10988]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 12385,
-      "id": "000001aa",
-      "start": 12335,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 12338,
-      "id": "000001ab",
-      "start": 12335,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 12385,
-      "id": "000001ac",
-      "start": 12381,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 12389,
-      "id": "000001ad",
-      "start": 12385,
-      "type": "-atjson-parse-token",
+      "id": "M00000040",
+      "range": "(11064..11117]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 12579,
-      "id": "000001ae",
-      "start": 12390,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 12393,
-      "id": "000001af",
-      "start": 12390,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 12579,
-      "id": "000001b0",
-      "start": 12575,
-      "type": "-atjson-parse-token",
+      "id": "M00000041",
+      "range": "(11193..11225]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 12657,
-      "id": "000001b1",
-      "start": 12580,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 12583,
-      "id": "000001b2",
-      "start": 12580,
-      "type": "-atjson-parse-token",
+      "id": "M00000042",
+      "range": "(11317..11398]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 12653,
-      "id": "000001b3",
-      "start": 12583,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 12586,
-      "id": "000001b4",
-      "start": 12583,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 12653,
-      "id": "000001b5",
-      "start": 12649,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 12657,
-      "id": "000001b6",
-      "start": 12653,
-      "type": "-atjson-parse-token",
+      "id": "M00000043",
+      "range": "(11785..11851]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 12737,
-      "id": "000001b7",
-      "start": 12658,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 12661,
-      "id": "000001b8",
-      "start": 12658,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 12737,
-      "id": "000001b9",
-      "start": 12733,
-      "type": "-atjson-parse-token",
+      "id": "M00000044",
+      "range": "(11908..11972]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 12805,
-      "id": "000001ba",
-      "start": 12738,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 12741,
-      "id": "000001bb",
-      "start": 12738,
-      "type": "-atjson-parse-token",
+      "id": "M00000045",
+      "range": "(11986..12011]",
+      "type": "bold",
     },
     {
       "attributes": {},
-      "end": 12801,
-      "id": "000001bc",
-      "start": 12741,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 12744,
-      "id": "000001bd",
-      "start": 12741,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 12801,
-      "id": "000001be",
-      "start": 12797,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 12805,
-      "id": "000001bf",
-      "start": 12801,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 12885,
-      "id": "000001c0",
-      "start": 12806,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 12809,
-      "id": "000001c1",
-      "start": 12806,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 12885,
-      "id": "000001c2",
-      "start": 12881,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 12932,
-      "id": "000001c3",
-      "start": 12886,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 12889,
-      "id": "000001c4",
-      "start": 12886,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 12928,
-      "id": "000001c5",
-      "start": 12889,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 12892,
-      "id": "000001c6",
-      "start": 12889,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 12928,
-      "id": "000001c7",
-      "start": 12924,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 12932,
-      "id": "000001c8",
-      "start": 12928,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 13028,
-      "id": "000001c9",
-      "start": 12933,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 12936,
-      "id": "000001ca",
-      "start": 12933,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 13028,
-      "id": "000001cb",
-      "start": 13024,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 13124,
-      "id": "000001cc",
-      "start": 13029,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 13032,
-      "id": "000001cd",
-      "start": 13029,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 13120,
-      "id": "000001ce",
-      "start": 13032,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 13035,
-      "id": "000001cf",
-      "start": 13032,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 13120,
-      "id": "000001d0",
-      "start": 13116,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 13124,
-      "id": "000001d1",
-      "start": 13120,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 13515,
-      "id": "000001d2",
-      "start": 13125,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 13128,
-      "id": "000001d3",
-      "start": 13125,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 13515,
-      "id": "000001d4",
-      "start": 13511,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 13596,
-      "id": "000001d5",
-      "start": 13516,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 13519,
-      "id": "000001d6",
-      "start": 13516,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 13592,
-      "id": "000001d7",
-      "start": 13519,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 13522,
-      "id": "000001d8",
-      "start": 13519,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 13592,
-      "id": "000001d9",
-      "start": 13588,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 13596,
-      "id": "000001da",
-      "start": 13592,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 13657,
-      "id": "000001db",
-      "start": 13597,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 13600,
-      "id": "000001dc",
-      "start": 13597,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 13657,
-      "id": "000001dd",
-      "start": 13653,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 13736,
-      "id": "000001de",
-      "start": 13658,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 13661,
-      "id": "000001df",
-      "start": 13658,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 13732,
-      "id": "000001e0",
-      "start": 13661,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 13664,
-      "id": "000001e1",
-      "start": 13661,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 13732,
-      "id": "000001e2",
-      "start": 13728,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 13736,
-      "id": "000001e3",
-      "start": 13732,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 13754,
-      "id": "000001e4",
-      "start": 13737,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 13740,
-      "id": "000001e5",
-      "start": 13737,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 13754,
-      "id": "000001e6",
-      "start": 13750,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 13794,
-      "id": "000001e7",
-      "start": 13755,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 13758,
-      "id": "000001e8",
-      "start": 13755,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 13790,
-      "id": "000001e9",
-      "start": 13758,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 13761,
-      "id": "000001ea",
-      "start": 13758,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 13790,
-      "id": "000001eb",
-      "start": 13786,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 13794,
-      "id": "000001ec",
-      "start": 13790,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 13917,
-      "id": "000001ed",
-      "start": 13795,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 13798,
-      "id": "000001ee",
-      "start": 13795,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 13917,
-      "id": "000001ef",
-      "start": 13913,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 14021,
-      "id": "000001f0",
-      "start": 13918,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 13921,
-      "id": "000001f1",
-      "start": 13918,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 14017,
-      "id": "000001f2",
-      "start": 13921,
-      "type": "-offset-bold",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<b>",
-      },
-      "end": 13924,
-      "id": "000001f3",
-      "start": 13921,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</b>",
-      },
-      "end": 14017,
-      "id": "000001f4",
-      "start": 14013,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 14021,
-      "id": "000001f5",
-      "start": 14017,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 14058,
-      "id": "000001f6",
-      "start": 14022,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 14025,
-      "id": "000001f7",
-      "start": 14022,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 14058,
-      "id": "000001f8",
-      "start": 14054,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</body>",
-      },
-      "end": 14066,
-      "id": "000001f9",
-      "start": 14059,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</pam:article>",
-      },
-      "end": 14081,
-      "id": "000001fa",
-      "start": 14067,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</pam:message>",
-      },
-      "end": 14096,
-      "id": "000001fb",
-      "start": 14082,
-      "type": "-atjson-parse-token",
+      "id": "M00000046",
+      "range": "(12130..12219]",
+      "type": "bold",
     },
   ],
-  "content": "<?xml version="1.0" encoding="utf-8"?>
-<pam:message xmlns:pam="http://prismstandard.org/namespaces/pam/2.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:pim="http://prismstandard.org/namespaces/pim/2.0/" xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/" xmlns:prl="http://prismstandard.org/namespaces/prl/2.0/" xmlns="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://prismstandard.org/namespaces/pam/2.0/ pam.xsd">
-<pam:article xml:lang="en-US">
-
-<body>
-<h1>FRESH PAINT</h1>
-<p class="byline">By XXXXXXX<br/>Photographs by XXXXXXX<br/>Photographs by XXXXXXX<br/>Photographs by XXXXXXX</p>
-<p class="deck">FOR A WHILE THERE, PAINTING FELL OUT OF STYLE IN AN ART WORLD THAT FAVORED PERFORMANCE, VIDEO, AND INSTALLATIONS. BUT ACRYLIC ON CANVAS IS BACK, BABY—SO WE VISITED FOUR HIGHLY ORIGINAL PAINTERS, PHOTOGRAPHED THEM IN THEIR STUDIOS, THEN ASKED THEM TO COMPLETE AN E-MAIL QUESTIONNAIRE—AND DOODLE US A SELF-PORTRAIT.</p>
+  "text": "￼
 
 
 
 
-
-<h2>Robert Nava</h2>
-
-<p><i>Five-Minute Self-Portrait,</i> 2018</p>
-<p><b>BROOKLYN<br/>b. 1985</b></p>
-
-
-<p><b><small>NAVA'S PAINTINGS OF PRIMORDIAL MONSTERS</small></b> and myths balance ceremonial seriousness with childlike play. Originally from East Chicago, Indiana, he received an M.F.A. from Yale University before moving to Brooklyn, where we caught up with him while at work in his studio.</p>
-<p><b><small>GQ STYLE:</small> How did you arrive at your painting style? What factors influenced your development most?</b></p>
-<p><b><small>ROBERT NAVA:</small></b> Drawing every morning, trying to keep up with my imagination. Looking at a lot of ancient art, mainly Sumerian, Egyptian, Mayan. The mandala. Cave painting. The older artworks have a big impact, and I'm able to see the amount of work put into them, and they feel like they are timeless to a degree. But also they contain so much mystery. There's another level of mindfulness to “care” in them.</p>
-<p><b>What is your latest body of work all about?</b></p>
-<p>Making new myths. Trying to make monsters, angels, ghosts, putting an energy into them.</p>
-<p><b>What's something you'd like to do as an artist but haven't yet?</b></p>
-<p>Make large sculpture with metal.</p>
-<p><b>What do you do when you need a break from making art?</b></p>
-<p>Hang with my cat, Jumanji. Go to rooftops. The beach. Find some live music to enjoy.</p>
-<p><b>What do you wear when you paint?</b></p>
-<p>Usually shorts and headphones. The less the better.</p>
-<p><b>If you're at a party and a new acquaintance asks what your work is like, what do you say?</b></p>
-<p>I try to show a web page or Instagram.</p>
-<p><b>Who was the first artist that really blew your mind? And who was the most recent?</b></p>
-<p>Van Gogh and Huma Bhabha. Van Gogh: The soul and application of paint. The fearlessness. The paint is very alive—those paintings have an honesty that cannot be denied. Huma Bhabha: An engagement with the realness in materials with immense weight and impact—her works are very “in your face,” with a raw energy.</p>
-<p><b>Beyond the basic tools, what things do you need in order to paint?</b></p>
-<p>Loud music. There are so many artists and moods, but lately: electronic music, often techno, house, disco. Anything that takes you on a journey for hours on end.</p>
-<p><b>What's the best advice you've ever received from another artist?</b></p>
-<p>“There are no mistakes,” from my first-grade art teacher, Mrs. Shaver.</p>
-<h2>Devan Shimoyama</h2>
-
-<p><i>Five-Minute Self-Portrait,</i> 2018</p>
-<p><b>PITTSBURGH<br/>b. 1989</b></p>
-<p><b><small>PHILADELPHIA NATIVE</small></b> Shimoyama—also a Yale M.F.A. graduate—is now based in Pittsburgh, where he teaches at Carnegie Mellon University. His paintings borrow materials from drag culture—glitter, feathers, and rhinestones—and explore issues related to race, masculinity, and illusions of wealth. His debut solo museum exhibition, <i>Cry, Baby,</i> is at the Andy Warhol Museum through March 2019.</p>
-<p><b><small>GQ STYLE:</small> How did you arrive at your painting style? What factors influenced your development most?</b></p>
-<p><small><b>DEVAN SHIMOYAMA:</b></small> My painting style came about from my love of experimenting with all kinds of materials, drag culture, and fashion. I remember when I was first starting to paint, I was fascinated by how unconventional painting materials would mix together to create these psychedelic, shimmering encrusted spills. I'd play around with spray paint, quick-dry enamel, and fabric dye. Those eventually led to my interest in other unconventional painting materials that are much more in line with what drag performers use to get a look together, like rhinestones, glitter, feathers, et cetera, which they're using to create the illusion and fantasy of a wealthy, beautiful fictional character.</p>
-<p><b>What is your latest body of work all about?</b></p>
-<p>The last solo exhibition I had was titled <i>Sweet,</i> which was exploring the toxic masculinity of black barbershops. More recently, I've begun a body of work where I am depicting black individuals tending to their homes and thinking about the importance of black ownership, whether that ownership is businesses, properties, et cetera. I just have been thinking about the importance of people of color actually being able to have more agency and not become such easy targets for displacement and gentrification.</p>
-<p><b>What's something you'd like to do as an artist but haven't yet?</b></p>
-<p>I would love to actually collaborate with a fashion designer and create a line. I love fashion so much, and I would be completely invested in creating everything, even creating custom fabrics and accessories. I think that designers like Kerby Jean-Raymond from Pyer Moss have found a really nuanced way to intersect art, activism, and fashion in such a smart way.</p>
-<p><b>What do you do when you need a break from making art?</b></p>
-<p>I need mindless activity. I hang out with my two dogs (two Cavalier King Charles spaniels, named River and Bowie), or I play mindless games like Stardew Valley or watch guilty-pleasure reality-TV shows.</p>
+￼FRESH PAINT
+￼By XXXXXXX￼Photographs by XXXXXXX￼Photographs by XXXXXXX￼Photographs by XXXXXXX
+￼FOR A WHILE THERE, PAINTING FELL OUT OF STYLE IN AN ART WORLD THAT FAVORED PERFORMANCE, VIDEO, AND INSTALLATIONS. BUT ACRYLIC ON CANVAS IS BACK, BABY—SO WE VISITED FOUR HIGHLY ORIGINAL PAINTERS, PHOTOGRAPHED THEM IN THEIR STUDIOS, THEN ASKED THEM TO COMPLETE AN E-MAIL QUESTIONNAIRE—AND DOODLE US A SELF-PORTRAIT.
 
 
 
-<p><b>What do you wear when you paint?</b></p>
-<p>I normally wear either a pair of denim cutoff shorts and a tank top or my bright red Dickies short-sleeve coveralls. I also always wear my Blundstone Chelsea boots as my painting shoes. They're covered in all kinds of splattered paint and glitter.</p>
-<p><b>Who was the first artist that really blew your mind? And who was the most recent?</b></p>
-<p>Wangechi Mutu is the first artist that really blew my mind. I was completely fascinated by her use of ink and collage to make these explosive, hybridized characters that were so indomitable in spirit and strength. Most recently, my best friend, Haley Josephs, has blown my mind pretty consistently with her new work. The colors, the power in the women she's depicting, and the fantastical reality she creates never fail to impress me.</p>
-<p><b>Beyond the basic tools, what things do you need in order to paint?</b></p>
-<p>I need to always have jewelry, glitter, rhinestones, and fabric, but also I need to listen to something while I'm working. Depending on what I'm working on, I need to play a good album that matches my mood—currently listening to Kelela, SZA, Blood Orange, and Aminé on rotation.</p>
-<p><b>What's the best advice you've ever received from another artist?</b></p>
-<p>Josephine Halvorson gave me some of my best studio visits while in grad school at Yale, and I remember her telling me that she could tell when my work was coming from a place of love and talking about love and that there was strength in that. I've kept that in mind ever since, always making sure to make art from something real and true and significant and from a place of love.</p>
-<p><b>If you're at a party and a new acquaintance asks what your work is like, what do you say?</b></p>
-<p>I'd say that I make mythological, epic fantasy-figure paintings with drag-queen materials. That's my elevator pitch!</p>
-<h2>Emily Mae Smith</h2>
-
-<p><i>Five-Minute Self-Portrait,</i> 2018</p>
-<p><b>BROOKLYN<br/>b. 1979</b></p>
-<p><small><b>BORN IN AUSTIN,</b></small> Smith paints cartoonish figures and surreal scenarios in photo-realistic detail, all of it oozing with sensuality and stark feminine energy. We caught up with Smith at her studio in Brooklyn as she prepared for a show at Galerie Perrotin in Manhattan and for her first solo museum show, which opens at Le Consortium in Dijon, France, in November.</p>
-<p><b><small>GQ STYLE:</small> How did you arrive at your painting style? What factors influenced your development most?</b></p>
-<p><b><small>EMILY MAE SMITH:</small></b> Learning what to leave out and how to do just enough—to not over-do—was very important. That comes with experience and practice. I have been painting with the same materials for 20 years. A lot of people like to discuss their childhood as being formative, but I prefer to emphasize the experiences of my adult life. As a woman, my point of view has been radicalized during this time.</p>
-<p><b>What is your latest body of work all about?</b></p>
-<p>An anthropomorphic broom appears in a lot of my paintings. Its figure forms a kind of totem: an object imbued with a special power beyond its literal form. These brooms are tools for new potentialities, occupying and distorting historical compositions, claiming space for feminine subjectivity.</p>
-<p><b>What's something you'd like to do as an artist but haven't yet?</b></p>
-<p>There are paintings I thought of two years ago that I'm just now able to execute—my mind has to slowly engineer them, sometimes silently behind the scenes, like a program running in the background. Then one day it's ready.</p>
-<p><b>Beyond the basic tools, what things do you need in order to paint?</b></p>
-<p>Discipline, will, time.</p>
-<p><b>What do you do when you need a break from making art?</b></p>
-<p>I recently got a puppy, who forces me to take more breaks. I like the walks.</p>
-<p><b>What do you wear when you paint?</b></p>
-<p>My favorite piece of clothing to wear in the studio is a boy's ranger vest, which I bought from a thrift store in Aspen.</p>
-<p><b>Who was the first artist that really blew your mind? And who was the most recent?</b></p>
-<p>When I was about 17, I saw Georges Seurat's <i>A Sunday Afternoon on the Island of La Grande Jatte</i> at the Art Institute of Chicago. I knew of it from books, but seeing it in person blew my mind. At that moment I fell in love with painting down to the material level. It was the first time that I truly understood painting beyond image. I saw that it was conceptual, experiential, and that depth of meaning worked far beyond a picture. Recently I visited the Alte Nationalgalerie, in Berlin, which holds masterpiece paintings from the Romantic period. There I saw mind-blowing Arnold Böcklin paintings. I'm thinking about those a lot right now.</p>
-<p><b>What's the best advice you've ever received from another artist?</b></p>
-<p>Hands-down best advice, from my partner: “Learn to make small paintings.” This came in a particularly rough patch in my life. I was deeply struggling at every level. Learning to paint in reduced scale with reduced materials was a painful but great crucible for my work.</p>
-<p><b>If you're at a party and a new acquaintance asks what your work is like, what do you say?</b></p>
-<p>“Good.”</p>
 
 
+￼Robert Nava
 
-<h2>Joe Roberts</h2>
-
-<p><i>Five-Minute Self-Portrait,</i> 2018</p>
-<p><b>SAN FRANCISCO<br/>b. 1976</b></p>
-
+￼Five-Minute Self-Portrait, 2018
+￼BROOKLYN￼b. 1985
 
 
-<p><b><small>BORN IN MADISON, WISCONSIN,</small></b> Roberts takes inspiration from comic books, skateboarding, space exploration, and his experiences with psychedelics. Roberts, a.k.a. LSD World Peace, has collaborated with Supreme and designed graphics for GX1000, a skate brand based in San Francisco, where he works and lives.</p>
-<p><b><small>GQ STYLE:</small> How did you arrive at your painting style? What factors influenced your development most?</b></p>
-<p><small><b>JOE ROBERTS:</b></small> I have been learning how to paint for a million years, and I'm still not very good at it. I don't really have any expectations when I paint. It's more fun that way.</p>
-<p><b>What is your latest body of work all about?</b></p>
-<p>Trips. I went camping once a month for a year, and I ate mushrooms every time. I made a bunch of paintings about these experiences. Kinda my way of integrating my trips with my life.</p>
-<p><b>What's something you'd like to do as an artist but haven't yet?</b></p>
-<p>I have made blueprints for a wish machine, and I would like to build it.</p>
-<p><b>What do you do when you need a break from making art?</b></p>
-<p>I go on a walk with my dog, Kevin. Or I go skateboarding. Or go camping.</p>
-<p><b>What do you wear when you paint?</b></p>
-<p>Just whatever clothes I'm wearing that day. Everything I have has paint on it somewhere.</p>
-<p><b>Who was the first artist that really blew your mind? And who was the most recent?</b></p>
-<p>The first was my grandfather, Steve Vasy. He made all sorts of art. He made collages. He was a printmaker. He made things out of found objects. He taught me all sorts of things about art and collecting junk and how to see. Most recently, Tahiti Pehrson. I am drawn to Tahiti's work because it's pretty amazing—he makes these paper cutouts that are incredibly detailed and meticulous.</p>
-<p><b>Beyond the basic tools, what things do you need in order to paint?</b></p>
-<p>Not much. Maybe a glass of water and some headphones.</p>
-<p><b>What's the best advice you've ever received from another artist?</b></p>
-<p>“Breathe.”</p>
-<p><b>Who gave you that advice?</b></p>
-<p>The photographer that came to my studio to shoot me for you guys [Damien Maloney]. I guess I was holding my breath.</p>
-<p><b>If you're at a party and a new acquaintance asks what your work is like, what do you say?</b></p>
-<p>“Amateur landscape painting.”</p>
-</body>
-</pam:article>
-</pam:message>
+￼NAVA'S PAINTINGS OF PRIMORDIAL MONSTERS and myths balance ceremonial seriousness with childlike play. Originally from East Chicago, Indiana, he received an M.F.A. from Yale University before moving to Brooklyn, where we caught up with him while at work in his studio.
+￼GQ STYLE: How did you arrive at your painting style? What factors influenced your development most?
+￼ROBERT NAVA: Drawing every morning, trying to keep up with my imagination. Looking at a lot of ancient art, mainly Sumerian, Egyptian, Mayan. The mandala. Cave painting. The older artworks have a big impact, and I'm able to see the amount of work put into them, and they feel like they are timeless to a degree. But also they contain so much mystery. There's another level of mindfulness to “care” in them.
+￼What is your latest body of work all about?
+￼Making new myths. Trying to make monsters, angels, ghosts, putting an energy into them.
+￼What's something you'd like to do as an artist but haven't yet?
+￼Make large sculpture with metal.
+￼What do you do when you need a break from making art?
+￼Hang with my cat, Jumanji. Go to rooftops. The beach. Find some live music to enjoy.
+￼What do you wear when you paint?
+￼Usually shorts and headphones. The less the better.
+￼If you're at a party and a new acquaintance asks what your work is like, what do you say?
+￼I try to show a web page or Instagram.
+￼Who was the first artist that really blew your mind? And who was the most recent?
+￼Van Gogh and Huma Bhabha. Van Gogh: The soul and application of paint. The fearlessness. The paint is very alive—those paintings have an honesty that cannot be denied. Huma Bhabha: An engagement with the realness in materials with immense weight and impact—her works are very “in your face,” with a raw energy.
+￼Beyond the basic tools, what things do you need in order to paint?
+￼Loud music. There are so many artists and moods, but lately: electronic music, often techno, house, disco. Anything that takes you on a journey for hours on end.
+￼What's the best advice you've ever received from another artist?
+￼“There are no mistakes,” from my first-grade art teacher, Mrs. Shaver.
+￼Devan Shimoyama
+
+￼Five-Minute Self-Portrait, 2018
+￼PITTSBURGH￼b. 1989
+￼PHILADELPHIA NATIVE Shimoyama—also a Yale M.F.A. graduate—is now based in Pittsburgh, where he teaches at Carnegie Mellon University. His paintings borrow materials from drag culture—glitter, feathers, and rhinestones—and explore issues related to race, masculinity, and illusions of wealth. His debut solo museum exhibition, Cry, Baby, is at the Andy Warhol Museum through March 2019.
+￼GQ STYLE: How did you arrive at your painting style? What factors influenced your development most?
+￼DEVAN SHIMOYAMA: My painting style came about from my love of experimenting with all kinds of materials, drag culture, and fashion. I remember when I was first starting to paint, I was fascinated by how unconventional painting materials would mix together to create these psychedelic, shimmering encrusted spills. I'd play around with spray paint, quick-dry enamel, and fabric dye. Those eventually led to my interest in other unconventional painting materials that are much more in line with what drag performers use to get a look together, like rhinestones, glitter, feathers, et cetera, which they're using to create the illusion and fantasy of a wealthy, beautiful fictional character.
+￼What is your latest body of work all about?
+￼The last solo exhibition I had was titled Sweet, which was exploring the toxic masculinity of black barbershops. More recently, I've begun a body of work where I am depicting black individuals tending to their homes and thinking about the importance of black ownership, whether that ownership is businesses, properties, et cetera. I just have been thinking about the importance of people of color actually being able to have more agency and not become such easy targets for displacement and gentrification.
+￼What's something you'd like to do as an artist but haven't yet?
+￼I would love to actually collaborate with a fashion designer and create a line. I love fashion so much, and I would be completely invested in creating everything, even creating custom fabrics and accessories. I think that designers like Kerby Jean-Raymond from Pyer Moss have found a really nuanced way to intersect art, activism, and fashion in such a smart way.
+￼What do you do when you need a break from making art?
+￼I need mindless activity. I hang out with my two dogs (two Cavalier King Charles spaniels, named River and Bowie), or I play mindless games like Stardew Valley or watch guilty-pleasure reality-TV shows.
+
+
+
+￼What do you wear when you paint?
+￼I normally wear either a pair of denim cutoff shorts and a tank top or my bright red Dickies short-sleeve coveralls. I also always wear my Blundstone Chelsea boots as my painting shoes. They're covered in all kinds of splattered paint and glitter.
+￼Who was the first artist that really blew your mind? And who was the most recent?
+￼Wangechi Mutu is the first artist that really blew my mind. I was completely fascinated by her use of ink and collage to make these explosive, hybridized characters that were so indomitable in spirit and strength. Most recently, my best friend, Haley Josephs, has blown my mind pretty consistently with her new work. The colors, the power in the women she's depicting, and the fantastical reality she creates never fail to impress me.
+￼Beyond the basic tools, what things do you need in order to paint?
+￼I need to always have jewelry, glitter, rhinestones, and fabric, but also I need to listen to something while I'm working. Depending on what I'm working on, I need to play a good album that matches my mood—currently listening to Kelela, SZA, Blood Orange, and Aminé on rotation.
+￼What's the best advice you've ever received from another artist?
+￼Josephine Halvorson gave me some of my best studio visits while in grad school at Yale, and I remember her telling me that she could tell when my work was coming from a place of love and talking about love and that there was strength in that. I've kept that in mind ever since, always making sure to make art from something real and true and significant and from a place of love.
+￼If you're at a party and a new acquaintance asks what your work is like, what do you say?
+￼I'd say that I make mythological, epic fantasy-figure paintings with drag-queen materials. That's my elevator pitch!
+￼Emily Mae Smith
+
+￼Five-Minute Self-Portrait, 2018
+￼BROOKLYN￼b. 1979
+￼BORN IN AUSTIN, Smith paints cartoonish figures and surreal scenarios in photo-realistic detail, all of it oozing with sensuality and stark feminine energy. We caught up with Smith at her studio in Brooklyn as she prepared for a show at Galerie Perrotin in Manhattan and for her first solo museum show, which opens at Le Consortium in Dijon, France, in November.
+￼GQ STYLE: How did you arrive at your painting style? What factors influenced your development most?
+￼EMILY MAE SMITH: Learning what to leave out and how to do just enough—to not over-do—was very important. That comes with experience and practice. I have been painting with the same materials for 20 years. A lot of people like to discuss their childhood as being formative, but I prefer to emphasize the experiences of my adult life. As a woman, my point of view has been radicalized during this time.
+￼What is your latest body of work all about?
+￼An anthropomorphic broom appears in a lot of my paintings. Its figure forms a kind of totem: an object imbued with a special power beyond its literal form. These brooms are tools for new potentialities, occupying and distorting historical compositions, claiming space for feminine subjectivity.
+￼What's something you'd like to do as an artist but haven't yet?
+￼There are paintings I thought of two years ago that I'm just now able to execute—my mind has to slowly engineer them, sometimes silently behind the scenes, like a program running in the background. Then one day it's ready.
+￼Beyond the basic tools, what things do you need in order to paint?
+￼Discipline, will, time.
+￼What do you do when you need a break from making art?
+￼I recently got a puppy, who forces me to take more breaks. I like the walks.
+￼What do you wear when you paint?
+￼My favorite piece of clothing to wear in the studio is a boy's ranger vest, which I bought from a thrift store in Aspen.
+￼Who was the first artist that really blew your mind? And who was the most recent?
+￼When I was about 17, I saw Georges Seurat's A Sunday Afternoon on the Island of La Grande Jatte at the Art Institute of Chicago. I knew of it from books, but seeing it in person blew my mind. At that moment I fell in love with painting down to the material level. It was the first time that I truly understood painting beyond image. I saw that it was conceptual, experiential, and that depth of meaning worked far beyond a picture. Recently I visited the Alte Nationalgalerie, in Berlin, which holds masterpiece paintings from the Romantic period. There I saw mind-blowing Arnold Böcklin paintings. I'm thinking about those a lot right now.
+￼What's the best advice you've ever received from another artist?
+￼Hands-down best advice, from my partner: “Learn to make small paintings.” This came in a particularly rough patch in my life. I was deeply struggling at every level. Learning to paint in reduced scale with reduced materials was a painful but great crucible for my work.
+￼If you're at a party and a new acquaintance asks what your work is like, what do you say?
+￼“Good.”
+
+
+
+￼Joe Roberts
+
+￼Five-Minute Self-Portrait, 2018
+￼SAN FRANCISCO￼b. 1976
+
+
+
+￼BORN IN MADISON, WISCONSIN, Roberts takes inspiration from comic books, skateboarding, space exploration, and his experiences with psychedelics. Roberts, a.k.a. LSD World Peace, has collaborated with Supreme and designed graphics for GX1000, a skate brand based in San Francisco, where he works and lives.
+￼GQ STYLE: How did you arrive at your painting style? What factors influenced your development most?
+￼JOE ROBERTS: I have been learning how to paint for a million years, and I'm still not very good at it. I don't really have any expectations when I paint. It's more fun that way.
+￼What is your latest body of work all about?
+￼Trips. I went camping once a month for a year, and I ate mushrooms every time. I made a bunch of paintings about these experiences. Kinda my way of integrating my trips with my life.
+￼What's something you'd like to do as an artist but haven't yet?
+￼I have made blueprints for a wish machine, and I would like to build it.
+￼What do you do when you need a break from making art?
+￼I go on a walk with my dog, Kevin. Or I go skateboarding. Or go camping.
+￼What do you wear when you paint?
+￼Just whatever clothes I'm wearing that day. Everything I have has paint on it somewhere.
+￼Who was the first artist that really blew your mind? And who was the most recent?
+￼The first was my grandfather, Steve Vasy. He made all sorts of art. He made collages. He was a printmaker. He made things out of found objects. He taught me all sorts of things about art and collecting junk and how to see. Most recently, Tahiti Pehrson. I am drawn to Tahiti's work because it's pretty amazing—he makes these paper cutouts that are incredibly detailed and meticulous.
+￼Beyond the basic tools, what things do you need in order to paint?
+￼Not much. Maybe a glass of water and some headphones.
+￼What's the best advice you've ever received from another artist?
+￼“Breathe.”
+￼Who gave you that advice?
+￼The photographer that came to my studio to shoot me for you guys [Damien Maloney]. I guess I was holding my breath.
+￼If you're at a party and a new acquaintance asks what your work is like, what do you say?
+￼“Amateur landscape painting.”￼
+
+
+
 ",
-  "contentType": "application/vnd.atjson+offset",
-  "schema": [
-    "-offset-blockquote",
-    "-offset-bold",
-    "-offset-ceros-embed",
-    "-offset-code",
-    "-offset-code-block",
-    "-offset-facebook-embed",
-    "-offset-firework-embed",
-    "-offset-fixed-indent",
-    "-offset-giphy-embed",
-    "-offset-group-item",
-    "-offset-group",
-    "-offset-heading",
-    "-offset-horizontal-rule",
-    "-offset-html",
-    "-offset-iframe-embed",
-    "-offset-image",
-    "-offset-instagram-embed",
-    "-offset-italic",
-    "-offset-line-break",
-    "-offset-link",
-    "-offset-list",
-    "-offset-list-item",
-    "-offset-paragraph",
-    "-offset-pinterest-embed",
-    "-offset-pullquote",
-    "-offset-section",
-    "-offset-sidebar",
-    "-offset-small-caps",
-    "-offset-strikethrough",
-    "-offset-subscript",
-    "-offset-superscript",
-    "-offset-tiktok-embed",
-    "-offset-twitter-embed",
-    "-offset-underline",
-    "-offset-video-embed",
-  ],
 }
 `;
 
 exports[`@atjson/source-prism prism snapshots parses gq-santoni.xml 1`] = `
 {
-  "attributes": {},
-  "children": [
-    "
-",
+  "blocks": [
+    {
+      "attributes": {},
+      "id": "B00000000",
+      "parents": [],
+      "selfClosing": false,
+      "type": "text",
+    },
     {
       "attributes": {
         "xmlns": "http://www.w3.org/1999/xhtml",
       },
-      "children": [
-        "
-",
-        {
-          "attributes": {},
-          "children": [
-            "
-",
-            {
-              "attributes": {},
-              "children": [
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-identifier",
-                  },
-                  "children": [
-                    "XXXXXXX",
-                  ],
-                  "id": "00000008",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Santoni",
-                  ],
-                  "id": "0000000b",
-                  "type": "title",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-creator",
-                  },
-                  "children": [
-                    "XXXXXXX",
-                  ],
-                  "id": "0000000e",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-publicationname",
-                  },
-                  "children": [
-                    "GQ",
-                  ],
-                  "id": "00000011",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-issn",
-                  },
-                  "children": [
-                    "2471-5393",
-                  ],
-                  "id": "00000014",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-publisher",
-                  },
-                  "children": [
-                    "Condé Nast",
-                  ],
-                  "id": "00000017",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-coverdate",
-                  },
-                  "children": [
-                    "2018-11-13",
-                  ],
-                  "id": "0000001a",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-coverdisplaydate",
-                  },
-                  "children": [
-                    "GQ Style Holiday 2018",
-                  ],
-                  "id": "0000001d",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-volume",
-                  },
-                  "children": [
-                    "3",
-                  ],
-                  "id": "00000020",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-number",
-                  },
-                  "children": [
-                    "3",
-                  ],
-                  "id": "00000023",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-startingpage",
-                  },
-                  "children": [
-                    "74",
-                  ],
-                  "id": "00000026",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-section",
-                  },
-                  "children": [
-                    "
-",
-                  ],
-                  "id": "00000029",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-subsection1",
-                  },
-                  "children": [
-                    "
-",
-                  ],
-                  "id": "0000002c",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-subject",
-                  },
-                  "children": [
-                    " ",
-                  ],
-                  "id": "0000002f",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "The Most Italian Shoes in All of Italy",
-                  ],
-                  "id": "00000032",
-                  "type": "description",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-wordcount",
-                  },
-                  "children": [
-                    "886",
-                  ],
-                  "id": "00000035",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-copyright",
-                  },
-                  "children": [
-                    "COPYRIGHT ©2018 THE CONDÉ NAST PUBLICATIONS. ALL RIGHTS RESERVED.",
-                  ],
-                  "id": "00000038",
-                  "type": "unknown",
-                },
-                "
-",
-                "
-",
-              ],
-              "id": "00000006",
-              "type": "head",
-            },
-            "
-",
-            {
-              "attributes": {},
-              "children": [
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "SANTONI",
-                  ],
-                  "id": "00000041",
-                  "type": "h1",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "class": "byline",
-                  },
-                  "children": [
-                    "—CAM WOLF",
-                  ],
-                  "id": "00000044",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "class": "deck",
-                  },
-                  "children": [
-                    "The Most Italian Shoes in All of Italy",
-                  ],
-                  "id": "00000047",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "0000004c",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Courtesy of Santoni",
-                      ],
-                      "id": "00000051",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "0000004a",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000057",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Courtesy of Santoni",
-                      ],
-                      "id": "0000005c",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000055",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000062",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Courtesy of Santoni",
-                      ],
-                      "id": "00000067",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000060",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "0000006d",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Courtesy of Santoni",
-                      ],
-                      "id": "00000072",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-caption",
-                      },
-                      "children": [
-                        "Artisans at Santoni spend decades perfecting the craft of shoemaking. What sets the label's footwear apart? “Quality, quality, quality,” Giuseppe Santoni says.",
-                      ],
-                      "id": "00000075",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "0000006b",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "0000007b",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Courtesy of Santoni",
-                      ],
-                      "id": "00000080",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-caption",
-                      },
-                      "children": [
-                        "Santoni was appointed CEO of his family's business in 1990 at only 21 years old; in 2018 the brand's classic designs still have a youthful vibe.",
-                      ],
-                      "id": "00000083",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000079",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000089",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Courtesy of Santoni",
-                      ],
-                      "id": "0000008e",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-caption",
-                      },
-                      "children": [
-                        "Up to 12 layers of paint are used to build color. Wearing the shoes, Santoni says, is like driving a Rolls-Royce.",
-                      ],
-                      "id": "00000091",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000087",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "In the fantastical universe of Santoni, a shoe is not just a shoe—it is an ",
-                    {
-                      "attributes": {},
-                      "children": [
-                        "object of desire,",
-                      ],
-                      "id": "00000097",
-                      "type": "i",
-                    },
-                    " according to the label's CEO, Giuseppe Santoni. The tradition of handmade shoes and the skillful artisans in the brand's workshop are guided not by corporate responsibility or nine-to-five obligation but by a watchful genie. An energy that maintains the quality of the label's shoes, so says Santoni. The brand is headquartered in the Italian region of Marche—what appears to be a paradise hundreds of miles from the country's fashion capital. And of course Santoni tells his family's tale in an Italian accent that's as thick and comforting as a good red sauce. “Growing up surrounded by beauty, you get affected by this influence,” he says.",
-                  ],
-                  "id": "00000095",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "His English is near perfect. When Santoni was barely 20, his father sent him to England specifically to learn the language so that he could eventually sell the shoes to English-speaking clientele. He's been part of the family-owned business, originally founded by his parents in 1975, since he was a child. No choice, really: The shoe workshop and the Santoni household were attached. That Santoni would one day take up the mantle of CEO was never in question. “Unlike the other kids in the world,” Santoni says, “I never dreamed to become a policeman or a fireman; I just wanted to do my father's job.”",
-                  ],
-                  "id": "0000009b",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Maybe it is this generational devotion to crafting shoes that sets Santoni apart from other footwear labels. There are plenty of brands that make fine dress shoes. But Santoni, the brand and the man, is not satisfied with shoes so steeped in tradition and precious about design that they remain unchanged for decades. “I don't like to make shoes that always look the same,” he says. Sure, the label sells the classics, but a “black” Santoni cap-toe oxford might burn just beneath the surface with a deep blue—an effect achieved by painting on a dozen layers of color. This sort of shoe epitomizes Santoni's design philosophy. Like any good character in a Pixar movie, the shoes are timeless objects imbued with a bit of magic.",
-                  ],
-                  "id": "0000009e",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "In 2018, you can't just design shoes. For years, people have been led to believe that it's completely acceptable to fill up closets and storage units by amassing the latest shoes and sneakers. This is the quandary for Santoni, which is in the business of selling you dress shoes with four-figure price tags that it wants you to keep for decades. “We make things that are absolutely useless for the survival of a person,” says Santoni. “Nowadays, everyone has more shoes than you need to live three lives.”",
-                  ],
-                  "id": "000000a1",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Shoe overload is why Santoni paints its pairs of oxfords again, then again, then again, then again, then maybe a couple more times after that. A simple pair of boots is equipped with buckles, straps, and gold zippers. Other brands are interested in classics that will last a lifetime; Santoni aims a little north of that, adding subtle new twists that you've never seen before—but that will endure just as long. The brand wants to make understated shoes “but never a boring product or something [that makes] you say, ‘I already have this,’ ” Santoni explains.",
-                  ],
-                  "id": "000000a4",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "To do this, the company continues to employ artisans who have spent a lifetime with the family—Santoni's folks still get their hands on every shoe before it leaves the factory—but it also brings in young designers to sit on the other end of the seesaw, warding off boring products. Santoni says arguments between young and old employees occur every day: “But it's a clash where young people want to do things very difficult, and old people don't want to change. They do good together.”",
-                  ],
-                  "id": "000000a7",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "The result of this back-and-forth is a shoe as well constructed as anything out there but that doesn't turn its nose up at fashion. For Santoni, there are two types of people in the world. The first is “lawyers, very classic people, they love English shoes,” he explains. But then there are the people who ask for more from their footwear. Italy, he argues, is at the forefront of creativity, where customers might be entranced by tales of genies or smoldering blue lace-up dress shoes. Santoni doesn't just do beautiful footwear, after all. Fitting, because as Santoni sees it, those buying the brand aren't really interested in shoes, either. “The Santoni customer,” he says, “is a beauty lover.”",
-                  ],
-                  "id": "000000aa",
-                  "type": "p",
-                },
-                "
-",
-              ],
-              "id": "0000003f",
-              "type": "body",
-            },
-            "
-",
-          ],
-          "id": "00000004",
-          "type": "article",
-        },
-        "
-",
-      ],
-      "id": "00000002",
+      "id": "B00000001",
+      "parents": [],
+      "selfClosing": false,
       "type": "message",
     },
-    "
-",
+    {
+      "attributes": {},
+      "id": "B00000002",
+      "parents": [
+        "message",
+      ],
+      "selfClosing": false,
+      "type": "article",
+    },
+    {
+      "attributes": {},
+      "id": "B00000003",
+      "parents": [
+        "message",
+        "article",
+      ],
+      "selfClosing": false,
+      "type": "head",
+    },
+    {
+      "attributes": {},
+      "id": "B00000004",
+      "parents": [
+        "message",
+        "article",
+        "head",
+      ],
+      "selfClosing": false,
+      "type": "title",
+    },
+    {
+      "attributes": {},
+      "id": "B00000005",
+      "parents": [
+        "message",
+        "article",
+        "head",
+      ],
+      "selfClosing": false,
+      "type": "description",
+    },
+    {
+      "attributes": {},
+      "id": "B00000006",
+      "parents": [
+        "message",
+        "article",
+        "head",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
+      "id": "B00000007",
+      "parents": [
+        "message",
+        "article",
+      ],
+      "selfClosing": false,
+      "type": "body",
+    },
+    {
+      "attributes": {
+        "class": "byline",
+      },
+      "id": "B00000008",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {
+        "class": "deck",
+      },
+      "id": "B00000009",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000a",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000b",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000c",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000d",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000e",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000f",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000010",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000011",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000012",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000013",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000014",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000015",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000016",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000017",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
+      "id": "B00000018",
+      "parents": [
+        "message",
+        "article",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
+      "id": "B00000019",
+      "parents": [
+        "message",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
+      "id": "B0000001a",
+      "parents": [],
+      "selfClosing": false,
+      "type": "text",
+    },
   ],
-  "id": "00000000",
-  "type": "root",
+  "marks": [
+    {
+      "attributes": {},
+      "id": "M00000000",
+      "range": "(8..15]",
+      "type": "-dc-identifier",
+    },
+    {
+      "attributes": {},
+      "id": "M00000001",
+      "range": "(25..32]",
+      "type": "-dc-creator",
+    },
+    {
+      "attributes": {},
+      "id": "M00000002",
+      "range": "(33..35]",
+      "type": "-prism-publicationname",
+    },
+    {
+      "attributes": {},
+      "id": "M00000003",
+      "range": "(36..45]",
+      "type": "-prism-issn",
+    },
+    {
+      "attributes": {},
+      "id": "M00000004",
+      "range": "(46..56]",
+      "type": "-dc-publisher",
+    },
+    {
+      "attributes": {},
+      "id": "M00000005",
+      "range": "(57..67]",
+      "type": "-prism-coverdate",
+    },
+    {
+      "attributes": {},
+      "id": "M00000006",
+      "range": "(68..89]",
+      "type": "-prism-coverdisplaydate",
+    },
+    {
+      "attributes": {},
+      "id": "M00000007",
+      "range": "(90..91]",
+      "type": "-prism-volume",
+    },
+    {
+      "attributes": {},
+      "id": "M00000008",
+      "range": "(92..93]",
+      "type": "-prism-number",
+    },
+    {
+      "attributes": {},
+      "id": "M00000009",
+      "range": "(94..96]",
+      "type": "-prism-startingpage",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000a",
+      "range": "(97..98]",
+      "type": "-prism-section",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000b",
+      "range": "(99..100]",
+      "type": "-prism-subsection1",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000c",
+      "range": "(101..102]",
+      "type": "-dc-subject",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000d",
+      "range": "(144..147]",
+      "type": "-prism-wordcount",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000e",
+      "range": "(148..213]",
+      "type": "-prism-copyright",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000f",
+      "range": "(214..214]",
+      "type": "-cnp-category",
+    },
+    {
+      "attributes": {},
+      "id": "M00000010",
+      "range": "(218..225]",
+      "type": "h1",
+    },
+    {
+      "attributes": {},
+      "id": "M00000011",
+      "range": "(279..282]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000012",
+      "range": "(283..283]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000013",
+      "range": "(284..303]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000014",
+      "range": "(307..310]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000015",
+      "range": "(311..311]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000016",
+      "range": "(312..331]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000017",
+      "range": "(335..338]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000018",
+      "range": "(339..339]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000019",
+      "range": "(340..359]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001a",
+      "range": "(363..366]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001b",
+      "range": "(367..367]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001c",
+      "range": "(368..387]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001d",
+      "range": "(388..547]",
+      "type": "-pam-caption",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001e",
+      "range": "(551..554]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001f",
+      "range": "(555..555]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000020",
+      "range": "(556..575]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000021",
+      "range": "(576..720]",
+      "type": "-pam-caption",
+    },
+    {
+      "attributes": {},
+      "id": "M00000022",
+      "range": "(724..727]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000023",
+      "range": "(728..728]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000024",
+      "range": "(729..748]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000025",
+      "range": "(749..862]",
+      "type": "-pam-caption",
+    },
+    {
+      "attributes": {},
+      "id": "M00000026",
+      "range": "(940..957]",
+      "type": "i",
+    },
+  ],
+  "text": "￼
+￼
+￼
+￼
+XXXXXXX
+￼Santoni
+XXXXXXX
+GQ
+2471-5393
+Condé Nast
+2018-11-13
+GQ Style Holiday 2018
+3
+3
+74
+
+
+
+
+ 
+￼The Most Italian Shoes in All of Italy￼
+886
+COPYRIGHT ©2018 THE CONDÉ NAST PUBLICATIONS. ALL RIGHTS RESERVED.
+
+
+￼
+SANTONI
+￼—CAM WOLF
+￼The Most Italian Shoes in All of Italy
+￼
+psd
+
+Courtesy of Santoni
+
+￼
+psd
+
+Courtesy of Santoni
+
+￼
+psd
+
+Courtesy of Santoni
+
+￼
+psd
+
+Courtesy of Santoni
+Artisans at Santoni spend decades perfecting the craft of shoemaking. What sets the label's footwear apart? “Quality, quality, quality,” Giuseppe Santoni says.
+
+￼
+psd
+
+Courtesy of Santoni
+Santoni was appointed CEO of his family's business in 1990 at only 21 years old; in 2018 the brand's classic designs still have a youthful vibe.
+
+￼
+psd
+
+Courtesy of Santoni
+Up to 12 layers of paint are used to build color. Wearing the shoes, Santoni says, is like driving a Rolls-Royce.
+
+￼In the fantastical universe of Santoni, a shoe is not just a shoe—it is an object of desire, according to the label's CEO, Giuseppe Santoni. The tradition of handmade shoes and the skillful artisans in the brand's workshop are guided not by corporate responsibility or nine-to-five obligation but by a watchful genie. An energy that maintains the quality of the label's shoes, so says Santoni. The brand is headquartered in the Italian region of Marche—what appears to be a paradise hundreds of miles from the country's fashion capital. And of course Santoni tells his family's tale in an Italian accent that's as thick and comforting as a good red sauce. “Growing up surrounded by beauty, you get affected by this influence,” he says.
+￼His English is near perfect. When Santoni was barely 20, his father sent him to England specifically to learn the language so that he could eventually sell the shoes to English-speaking clientele. He's been part of the family-owned business, originally founded by his parents in 1975, since he was a child. No choice, really: The shoe workshop and the Santoni household were attached. That Santoni would one day take up the mantle of CEO was never in question. “Unlike the other kids in the world,” Santoni says, “I never dreamed to become a policeman or a fireman; I just wanted to do my father's job.”
+￼Maybe it is this generational devotion to crafting shoes that sets Santoni apart from other footwear labels. There are plenty of brands that make fine dress shoes. But Santoni, the brand and the man, is not satisfied with shoes so steeped in tradition and precious about design that they remain unchanged for decades. “I don't like to make shoes that always look the same,” he says. Sure, the label sells the classics, but a “black” Santoni cap-toe oxford might burn just beneath the surface with a deep blue—an effect achieved by painting on a dozen layers of color. This sort of shoe epitomizes Santoni's design philosophy. Like any good character in a Pixar movie, the shoes are timeless objects imbued with a bit of magic.
+￼In 2018, you can't just design shoes. For years, people have been led to believe that it's completely acceptable to fill up closets and storage units by amassing the latest shoes and sneakers. This is the quandary for Santoni, which is in the business of selling you dress shoes with four-figure price tags that it wants you to keep for decades. “We make things that are absolutely useless for the survival of a person,” says Santoni. “Nowadays, everyone has more shoes than you need to live three lives.”
+￼Shoe overload is why Santoni paints its pairs of oxfords again, then again, then again, then again, then maybe a couple more times after that. A simple pair of boots is equipped with buckles, straps, and gold zippers. Other brands are interested in classics that will last a lifetime; Santoni aims a little north of that, adding subtle new twists that you've never seen before—but that will endure just as long. The brand wants to make understated shoes “but never a boring product or something [that makes] you say, ‘I already have this,’ ” Santoni explains.
+￼To do this, the company continues to employ artisans who have spent a lifetime with the family—Santoni's folks still get their hands on every shoe before it leaves the factory—but it also brings in young designers to sit on the other end of the seesaw, warding off boring products. Santoni says arguments between young and old employees occur every day: “But it's a clash where young people want to do things very difficult, and old people don't want to change. They do good together.”
+￼The result of this back-and-forth is a shoe as well constructed as anything out there but that doesn't turn its nose up at fashion. For Santoni, there are two types of people in the world. The first is “lawyers, very classic people, they love English shoes,” he explains. But then there are the people who ask for more from their footwear. Italy, he argues, is at the forefront of creativity, where customers might be entranced by tales of genies or smoldering blue lace-up dress shoes. Santoni doesn't just do beautiful footwear, after all. Fitting, because as Santoni sees it, those buying the brand aren't really interested in shoes, either. “The Santoni customer,” he says, “is a beauty lover.”￼
+￼
+￼
+￼
+",
 }
 `;
 
 exports[`@atjson/source-prism prism snapshots parses gq-santoni.xml 2`] = `
 {
-  "annotations": [
+  "blocks": [
+    {
+      "attributes": {},
+      "id": "B00000000",
+      "parents": [],
+      "selfClosing": false,
+      "type": "text",
+    },
     {
       "attributes": {
-        "-atjson-reason": "<?xml>",
+        "level": 1,
       },
-      "end": 38,
-      "id": "00000001",
-      "start": 0,
-      "type": "-atjson-parse-token",
+      "id": "B00000001",
+      "parents": [],
+      "selfClosing": false,
+      "type": "heading",
     },
+    {
+      "attributes": {},
+      "id": "B00000002",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000003",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000004",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000005",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000006",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000007",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000008",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000009",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000a",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000b",
+      "parents": [],
+      "selfClosing": false,
+      "type": "text",
+    },
+  ],
+  "marks": [
     {
       "attributes": {
         "-pam-xmlns": "http://www.w3.org/1999/xhtml",
       },
-      "end": 5143,
-      "id": "00000002",
-      "start": 39,
+      "id": "M00000000",
+      "range": "(2..4400]",
       "type": "-pam-message",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<pam:message>",
-      },
-      "end": 578,
-      "id": "00000003",
-      "start": 39,
-      "type": "-atjson-parse-token",
-    },
-    {
       "attributes": {},
-      "end": 5128,
-      "id": "00000004",
-      "start": 579,
+      "id": "M00000001",
+      "range": "(3..4399]",
       "type": "-pam-article",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<pam:article>",
-      },
-      "end": 609,
-      "id": "00000005",
-      "start": 579,
-      "type": "-atjson-parse-token",
-    },
-    {
       "attributes": {},
-      "end": 5113,
-      "id": "00000006",
-      "start": 611,
+      "id": "M00000002",
+      "range": "(5..4398]",
       "type": "-html-body",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<body>",
-      },
-      "end": 617,
-      "id": "00000007",
-      "start": 611,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-offset-level": 1,
-      },
-      "end": 634,
-      "id": "00000008",
-      "start": 618,
-      "type": "-offset-heading",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<h1>",
-      },
-      "end": 622,
-      "id": "00000009",
-      "start": 618,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</h1>",
-      },
-      "end": 634,
-      "id": "0000000a",
-      "start": 629,
-      "type": "-atjson-parse-token",
-    },
-    {
       "attributes": {},
-      "end": 666,
-      "id": "0000000b",
-      "start": 635,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 653,
-      "id": "0000000c",
-      "start": 635,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 666,
-      "id": "0000000d",
-      "start": 662,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 725,
-      "id": "0000000e",
-      "start": 667,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 683,
-      "id": "0000000f",
-      "start": 667,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 725,
-      "id": "00000010",
-      "start": 721,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1481,
-      "id": "00000011",
-      "start": 732,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 735,
-      "id": "00000012",
-      "start": 732,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 834,
-      "id": "00000013",
-      "start": 810,
-      "type": "-offset-italic",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<i>",
-      },
-      "end": 813,
-      "id": "00000014",
-      "start": 810,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</i>",
-      },
-      "end": 834,
-      "id": "00000015",
-      "start": 830,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 1481,
-      "id": "00000016",
-      "start": 1477,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 2092,
-      "id": "00000017",
-      "start": 1482,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 1485,
-      "id": "00000018",
-      "start": 1482,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2092,
-      "id": "00000019",
-      "start": 2088,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 2826,
-      "id": "0000001a",
-      "start": 2093,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2096,
-      "id": "0000001b",
-      "start": 2093,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2826,
-      "id": "0000001c",
-      "start": 2822,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3339,
-      "id": "0000001d",
-      "start": 2827,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2830,
-      "id": "0000001e",
-      "start": 2827,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 3339,
-      "id": "0000001f",
-      "start": 3335,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3906,
-      "id": "00000020",
-      "start": 3340,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 3343,
-      "id": "00000021",
-      "start": 3340,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 3906,
-      "id": "00000022",
-      "start": 3902,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 4399,
-      "id": "00000023",
-      "start": 3907,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 3910,
-      "id": "00000024",
-      "start": 3907,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 4399,
-      "id": "00000025",
-      "start": 4395,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 5105,
-      "id": "00000026",
-      "start": 4400,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 4403,
-      "id": "00000027",
-      "start": 4400,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 5105,
-      "id": "00000028",
-      "start": 5101,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</body>",
-      },
-      "end": 5113,
-      "id": "00000029",
-      "start": 5106,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</pam:article>",
-      },
-      "end": 5128,
-      "id": "0000002a",
-      "start": 5114,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</pam:message>",
-      },
-      "end": 5143,
-      "id": "0000002b",
-      "start": 5129,
-      "type": "-atjson-parse-token",
+      "id": "M00000003",
+      "range": "(148..165]",
+      "type": "italic",
     },
   ],
-  "content": "<?xml version="1.0" encoding="utf-8"?>
-<pam:message xmlns:pam="http://prismstandard.org/namespaces/pam/2.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:pim="http://prismstandard.org/namespaces/pim/2.0/" xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/" xmlns:prl="http://prismstandard.org/namespaces/prl/2.0/" xmlns="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://prismstandard.org/namespaces/pam/2.0/ pam.xsd">
-<pam:article xml:lang="en-US">
-
-<body>
-<h1>SANTONI</h1>
-<p class="byline">—CAM WOLF</p>
-<p class="deck">The Most Italian Shoes in All of Italy</p>
+  "text": "￼
 
 
 
 
+￼SANTONI
+￼—CAM WOLF
+￼The Most Italian Shoes in All of Italy
 
 
-<p>In the fantastical universe of Santoni, a shoe is not just a shoe—it is an <i>object of desire,</i> according to the label's CEO, Giuseppe Santoni. The tradition of handmade shoes and the skillful artisans in the brand's workshop are guided not by corporate responsibility or nine-to-five obligation but by a watchful genie. An energy that maintains the quality of the label's shoes, so says Santoni. The brand is headquartered in the Italian region of Marche—what appears to be a paradise hundreds of miles from the country's fashion capital. And of course Santoni tells his family's tale in an Italian accent that's as thick and comforting as a good red sauce. “Growing up surrounded by beauty, you get affected by this influence,” he says.</p>
-<p>His English is near perfect. When Santoni was barely 20, his father sent him to England specifically to learn the language so that he could eventually sell the shoes to English-speaking clientele. He's been part of the family-owned business, originally founded by his parents in 1975, since he was a child. No choice, really: The shoe workshop and the Santoni household were attached. That Santoni would one day take up the mantle of CEO was never in question. “Unlike the other kids in the world,” Santoni says, “I never dreamed to become a policeman or a fireman; I just wanted to do my father's job.”</p>
-<p>Maybe it is this generational devotion to crafting shoes that sets Santoni apart from other footwear labels. There are plenty of brands that make fine dress shoes. But Santoni, the brand and the man, is not satisfied with shoes so steeped in tradition and precious about design that they remain unchanged for decades. “I don't like to make shoes that always look the same,” he says. Sure, the label sells the classics, but a “black” Santoni cap-toe oxford might burn just beneath the surface with a deep blue—an effect achieved by painting on a dozen layers of color. This sort of shoe epitomizes Santoni's design philosophy. Like any good character in a Pixar movie, the shoes are timeless objects imbued with a bit of magic.</p>
-<p>In 2018, you can't just design shoes. For years, people have been led to believe that it's completely acceptable to fill up closets and storage units by amassing the latest shoes and sneakers. This is the quandary for Santoni, which is in the business of selling you dress shoes with four-figure price tags that it wants you to keep for decades. “We make things that are absolutely useless for the survival of a person,” says Santoni. “Nowadays, everyone has more shoes than you need to live three lives.”</p>
-<p>Shoe overload is why Santoni paints its pairs of oxfords again, then again, then again, then again, then maybe a couple more times after that. A simple pair of boots is equipped with buckles, straps, and gold zippers. Other brands are interested in classics that will last a lifetime; Santoni aims a little north of that, adding subtle new twists that you've never seen before—but that will endure just as long. The brand wants to make understated shoes “but never a boring product or something [that makes] you say, ‘I already have this,’ ” Santoni explains.</p>
-<p>To do this, the company continues to employ artisans who have spent a lifetime with the family—Santoni's folks still get their hands on every shoe before it leaves the factory—but it also brings in young designers to sit on the other end of the seesaw, warding off boring products. Santoni says arguments between young and old employees occur every day: “But it's a clash where young people want to do things very difficult, and old people don't want to change. They do good together.”</p>
-<p>The result of this back-and-forth is a shoe as well constructed as anything out there but that doesn't turn its nose up at fashion. For Santoni, there are two types of people in the world. The first is “lawyers, very classic people, they love English shoes,” he explains. But then there are the people who ask for more from their footwear. Italy, he argues, is at the forefront of creativity, where customers might be entranced by tales of genies or smoldering blue lace-up dress shoes. Santoni doesn't just do beautiful footwear, after all. Fitting, because as Santoni sees it, those buying the brand aren't really interested in shoes, either. “The Santoni customer,” he says, “is a beauty lover.”</p>
-</body>
-</pam:article>
-</pam:message>
+
+
+
+
+￼In the fantastical universe of Santoni, a shoe is not just a shoe—it is an object of desire, according to the label's CEO, Giuseppe Santoni. The tradition of handmade shoes and the skillful artisans in the brand's workshop are guided not by corporate responsibility or nine-to-five obligation but by a watchful genie. An energy that maintains the quality of the label's shoes, so says Santoni. The brand is headquartered in the Italian region of Marche—what appears to be a paradise hundreds of miles from the country's fashion capital. And of course Santoni tells his family's tale in an Italian accent that's as thick and comforting as a good red sauce. “Growing up surrounded by beauty, you get affected by this influence,” he says.
+￼His English is near perfect. When Santoni was barely 20, his father sent him to England specifically to learn the language so that he could eventually sell the shoes to English-speaking clientele. He's been part of the family-owned business, originally founded by his parents in 1975, since he was a child. No choice, really: The shoe workshop and the Santoni household were attached. That Santoni would one day take up the mantle of CEO was never in question. “Unlike the other kids in the world,” Santoni says, “I never dreamed to become a policeman or a fireman; I just wanted to do my father's job.”
+￼Maybe it is this generational devotion to crafting shoes that sets Santoni apart from other footwear labels. There are plenty of brands that make fine dress shoes. But Santoni, the brand and the man, is not satisfied with shoes so steeped in tradition and precious about design that they remain unchanged for decades. “I don't like to make shoes that always look the same,” he says. Sure, the label sells the classics, but a “black” Santoni cap-toe oxford might burn just beneath the surface with a deep blue—an effect achieved by painting on a dozen layers of color. This sort of shoe epitomizes Santoni's design philosophy. Like any good character in a Pixar movie, the shoes are timeless objects imbued with a bit of magic.
+￼In 2018, you can't just design shoes. For years, people have been led to believe that it's completely acceptable to fill up closets and storage units by amassing the latest shoes and sneakers. This is the quandary for Santoni, which is in the business of selling you dress shoes with four-figure price tags that it wants you to keep for decades. “We make things that are absolutely useless for the survival of a person,” says Santoni. “Nowadays, everyone has more shoes than you need to live three lives.”
+￼Shoe overload is why Santoni paints its pairs of oxfords again, then again, then again, then again, then maybe a couple more times after that. A simple pair of boots is equipped with buckles, straps, and gold zippers. Other brands are interested in classics that will last a lifetime; Santoni aims a little north of that, adding subtle new twists that you've never seen before—but that will endure just as long. The brand wants to make understated shoes “but never a boring product or something [that makes] you say, ‘I already have this,’ ” Santoni explains.
+￼To do this, the company continues to employ artisans who have spent a lifetime with the family—Santoni's folks still get their hands on every shoe before it leaves the factory—but it also brings in young designers to sit on the other end of the seesaw, warding off boring products. Santoni says arguments between young and old employees occur every day: “But it's a clash where young people want to do things very difficult, and old people don't want to change. They do good together.”
+￼The result of this back-and-forth is a shoe as well constructed as anything out there but that doesn't turn its nose up at fashion. For Santoni, there are two types of people in the world. The first is “lawyers, very classic people, they love English shoes,” he explains. But then there are the people who ask for more from their footwear. Italy, he argues, is at the forefront of creativity, where customers might be entranced by tales of genies or smoldering blue lace-up dress shoes. Santoni doesn't just do beautiful footwear, after all. Fitting, because as Santoni sees it, those buying the brand aren't really interested in shoes, either. “The Santoni customer,” he says, “is a beauty lover.”￼
+
+
+
 ",
-  "contentType": "application/vnd.atjson+offset",
-  "schema": [
-    "-offset-blockquote",
-    "-offset-bold",
-    "-offset-ceros-embed",
-    "-offset-code",
-    "-offset-code-block",
-    "-offset-facebook-embed",
-    "-offset-firework-embed",
-    "-offset-fixed-indent",
-    "-offset-giphy-embed",
-    "-offset-group-item",
-    "-offset-group",
-    "-offset-heading",
-    "-offset-horizontal-rule",
-    "-offset-html",
-    "-offset-iframe-embed",
-    "-offset-image",
-    "-offset-instagram-embed",
-    "-offset-italic",
-    "-offset-line-break",
-    "-offset-link",
-    "-offset-list",
-    "-offset-list-item",
-    "-offset-paragraph",
-    "-offset-pinterest-embed",
-    "-offset-pullquote",
-    "-offset-section",
-    "-offset-sidebar",
-    "-offset-small-caps",
-    "-offset-strikethrough",
-    "-offset-subscript",
-    "-offset-superscript",
-    "-offset-tiktok-embed",
-    "-offset-twitter-embed",
-    "-offset-underline",
-    "-offset-video-embed",
-  ],
 }
 `;
 
 exports[`@atjson/source-prism prism snapshots parses gq-yuketen.xml 1`] = `
 {
-  "attributes": {},
-  "children": [
-    "
-",
+  "blocks": [
+    {
+      "attributes": {},
+      "id": "B00000000",
+      "parents": [],
+      "selfClosing": false,
+      "type": "text",
+    },
     {
       "attributes": {
         "xmlns": "http://www.w3.org/1999/xhtml",
       },
-      "children": [
-        "
-",
-        {
-          "attributes": {},
-          "children": [
-            "
-",
-            {
-              "attributes": {},
-              "children": [
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-identifier",
-                  },
-                  "children": [
-                    "XXXXXXX",
-                  ],
-                  "id": "00000008",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Yuketen",
-                  ],
-                  "id": "0000000b",
-                  "type": "title",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-creator",
-                  },
-                  "children": [
-                    "XXXXXXX",
-                  ],
-                  "id": "0000000e",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-publicationname",
-                  },
-                  "children": [
-                    "GQ",
-                  ],
-                  "id": "00000011",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-issn",
-                  },
-                  "children": [
-                    "2471-5393",
-                  ],
-                  "id": "00000014",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-publisher",
-                  },
-                  "children": [
-                    "Condé Nast",
-                  ],
-                  "id": "00000017",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-coverdate",
-                  },
-                  "children": [
-                    "2018-11-13",
-                  ],
-                  "id": "0000001a",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-coverdisplaydate",
-                  },
-                  "children": [
-                    "GQ Style Holiday 2018",
-                  ],
-                  "id": "0000001d",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-volume",
-                  },
-                  "children": [
-                    "3",
-                  ],
-                  "id": "00000020",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-number",
-                  },
-                  "children": [
-                    "3",
-                  ],
-                  "id": "00000023",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-startingpage",
-                  },
-                  "children": [
-                    "72",
-                  ],
-                  "id": "00000026",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-section",
-                  },
-                  "children": [
-                    "
-",
-                  ],
-                  "id": "00000029",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-dc-subject",
-                  },
-                  "children": [
-                    " ",
-                  ],
-                  "id": "0000002c",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "The Japanese Shoemaker Keeping America's Forgotten Traditions Alive",
-                  ],
-                  "id": "0000002f",
-                  "type": "description",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-wordcount",
-                  },
-                  "children": [
-                    "665",
-                  ],
-                  "id": "00000032",
-                  "type": "unknown",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "attributes": {},
-                    "type": "-prism-copyright",
-                  },
-                  "children": [
-                    "COPYRIGHT ©2018 THE CONDÉ NAST PUBLICATIONS. ALL RIGHTS RESERVED.",
-                  ],
-                  "id": "00000035",
-                  "type": "unknown",
-                },
-                "
-",
-              ],
-              "id": "00000006",
-              "type": "head",
-            },
-            "
-",
-            {
-              "attributes": {},
-              "children": [
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "YUKETEN",
-                  ],
-                  "id": "0000003b",
-                  "type": "h1",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "class": "byline",
-                  },
-                  "children": [
-                    "—XXXXXXX",
-                  ],
-                  "id": "0000003e",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {
-                    "class": "deck",
-                  },
-                  "children": [
-                    "The Japanese Shoemaker Keeping America's Forgotten Traditions Alive",
-                  ],
-                  "id": "00000041",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000046",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Courtesy of Yuketen",
-                      ],
-                      "id": "0000004b",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000044",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000051",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Courtesy of Yuketen",
-                      ],
-                      "id": "00000056",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "0000004f",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "0000005c",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Courtesy of Yuketen",
-                      ],
-                      "id": "00000061",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "0000005a",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "For a guy who runs an independent leather-shoe company in an era when fashion is completely obsessed with sneakers, Yuki Matsuda keeps a pretty level head about the whole thing. “I'm like, ‘Okay, I need to make something much cooler than the sneaker,’ ” Matsuda says. In the years since founding Yuketen, in 1995, he's designed hundreds of hand-sewn moccasins, cordovan leather hard-bottoms, preppy loafers and boat shoes, fancy cowboy boots, and rugged hikers, all made using old-world methods. Sometimes his quest to improve upon the sneaker means remixing the North American shoe canon like he's been given the keys to a Hollywood-country-western costume shop: Yuketen loafers get western-belt-buckle straps. A dressy chukka is punched up with snakeskin leather. The brand's most recognizable silhouette, the Maine Guide Boot, merges a Native American moccasin with a New England trapper boot, all atop a chunky, urban-ready sole.",
-                  ],
-                  "id": "00000065",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "From his headquarters in South Bay, Los Angeles, Matsuda has also taken the sneaker head-on, introducing the world to the Land Jordan, the only basketball-inspired shoe you could wear to a job interview. It has a Goodyear-welted Vibram sole and a hand-cut upper that mimics the Jordan 11 Low I.E.—definitive proof that Matsuda can still turn up the heat in the footwear world in 2018. The 50-year-old designer caught the Americana bug when he was 15 and living in Osaka, working at an imported-goods store selling selvage Levi's and made-in-America Converse. He's been an avid collector of gear from the golden days of manufacturing ever since—denim, military garb, watches, and, of course, shoes. “I'm a shoe freak,” Matsuda says. “I make everything at Yuketen for me.”",
-                  ],
-                  "id": "00000068",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "Yuketen is part of Matsuda's artisanal, vintage-inspired menswear empire under his company, Meg Co., which also owns Monitaly, Epperson Mountaineering, and Chamula. Every Yuketen shoe is bench-made using traditional techniques. The famous moccasins, like the Guide Boot, come from Maine, where they are hand-sewn by a group of employees who learned the craft at the Sebago factory before working for Yuketen. (The boot takes about five months to build, start to finish.) “We can't produce many shoes, so we are not focused on selling 10,000 pairs a year,” says Matsuda. “But when it comes to the quality, it's so good. I'm amazed every time I open a shoe shipment from the factory.”",
-                  ],
-                  "id": "0000006b",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "It's that unreplicable, rare character that has earned Yuketen many fans in the fashion world and beyond. But even after more than two decades in the shoe game, Yuketen is still not immune to the vagaries of domestic manufacturing. Despite high demand, there are simply not enough skilled workers to replace the aging craftspeople behind the product. “It's sad,” Matsuda says. “We are in a dying art. I don't know how long we can keep doing it. Maybe five more years?” Luckily, Yuketen also has more manufacturers in Italy and some in Mexico. It's entirely possible its U.S.A.-made range will eventually be a thing of the past. For now, though, Yuketen remains an all-too-scarce anomaly, a brand that's a living testament to a slower, better, doper way of doing things. Let's wear it while we can.",
-                  ],
-                  "id": "0000006e",
-                  "type": "p",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000073",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Courtesy of Yuketen",
-                      ],
-                      "id": "00000078",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-caption",
-                      },
-                      "children": [
-                        "The aesthetics of Yuketen and Monitaly, Matsuda's highly advanced military-inspired apparel brand, work together hand in glove…or foot in shoe.",
-                      ],
-                      "id": "0000007b",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "00000071",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "00000081",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Courtesy of Yuketen",
-                      ],
-                      "id": "00000086",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-caption",
-                      },
-                      "children": [
-                        "Yuki Matsuda can often be found at the Rose Bowl Flea Market in Pasadena, California, where he hunts for rare Native American and country-western goods that inspire his fashion lines.",
-                      ],
-                      "id": "00000089",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "0000007f",
-                  "type": "media",
-                },
-                "
-",
-                {
-                  "attributes": {},
-                  "children": [
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-dc-type",
-                      },
-                      "children": [
-                        "psd",
-                      ],
-                      "id": "0000008f",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-credit",
-                      },
-                      "children": [
-                        "Courtesy of Yuketen",
-                      ],
-                      "id": "00000094",
-                      "type": "unknown",
-                    },
-                    "
-",
-                    {
-                      "attributes": {
-                        "attributes": {},
-                        "type": "-pam-caption",
-                      },
-                      "children": [
-                        "Matsuda only uses leather from Chicago's famed Horween tannery, which has been supplying America's footwear industry since 1905.",
-                      ],
-                      "id": "00000097",
-                      "type": "unknown",
-                    },
-                    "
-",
-                  ],
-                  "id": "0000008d",
-                  "type": "media",
-                },
-                "
-",
-              ],
-              "id": "00000039",
-              "type": "body",
-            },
-            "
-",
-          ],
-          "id": "00000004",
-          "type": "article",
-        },
-        "
-",
-      ],
-      "id": "00000002",
+      "id": "B00000001",
+      "parents": [],
+      "selfClosing": false,
       "type": "message",
     },
-    "
-",
+    {
+      "attributes": {},
+      "id": "B00000002",
+      "parents": [
+        "message",
+      ],
+      "selfClosing": false,
+      "type": "article",
+    },
+    {
+      "attributes": {},
+      "id": "B00000003",
+      "parents": [
+        "message",
+        "article",
+      ],
+      "selfClosing": false,
+      "type": "head",
+    },
+    {
+      "attributes": {},
+      "id": "B00000004",
+      "parents": [
+        "message",
+        "article",
+        "head",
+      ],
+      "selfClosing": false,
+      "type": "title",
+    },
+    {
+      "attributes": {},
+      "id": "B00000005",
+      "parents": [
+        "message",
+        "article",
+        "head",
+      ],
+      "selfClosing": false,
+      "type": "description",
+    },
+    {
+      "attributes": {},
+      "id": "B00000006",
+      "parents": [
+        "message",
+        "article",
+        "head",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
+      "id": "B00000007",
+      "parents": [
+        "message",
+        "article",
+      ],
+      "selfClosing": false,
+      "type": "body",
+    },
+    {
+      "attributes": {
+        "class": "byline",
+      },
+      "id": "B00000008",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {
+        "class": "deck",
+      },
+      "id": "B00000009",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000a",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000b",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000c",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000d",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000e",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B0000000f",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000010",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "p",
+    },
+    {
+      "attributes": {},
+      "id": "B00000011",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000012",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000013",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "media",
+    },
+    {
+      "attributes": {},
+      "id": "B00000014",
+      "parents": [
+        "message",
+        "article",
+        "body",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
+      "id": "B00000015",
+      "parents": [
+        "message",
+        "article",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
+      "id": "B00000016",
+      "parents": [
+        "message",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
+      "id": "B00000017",
+      "parents": [],
+      "selfClosing": false,
+      "type": "text",
+    },
   ],
-  "id": "00000000",
-  "type": "root",
+  "marks": [
+    {
+      "attributes": {},
+      "id": "M00000000",
+      "range": "(8..15]",
+      "type": "-dc-identifier",
+    },
+    {
+      "attributes": {},
+      "id": "M00000001",
+      "range": "(25..32]",
+      "type": "-dc-creator",
+    },
+    {
+      "attributes": {},
+      "id": "M00000002",
+      "range": "(33..35]",
+      "type": "-prism-publicationname",
+    },
+    {
+      "attributes": {},
+      "id": "M00000003",
+      "range": "(36..45]",
+      "type": "-prism-issn",
+    },
+    {
+      "attributes": {},
+      "id": "M00000004",
+      "range": "(46..56]",
+      "type": "-dc-publisher",
+    },
+    {
+      "attributes": {},
+      "id": "M00000005",
+      "range": "(57..67]",
+      "type": "-prism-coverdate",
+    },
+    {
+      "attributes": {},
+      "id": "M00000006",
+      "range": "(68..89]",
+      "type": "-prism-coverdisplaydate",
+    },
+    {
+      "attributes": {},
+      "id": "M00000007",
+      "range": "(90..91]",
+      "type": "-prism-volume",
+    },
+    {
+      "attributes": {},
+      "id": "M00000008",
+      "range": "(92..93]",
+      "type": "-prism-number",
+    },
+    {
+      "attributes": {},
+      "id": "M00000009",
+      "range": "(94..96]",
+      "type": "-prism-startingpage",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000a",
+      "range": "(97..98]",
+      "type": "-prism-section",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000b",
+      "range": "(99..100]",
+      "type": "-dc-subject",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000c",
+      "range": "(171..174]",
+      "type": "-prism-wordcount",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000d",
+      "range": "(175..240]",
+      "type": "-prism-copyright",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000e",
+      "range": "(244..251]",
+      "type": "h1",
+    },
+    {
+      "attributes": {},
+      "id": "M0000000f",
+      "range": "(333..336]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000010",
+      "range": "(337..337]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000011",
+      "range": "(338..357]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000012",
+      "range": "(361..364]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000013",
+      "range": "(365..365]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000014",
+      "range": "(366..385]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000015",
+      "range": "(389..392]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000016",
+      "range": "(393..393]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000017",
+      "range": "(394..413]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000018",
+      "range": "(3607..3610]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000019",
+      "range": "(3611..3611]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001a",
+      "range": "(3612..3631]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001b",
+      "range": "(3632..3775]",
+      "type": "-pam-caption",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001c",
+      "range": "(3779..3782]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001d",
+      "range": "(3783..3783]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001e",
+      "range": "(3784..3803]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M0000001f",
+      "range": "(3804..3987]",
+      "type": "-pam-caption",
+    },
+    {
+      "attributes": {},
+      "id": "M00000020",
+      "range": "(3991..3994]",
+      "type": "-dc-type",
+    },
+    {
+      "attributes": {},
+      "id": "M00000021",
+      "range": "(3995..3995]",
+      "type": "-pam-mediareference",
+    },
+    {
+      "attributes": {},
+      "id": "M00000022",
+      "range": "(3996..4015]",
+      "type": "-pam-credit",
+    },
+    {
+      "attributes": {},
+      "id": "M00000023",
+      "range": "(4016..4144]",
+      "type": "-pam-caption",
+    },
+  ],
+  "text": "￼
+￼
+￼
+￼
+XXXXXXX
+￼Yuketen
+XXXXXXX
+GQ
+2471-5393
+Condé Nast
+2018-11-13
+GQ Style Holiday 2018
+3
+3
+72
+
+
+ 
+￼The Japanese Shoemaker Keeping America's Forgotten Traditions Alive￼
+665
+COPYRIGHT ©2018 THE CONDÉ NAST PUBLICATIONS. ALL RIGHTS RESERVED.
+
+￼
+YUKETEN
+￼—XXXXXXX
+￼The Japanese Shoemaker Keeping America's Forgotten Traditions Alive
+￼
+psd
+
+Courtesy of Yuketen
+
+￼
+psd
+
+Courtesy of Yuketen
+
+￼
+psd
+
+Courtesy of Yuketen
+
+￼For a guy who runs an independent leather-shoe company in an era when fashion is completely obsessed with sneakers, Yuki Matsuda keeps a pretty level head about the whole thing. “I'm like, ‘Okay, I need to make something much cooler than the sneaker,’ ” Matsuda says. In the years since founding Yuketen, in 1995, he's designed hundreds of hand-sewn moccasins, cordovan leather hard-bottoms, preppy loafers and boat shoes, fancy cowboy boots, and rugged hikers, all made using old-world methods. Sometimes his quest to improve upon the sneaker means remixing the North American shoe canon like he's been given the keys to a Hollywood-country-western costume shop: Yuketen loafers get western-belt-buckle straps. A dressy chukka is punched up with snakeskin leather. The brand's most recognizable silhouette, the Maine Guide Boot, merges a Native American moccasin with a New England trapper boot, all atop a chunky, urban-ready sole.
+￼From his headquarters in South Bay, Los Angeles, Matsuda has also taken the sneaker head-on, introducing the world to the Land Jordan, the only basketball-inspired shoe you could wear to a job interview. It has a Goodyear-welted Vibram sole and a hand-cut upper that mimics the Jordan 11 Low I.E.—definitive proof that Matsuda can still turn up the heat in the footwear world in 2018. The 50-year-old designer caught the Americana bug when he was 15 and living in Osaka, working at an imported-goods store selling selvage Levi's and made-in-America Converse. He's been an avid collector of gear from the golden days of manufacturing ever since—denim, military garb, watches, and, of course, shoes. “I'm a shoe freak,” Matsuda says. “I make everything at Yuketen for me.”
+￼Yuketen is part of Matsuda's artisanal, vintage-inspired menswear empire under his company, Meg Co., which also owns Monitaly, Epperson Mountaineering, and Chamula. Every Yuketen shoe is bench-made using traditional techniques. The famous moccasins, like the Guide Boot, come from Maine, where they are hand-sewn by a group of employees who learned the craft at the Sebago factory before working for Yuketen. (The boot takes about five months to build, start to finish.) “We can't produce many shoes, so we are not focused on selling 10,000 pairs a year,” says Matsuda. “But when it comes to the quality, it's so good. I'm amazed every time I open a shoe shipment from the factory.”
+￼It's that unreplicable, rare character that has earned Yuketen many fans in the fashion world and beyond. But even after more than two decades in the shoe game, Yuketen is still not immune to the vagaries of domestic manufacturing. Despite high demand, there are simply not enough skilled workers to replace the aging craftspeople behind the product. “It's sad,” Matsuda says. “We are in a dying art. I don't know how long we can keep doing it. Maybe five more years?” Luckily, Yuketen also has more manufacturers in Italy and some in Mexico. It's entirely possible its U.S.A.-made range will eventually be a thing of the past. For now, though, Yuketen remains an all-too-scarce anomaly, a brand that's a living testament to a slower, better, doper way of doing things. Let's wear it while we can.
+￼
+psd
+
+Courtesy of Yuketen
+The aesthetics of Yuketen and Monitaly, Matsuda's highly advanced military-inspired apparel brand, work together hand in glove…or foot in shoe.
+
+￼
+psd
+
+Courtesy of Yuketen
+Yuki Matsuda can often be found at the Rose Bowl Flea Market in Pasadena, California, where he hunts for rare Native American and country-western goods that inspire his fashion lines.
+
+￼
+psd
+
+Courtesy of Yuketen
+Matsuda only uses leather from Chicago's famed Horween tannery, which has been supplying America's footwear industry since 1905.
+￼
+￼
+￼
+￼
+",
 }
 `;
 
 exports[`@atjson/source-prism prism snapshots parses gq-yuketen.xml 2`] = `
 {
-  "annotations": [
+  "blocks": [
+    {
+      "attributes": {},
+      "id": "B00000000",
+      "parents": [],
+      "selfClosing": false,
+      "type": "text",
+    },
     {
       "attributes": {
-        "-atjson-reason": "<?xml>",
+        "level": 1,
       },
-      "end": 38,
-      "id": "00000001",
-      "start": 0,
-      "type": "-atjson-parse-token",
+      "id": "B00000001",
+      "parents": [],
+      "selfClosing": false,
+      "type": "heading",
     },
+    {
+      "attributes": {},
+      "id": "B00000002",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000003",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000004",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000005",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000006",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000007",
+      "parents": [],
+      "selfClosing": false,
+      "type": "paragraph",
+    },
+    {
+      "attributes": {},
+      "id": "B00000008",
+      "parents": [],
+      "selfClosing": false,
+      "type": "text",
+    },
+  ],
+  "marks": [
     {
       "attributes": {
         "-pam-xmlns": "http://www.w3.org/1999/xhtml",
       },
-      "end": 4011,
-      "id": "00000002",
-      "start": 39,
+      "id": "M00000000",
+      "range": "(2..3293]",
       "type": "-pam-message",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<pam:message>",
-      },
-      "end": 578,
-      "id": "00000003",
-      "start": 39,
-      "type": "-atjson-parse-token",
-    },
-    {
       "attributes": {},
-      "end": 3996,
-      "id": "00000004",
-      "start": 579,
+      "id": "M00000001",
+      "range": "(3..3292]",
       "type": "-pam-article",
     },
     {
-      "attributes": {
-        "-atjson-reason": "<pam:article>",
-      },
-      "end": 609,
-      "id": "00000005",
-      "start": 579,
-      "type": "-atjson-parse-token",
-    },
-    {
       "attributes": {},
-      "end": 3981,
-      "id": "00000006",
-      "start": 611,
+      "id": "M00000002",
+      "range": "(5..3291]",
       "type": "-html-body",
     },
-    {
-      "attributes": {
-        "-atjson-reason": "<body>",
-      },
-      "end": 617,
-      "id": "00000007",
-      "start": 611,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-offset-level": 1,
-      },
-      "end": 634,
-      "id": "00000008",
-      "start": 618,
-      "type": "-offset-heading",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<h1>",
-      },
-      "end": 622,
-      "id": "00000009",
-      "start": 618,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</h1>",
-      },
-      "end": 634,
-      "id": "0000000a",
-      "start": 629,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 665,
-      "id": "0000000b",
-      "start": 635,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 653,
-      "id": "0000000c",
-      "start": 635,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 665,
-      "id": "0000000d",
-      "start": 661,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 753,
-      "id": "0000000e",
-      "start": 666,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 682,
-      "id": "0000000f",
-      "start": 666,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 753,
-      "id": "00000010",
-      "start": 749,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 1697,
-      "id": "00000011",
-      "start": 757,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 760,
-      "id": "00000012",
-      "start": 757,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 1697,
-      "id": "00000013",
-      "start": 1693,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 2475,
-      "id": "00000014",
-      "start": 1698,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 1701,
-      "id": "00000015",
-      "start": 1698,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 2475,
-      "id": "00000016",
-      "start": 2471,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3165,
-      "id": "00000017",
-      "start": 2476,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 2479,
-      "id": "00000018",
-      "start": 2476,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 3165,
-      "id": "00000019",
-      "start": 3161,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {},
-      "end": 3970,
-      "id": "0000001a",
-      "start": 3166,
-      "type": "-offset-paragraph",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "<p>",
-      },
-      "end": 3169,
-      "id": "0000001b",
-      "start": 3166,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</p>",
-      },
-      "end": 3970,
-      "id": "0000001c",
-      "start": 3966,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</body>",
-      },
-      "end": 3981,
-      "id": "0000001d",
-      "start": 3974,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</pam:article>",
-      },
-      "end": 3996,
-      "id": "0000001e",
-      "start": 3982,
-      "type": "-atjson-parse-token",
-    },
-    {
-      "attributes": {
-        "-atjson-reason": "</pam:message>",
-      },
-      "end": 4011,
-      "id": "0000001f",
-      "start": 3997,
-      "type": "-atjson-parse-token",
-    },
   ],
-  "content": "<?xml version="1.0" encoding="utf-8"?>
-<pam:message xmlns:pam="http://prismstandard.org/namespaces/pam/2.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:pim="http://prismstandard.org/namespaces/pim/2.0/" xmlns:prism="http://prismstandard.org/namespaces/basic/2.0/" xmlns:prl="http://prismstandard.org/namespaces/prl/2.0/" xmlns="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://prismstandard.org/namespaces/pam/2.0/ pam.xsd">
-<pam:article xml:lang="en-US">
-
-<body>
-<h1>YUKETEN</h1>
-<p class="byline">—XXXXXXX</p>
-<p class="deck">The Japanese Shoemaker Keeping America's Forgotten Traditions Alive</p>
+  "text": "￼
 
 
 
-<p>For a guy who runs an independent leather-shoe company in an era when fashion is completely obsessed with sneakers, Yuki Matsuda keeps a pretty level head about the whole thing. “I'm like, ‘Okay, I need to make something much cooler than the sneaker,’ ” Matsuda says. In the years since founding Yuketen, in 1995, he's designed hundreds of hand-sewn moccasins, cordovan leather hard-bottoms, preppy loafers and boat shoes, fancy cowboy boots, and rugged hikers, all made using old-world methods. Sometimes his quest to improve upon the sneaker means remixing the North American shoe canon like he's been given the keys to a Hollywood-country-western costume shop: Yuketen loafers get western-belt-buckle straps. A dressy chukka is punched up with snakeskin leather. The brand's most recognizable silhouette, the Maine Guide Boot, merges a Native American moccasin with a New England trapper boot, all atop a chunky, urban-ready sole.</p>
-<p>From his headquarters in South Bay, Los Angeles, Matsuda has also taken the sneaker head-on, introducing the world to the Land Jordan, the only basketball-inspired shoe you could wear to a job interview. It has a Goodyear-welted Vibram sole and a hand-cut upper that mimics the Jordan 11 Low I.E.—definitive proof that Matsuda can still turn up the heat in the footwear world in 2018. The 50-year-old designer caught the Americana bug when he was 15 and living in Osaka, working at an imported-goods store selling selvage Levi's and made-in-America Converse. He's been an avid collector of gear from the golden days of manufacturing ever since—denim, military garb, watches, and, of course, shoes. “I'm a shoe freak,” Matsuda says. “I make everything at Yuketen for me.”</p>
-<p>Yuketen is part of Matsuda's artisanal, vintage-inspired menswear empire under his company, Meg Co., which also owns Monitaly, Epperson Mountaineering, and Chamula. Every Yuketen shoe is bench-made using traditional techniques. The famous moccasins, like the Guide Boot, come from Maine, where they are hand-sewn by a group of employees who learned the craft at the Sebago factory before working for Yuketen. (The boot takes about five months to build, start to finish.) “We can't produce many shoes, so we are not focused on selling 10,000 pairs a year,” says Matsuda. “But when it comes to the quality, it's so good. I'm amazed every time I open a shoe shipment from the factory.”</p>
-<p>It's that unreplicable, rare character that has earned Yuketen many fans in the fashion world and beyond. But even after more than two decades in the shoe game, Yuketen is still not immune to the vagaries of domestic manufacturing. Despite high demand, there are simply not enough skilled workers to replace the aging craftspeople behind the product. “It's sad,” Matsuda says. “We are in a dying art. I don't know how long we can keep doing it. Maybe five more years?” Luckily, Yuketen also has more manufacturers in Italy and some in Mexico. It's entirely possible its U.S.A.-made range will eventually be a thing of the past. For now, though, Yuketen remains an all-too-scarce anomaly, a brand that's a living testament to a slower, better, doper way of doing things. Let's wear it while we can.</p>
+
+￼YUKETEN
+￼—XXXXXXX
+￼The Japanese Shoemaker Keeping America's Forgotten Traditions Alive
 
 
 
-</body>
-</pam:article>
-</pam:message>
+￼For a guy who runs an independent leather-shoe company in an era when fashion is completely obsessed with sneakers, Yuki Matsuda keeps a pretty level head about the whole thing. “I'm like, ‘Okay, I need to make something much cooler than the sneaker,’ ” Matsuda says. In the years since founding Yuketen, in 1995, he's designed hundreds of hand-sewn moccasins, cordovan leather hard-bottoms, preppy loafers and boat shoes, fancy cowboy boots, and rugged hikers, all made using old-world methods. Sometimes his quest to improve upon the sneaker means remixing the North American shoe canon like he's been given the keys to a Hollywood-country-western costume shop: Yuketen loafers get western-belt-buckle straps. A dressy chukka is punched up with snakeskin leather. The brand's most recognizable silhouette, the Maine Guide Boot, merges a Native American moccasin with a New England trapper boot, all atop a chunky, urban-ready sole.
+￼From his headquarters in South Bay, Los Angeles, Matsuda has also taken the sneaker head-on, introducing the world to the Land Jordan, the only basketball-inspired shoe you could wear to a job interview. It has a Goodyear-welted Vibram sole and a hand-cut upper that mimics the Jordan 11 Low I.E.—definitive proof that Matsuda can still turn up the heat in the footwear world in 2018. The 50-year-old designer caught the Americana bug when he was 15 and living in Osaka, working at an imported-goods store selling selvage Levi's and made-in-America Converse. He's been an avid collector of gear from the golden days of manufacturing ever since—denim, military garb, watches, and, of course, shoes. “I'm a shoe freak,” Matsuda says. “I make everything at Yuketen for me.”
+￼Yuketen is part of Matsuda's artisanal, vintage-inspired menswear empire under his company, Meg Co., which also owns Monitaly, Epperson Mountaineering, and Chamula. Every Yuketen shoe is bench-made using traditional techniques. The famous moccasins, like the Guide Boot, come from Maine, where they are hand-sewn by a group of employees who learned the craft at the Sebago factory before working for Yuketen. (The boot takes about five months to build, start to finish.) “We can't produce many shoes, so we are not focused on selling 10,000 pairs a year,” says Matsuda. “But when it comes to the quality, it's so good. I'm amazed every time I open a shoe shipment from the factory.”
+￼It's that unreplicable, rare character that has earned Yuketen many fans in the fashion world and beyond. But even after more than two decades in the shoe game, Yuketen is still not immune to the vagaries of domestic manufacturing. Despite high demand, there are simply not enough skilled workers to replace the aging craftspeople behind the product. “It's sad,” Matsuda says. “We are in a dying art. I don't know how long we can keep doing it. Maybe five more years?” Luckily, Yuketen also has more manufacturers in Italy and some in Mexico. It's entirely possible its U.S.A.-made range will eventually be a thing of the past. For now, though, Yuketen remains an all-too-scarce anomaly, a brand that's a living testament to a slower, better, doper way of doing things. Let's wear it while we can.￼
+
+
+
+
+
+
 ",
-  "contentType": "application/vnd.atjson+offset",
-  "schema": [
-    "-offset-blockquote",
-    "-offset-bold",
-    "-offset-ceros-embed",
-    "-offset-code",
-    "-offset-code-block",
-    "-offset-facebook-embed",
-    "-offset-firework-embed",
-    "-offset-fixed-indent",
-    "-offset-giphy-embed",
-    "-offset-group-item",
-    "-offset-group",
-    "-offset-heading",
-    "-offset-horizontal-rule",
-    "-offset-html",
-    "-offset-iframe-embed",
-    "-offset-image",
-    "-offset-instagram-embed",
-    "-offset-italic",
-    "-offset-line-break",
-    "-offset-link",
-    "-offset-list",
-    "-offset-list-item",
-    "-offset-paragraph",
-    "-offset-pinterest-embed",
-    "-offset-pullquote",
-    "-offset-section",
-    "-offset-sidebar",
-    "-offset-small-caps",
-    "-offset-strikethrough",
-    "-offset-subscript",
-    "-offset-superscript",
-    "-offset-tiktok-embed",
-    "-offset-twitter-embed",
-    "-offset-underline",
-    "-offset-video-embed",
-  ],
 }
 `;

--- a/packages/@atjson/source-url/src/converter.ts
+++ b/packages/@atjson/source-url/src/converter.ts
@@ -1,3 +1,4 @@
+import { ParseAnnotation } from "@atjson/document";
 import OffsetSource, {
   SocialURLs,
   VideoURLs,
@@ -26,6 +27,12 @@ URLSource.defineConverterTo(OffsetSource, (doc) => {
             attributes,
           })
         );
+        doc.addAnnotations(
+          new ParseAnnotation({
+            start: annotation.start,
+            end: annotation.end,
+          })
+        );
       }
     });
 
@@ -41,6 +48,12 @@ URLSource.defineConverterTo(OffsetSource, (doc) => {
             start: annotation.start,
             end: annotation.end,
             attributes: urlAttributes,
+          })
+        );
+        doc.addAnnotations(
+          new ParseAnnotation({
+            start: annotation.start,
+            end: annotation.end,
           })
         );
       } else {

--- a/packages/@atjson/source-url/test/url-test.ts
+++ b/packages/@atjson/source-url/test/url-test.ts
@@ -1,73 +1,22 @@
-import OffsetSource, {
-  FacebookEmbed,
-  GiphyEmbed,
-  IframeEmbed,
-  InstagramEmbed,
-  PinterestEmbed,
-  TikTokEmbed,
-  TwitterEmbed,
-  VideoEmbed,
-} from "@atjson/offset-annotations";
-import CommonMarkRenderer from "@atjson/renderer-commonmark";
-import URLSource from "../src/index";
-
-// Renders embeds as WordPress style shortcodes
-class EmbedRenderer extends CommonMarkRenderer {
-  *"facebook-embed"(facebook: FacebookEmbed) {
-    let iframeWidth = facebook.attributes.width;
-    let width = "";
-    if (iframeWidth) {
-      width = ` data-width="${iframeWidth}"`;
-    }
-    return `<div class="fb-post" data-href="${facebook.attributes.url}"${width} data-show-text="true"></div>`;
-  }
-
-  *"giphy-embed"(giphy: GiphyEmbed) {
-    return `<iframe src="${giphy.attributes.url}"></iframe>`;
-  }
-
-  *"iframe-embed"(iframe: IframeEmbed) {
-    let { url, height, width, sandbox } = iframe.attributes;
-    let sizeAttributes = "";
-    if (height) {
-      sizeAttributes += ` height="${height}"`;
-    }
-    if (width) {
-      sizeAttributes += ` width="${width}"`;
-    }
-    if (sandbox) {
-      sizeAttributes += ` sandbox="${sandbox}"`;
-    }
-    return `<iframe src="${url}"${sizeAttributes}></iframe>`;
-  }
-
-  *"tiktok-embed"(tiktok: TikTokEmbed) {
-    return `<blockquote class="tiktok-embed" cite="${tiktok.attributes.url}"></blockquote>`;
-  }
-
-  *"instagram-embed"(instagram: InstagramEmbed) {
-    return `<blockquote class="instagram-media" data-instgrm-permalink="${instagram.attributes.url}" data-instgrm-version="12"></blockquote>`;
-  }
-
-  *"pinterest-embed"(pinterest: PinterestEmbed) {
-    return `<a href="${pinterest.attributes.url}" data-pin-do="embedPin" data-pin-width="large">${pinterest.attributes.url}</a>`;
-  }
-
-  *"twitter-embed"(tweet: TwitterEmbed) {
-    return `<blockquote lang="en" data-type="twitter" data-url="${tweet.attributes.url}"><p><a href="${tweet.attributes.url}">${tweet.attributes.url}</a></p></blockquote>`;
-  }
-
-  *"video-embed"(video: VideoEmbed) {
-    return `<iframe src="${video.attributes.url}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>`;
-  }
-}
+import { serialize } from "@atjson/document";
+import OffsetSource, { VideoURLs } from "@atjson/offset-annotations";
+import URLSource from "../src";
 
 describe("url-source", () => {
   test("text that is not a URL is returned as plain text", () => {
-    let url = URLSource.fromRaw("Hi buddy!");
-    expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-      "Hi buddy\\!"
-    );
+    expect(
+      serialize(URLSource.fromRaw("Hi buddy!").convertTo(OffsetSource), {
+        withStableIds: true,
+      })
+    ).toMatchObject({
+      text: `\uFFFCHi buddy!`,
+      blocks: [
+        {
+          type: "text",
+        },
+      ],
+      marks: [],
+    });
   });
 
   test.each([
@@ -79,8 +28,19 @@ describe("url-source", () => {
   ])(
     "URLs that do not match our embed expansion are displayed as text (%s)",
     (text) => {
-      let url = URLSource.fromRaw(text);
-      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(text);
+      expect(
+        serialize(URLSource.fromRaw(text).convertTo(OffsetSource), {
+          withStableIds: true,
+        })
+      ).toMatchObject({
+        text: `\uFFFC${text}`,
+        blocks: [
+          {
+            type: "text",
+          },
+        ],
+        marks: [],
+      });
     }
   );
 
@@ -91,10 +51,22 @@ describe("url-source", () => {
       "https://www.instagr.am/p/Bnzz-g6gpwg",
       "https://instagr.am/p/Bnzz-g6gpwg/?taken-by=lgbt_history",
     ])("%s", (text) => {
-      let url = URLSource.fromRaw(text);
-      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-        '<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/Bnzz-g6gpwg" data-instgrm-version="12"></blockquote>'
-      );
+      let url = URLSource.fromRaw(text).convertTo(OffsetSource);
+      expect(serialize(url, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "instagram-embed",
+            attributes: {
+              url: "https://www.instagram.com/p/Bnzz-g6gpwg",
+            },
+          },
+        ],
+        marks: [],
+      });
     });
 
     test.each([
@@ -103,10 +75,22 @@ describe("url-source", () => {
       "https://instagr.am/tv/B95M4kNhbzz",
       "https://instagr.am/tv/B95M4kNhbzz/?utm_source=ig_web_copy_link",
     ])("%s", (text) => {
-      let url = URLSource.fromRaw(text);
-      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-        '<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/tv/B95M4kNhbzz" data-instgrm-version="12"></blockquote>'
-      );
+      let url = URLSource.fromRaw(text).convertTo(OffsetSource);
+      expect(serialize(url, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "instagram-embed",
+            attributes: {
+              url: "https://www.instagram.com/tv/B95M4kNhbzz",
+            },
+          },
+        ],
+        marks: [],
+      });
     });
   });
 
@@ -116,10 +100,22 @@ describe("url-source", () => {
       "https://m.twitter.com/jennschiffer/status/708888255828250625",
       "https://m.twitter.com/jennschiffer/status/708888255828250625?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed&ref_url=https%3A%2F%2Ftwitter.com%2Fjennschiffer%2Fstatus%2F708888255828250625",
     ])("%s", (text) => {
-      let url = URLSource.fromRaw(text);
-      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-        '<blockquote lang="en" data-type="twitter" data-url="https://twitter.com/jennschiffer/status/708888255828250625"><p><a href="https://twitter.com/jennschiffer/status/708888255828250625">https://twitter.com/jennschiffer/status/708888255828250625</a></p></blockquote>'
-      );
+      let url = URLSource.fromRaw(text).convertTo(OffsetSource);
+      expect(serialize(url, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "twitter-embed",
+            attributes: {
+              url: "https://twitter.com/jennschiffer/status/708888255828250625",
+            },
+          },
+        ],
+        marks: [],
+      });
     });
   });
 
@@ -129,10 +125,23 @@ describe("url-source", () => {
       "https://m.youtube.com/watch/?v=Mh5LY4Mz15o",
       "https://youtu.be/Mh5LY4Mz15o",
     ])("%s", (text) => {
-      let url = URLSource.fromRaw(text);
-      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-        '<iframe src="https://www.youtube.com/embed/Mh5LY4Mz15o" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>'
-      );
+      let url = URLSource.fromRaw(text).convertTo(OffsetSource);
+      expect(serialize(url, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "video-embed",
+            attributes: {
+              provider: VideoURLs.Provider.YOUTUBE,
+              url: "https://www.youtube.com/embed/Mh5LY4Mz15o",
+            },
+          },
+        ],
+        marks: [],
+      });
     });
 
     test.each([
@@ -145,10 +154,23 @@ describe("url-source", () => {
       "https://www.youtube-nocookie.com/embed/Mh5LY4Mz15o?controls=0",
       "https://www.youtube-nocookie.com/embed/Mh5LY4Mz15o?start=165&controls=0",
     ])("%s", (text) => {
-      let url = URLSource.fromRaw(text);
-      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-        `<iframe src="${text}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>`
-      );
+      let url = URLSource.fromRaw(text).convertTo(OffsetSource);
+      expect(serialize(url, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "video-embed",
+            attributes: {
+              provider: VideoURLs.Provider.YOUTUBE,
+              url: text,
+            },
+          },
+        ],
+        marks: [],
+      });
     });
   });
 
@@ -159,19 +181,45 @@ describe("url-source", () => {
       "http://vimeo.com/156254412",
       "http://player.vimeo.com/video/156254412",
     ])("%s", (text) => {
-      let url = URLSource.fromRaw(text);
-      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-        '<iframe src="https://player.vimeo.com/video/156254412" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>'
-      );
+      let url = URLSource.fromRaw(text).convertTo(OffsetSource);
+      expect(serialize(url, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "video-embed",
+            attributes: {
+              provider: VideoURLs.Provider.VIMEO,
+              url: "https://player.vimeo.com/video/156254412",
+            },
+          },
+        ],
+        marks: [],
+      });
     });
   });
 
   describe("dailymotion", () => {
     test.each(["https://www.dailymotion.com/video/x6gmvnp"])("%s", (text) => {
-      let url = URLSource.fromRaw(text);
-      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-        '<iframe src="https://www.dailymotion.com/embed/video/x6gmvnp" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>'
-      );
+      let url = URLSource.fromRaw(text).convertTo(OffsetSource);
+      expect(serialize(url, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "video-embed",
+            attributes: {
+              provider: VideoURLs.Provider.DAILYMOTION,
+              url: "https://www.dailymotion.com/embed/video/x6gmvnp",
+            },
+          },
+        ],
+        marks: [],
+      });
     });
   });
 
@@ -179,37 +227,88 @@ describe("url-source", () => {
     test.each([
       "https://players.brightcove.net/1752604059001/default_default/index.html?videoId=5802784116001",
     ])("%s", (url) => {
-      let doc = URLSource.fromRaw(url);
-      expect(EmbedRenderer.render(doc.convertTo(OffsetSource))).toBe(
-        `<iframe src="${url}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>`
-      );
+      let doc = URLSource.fromRaw(url).convertTo(OffsetSource);
+      expect(serialize(doc, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "video-embed",
+            attributes: {
+              provider: VideoURLs.Provider.BRIGHTCOVE,
+              url,
+            },
+          },
+        ],
+        marks: [],
+      });
     });
   });
 
   describe("pinterest", () => {
     test("profile", () => {
-      let url = URLSource.fromRaw("https://www.pinterest.com/alluremagazine/");
-      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-        '<a href="https://www.pinterest.com/alluremagazine/" data-pin-do="embedPin" data-pin-width="large">https://www.pinterest.com/alluremagazine/</a>'
-      );
+      let url = URLSource.fromRaw(
+        "https://www.pinterest.com/alluremagazine/"
+      ).convertTo(OffsetSource);
+      expect(serialize(url, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "pinterest-embed",
+            attributes: {
+              url: "https://www.pinterest.com/alluremagazine/",
+            },
+          },
+        ],
+        marks: [],
+      });
     });
 
     test("board", () => {
       let url = URLSource.fromRaw(
         "https://www.pinterest.com/alluremagazine/makeup-inspiration/"
-      );
-      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-        '<a href="https://www.pinterest.com/alluremagazine/makeup-inspiration/" data-pin-do="embedPin" data-pin-width="large">https://www.pinterest.com/alluremagazine/makeup-inspiration/</a>'
-      );
+      ).convertTo(OffsetSource);
+      expect(serialize(url, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "pinterest-embed",
+            attributes: {
+              url: "https://www.pinterest.com/alluremagazine/makeup-inspiration/",
+            },
+          },
+        ],
+        marks: [],
+      });
     });
 
     test("pin", () => {
       let url = URLSource.fromRaw(
         "https://www.pinterest.com/pin/246290673356918386/"
-      );
-      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-        '<a href="https://www.pinterest.com/pin/246290673356918386/" data-pin-do="embedPin" data-pin-width="large">https://www.pinterest.com/pin/246290673356918386/</a>'
-      );
+      ).convertTo(OffsetSource);
+      expect(serialize(url, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "pinterest-embed",
+            attributes: {
+              url: "https://www.pinterest.com/pin/246290673356918386/",
+            },
+          },
+        ],
+        marks: [],
+      });
     });
   });
 
@@ -218,10 +317,22 @@ describe("url-source", () => {
       "https://giphy.com/gifs/yosub-i-dont-know-her-3o7btW6jvrZduOA3ZK",
       "https://giphy.com/embed/3o7btW6jvrZduOA3ZK/",
     ])("%s", (text) => {
-      let url = URLSource.fromRaw(text);
-      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-        '<iframe src="https://giphy.com/embed/3o7btW6jvrZduOA3ZK"></iframe>'
-      );
+      let url = URLSource.fromRaw(text).convertTo(OffsetSource);
+      expect(serialize(url, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "giphy-embed",
+            attributes: {
+              url: "https://giphy.com/embed/3o7btW6jvrZduOA3ZK",
+            },
+          },
+        ],
+        marks: [],
+      });
     });
   });
 
@@ -231,10 +342,22 @@ describe("url-source", () => {
         "https://www.facebook.com/Vogue/photos/a.71982647278/10156453076157279/?type=3&theater",
         "https://www.facebook.com/Vogue/posts/10156453076157279",
       ])("%s", (text) => {
-        let url = URLSource.fromRaw(text);
-        expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-          '<div class="fb-post" data-href="https://www.facebook.com/Vogue/posts/10156453076157279" data-show-text="true"></div>'
-        );
+        let url = URLSource.fromRaw(text).convertTo(OffsetSource);
+        expect(serialize(url, { withStableIds: true })).toEqual({
+          text: "\uFFFC",
+          blocks: [
+            {
+              id: "B00000000",
+              parents: [],
+              selfClosing: false,
+              type: "facebook-embed",
+              attributes: {
+                url: "https://www.facebook.com/Vogue/posts/10156453076157279",
+              },
+            },
+          ],
+          marks: [],
+        });
       });
     });
 
@@ -243,10 +366,22 @@ describe("url-source", () => {
         "https://www.facebook.com/Vogue/videos/vb.42933792278/258591818132754/?type=2&theater",
         "https://www.facebook.com/Vogue/posts/258591818132754",
       ])("%s", (text) => {
-        let url = URLSource.fromRaw(text);
-        expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-          '<div class="fb-post" data-href="https://www.facebook.com/Vogue/posts/258591818132754" data-show-text="true"></div>'
-        );
+        let url = URLSource.fromRaw(text).convertTo(OffsetSource);
+        expect(serialize(url, { withStableIds: true })).toEqual({
+          text: "\uFFFC",
+          blocks: [
+            {
+              id: "B00000000",
+              parents: [],
+              selfClosing: false,
+              type: "facebook-embed",
+              attributes: {
+                url: "https://www.facebook.com/Vogue/posts/258591818132754",
+              },
+            },
+          ],
+          marks: [],
+        });
       });
     });
 
@@ -254,10 +389,22 @@ describe("url-source", () => {
       test("https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2FBeethovenOfficialPage%2Fposts%2F2923157684380743&width=500", () => {
         let url = URLSource.fromRaw(
           "https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2FBeethovenOfficialPage%2Fposts%2F2923157684380743"
-        );
-        expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-          '<div class="fb-post" data-href="https://www.facebook.com/BeethovenOfficialPage/posts/2923157684380743" data-show-text="true"></div>'
-        );
+        ).convertTo(OffsetSource);
+        expect(serialize(url, { withStableIds: true })).toEqual({
+          text: "\uFFFC",
+          blocks: [
+            {
+              id: "B00000000",
+              parents: [],
+              selfClosing: false,
+              type: "facebook-embed",
+              attributes: {
+                url: "https://www.facebook.com/BeethovenOfficialPage/posts/2923157684380743",
+              },
+            },
+          ],
+          marks: [],
+        });
       });
     });
   });
@@ -269,10 +416,22 @@ describe("url-source", () => {
       "http://www.tiktok.com/@vogueitalia/video/6771026615137750277",
       "http://m.tiktok.com/@vogueitalia/video/6771026615137750277",
     ])("%s", (text) => {
-      let url = URLSource.fromRaw(text);
-      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(
-        '<blockquote class="tiktok-embed" cite="https://www.tiktok.com/@vogueitalia/video/6771026615137750277"></blockquote>'
-      );
+      let url = URLSource.fromRaw(text).convertTo(OffsetSource);
+      expect(serialize(url, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "tiktok-embed",
+            attributes: {
+              url: "https://www.tiktok.com/@vogueitalia/video/6771026615137750277",
+            },
+          },
+        ],
+        marks: [],
+      });
     });
   });
 
@@ -280,54 +439,120 @@ describe("url-source", () => {
     test.each([
       [
         "https://open.spotify.com/track/5e0vgBWfwToyphURwynSXa?si=xxxxxxxxxxxxxxx",
-        '<iframe src="https://open.spotify.com/embed/track/5e0vgBWfwToyphURwynSXa" height="80" width="300"></iframe>',
+        {
+          url: "https://open.spotify.com/embed/track/5e0vgBWfwToyphURwynSXa",
+          height: "80",
+          width: "300",
+        },
       ],
       [
         "https://open.spotify.com/embed/track/5e0vgBWfwToyphURwynSXa?si=xxxxxxxxxxxxxxx",
-        '<iframe src="https://open.spotify.com/embed/track/5e0vgBWfwToyphURwynSXa" height="80" width="300"></iframe>',
+        {
+          url: "https://open.spotify.com/embed/track/5e0vgBWfwToyphURwynSXa",
+          height: "80",
+          width: "300",
+        },
       ],
       [
         "https://open.spotify.com/album/6UjZgFbK6CQptu8aOobzPV?si=xxxxxxxxxxxxxxx",
-        '<iframe src="https://open.spotify.com/embed/album/6UjZgFbK6CQptu8aOobzPV" height="380" width="300"></iframe>',
+        {
+          url: "https://open.spotify.com/embed/album/6UjZgFbK6CQptu8aOobzPV",
+          height: "380",
+          width: "300",
+        },
       ],
       [
         "https://open.spotify.com/embed/album/6UjZgFbK6CQptu8aOobzPV?si=xxxxxxxxxxxxxxx",
-        '<iframe src="https://open.spotify.com/embed/album/6UjZgFbK6CQptu8aOobzPV" height="380" width="300"></iframe>',
+        {
+          url: "https://open.spotify.com/embed/album/6UjZgFbK6CQptu8aOobzPV",
+          height: "380",
+          width: "300",
+        },
       ],
       [
         "https://open.spotify.com/artist/6sFIWsNpZYqfjUpaCgueju?si=xxxxxxxxxxxxxxx",
-        '<iframe src="https://open.spotify.com/embed/artist/6sFIWsNpZYqfjUpaCgueju" height="380" width="300"></iframe>',
+        {
+          url: "https://open.spotify.com/embed/artist/6sFIWsNpZYqfjUpaCgueju",
+          height: "380",
+          width: "300",
+        },
       ],
       [
         "https://open.spotify.com/embed/artist/6sFIWsNpZYqfjUpaCgueju?si=xxxxxxxxxxxxxxx",
-        '<iframe src="https://open.spotify.com/embed/artist/6sFIWsNpZYqfjUpaCgueju" height="380" width="300"></iframe>',
+        {
+          url: "https://open.spotify.com/embed/artist/6sFIWsNpZYqfjUpaCgueju",
+          height: "380",
+          width: "300",
+        },
       ],
       [
         "https://open.spotify.com/playlist/2s1HL7UaXEPWqJR4E1Gt1A?si=xxxxxxxxxxxxxxx",
-        '<iframe src="https://open.spotify.com/embed/playlist/2s1HL7UaXEPWqJR4E1Gt1A" height="380" width="300"></iframe>',
+        {
+          url: "https://open.spotify.com/embed/playlist/2s1HL7UaXEPWqJR4E1Gt1A",
+          height: "380",
+          width: "300",
+        },
       ],
       [
         "https://open.spotify.com/embed/playlist/2s1HL7UaXEPWqJR4E1Gt1A?si=xxxxxxxxxxxxxxx",
-        '<iframe src="https://open.spotify.com/embed/playlist/2s1HL7UaXEPWqJR4E1Gt1A" height="380" width="300"></iframe>',
+        {
+          url: "https://open.spotify.com/embed/playlist/2s1HL7UaXEPWqJR4E1Gt1A",
+          height: "380",
+          width: "300",
+        },
       ],
-    ])("%s", (url, rendered) => {
+    ])("%s", (url, attributes) => {
       let doc = URLSource.fromRaw(url).convertTo(OffsetSource);
-      expect(EmbedRenderer.render(doc)).toBe(rendered);
+      expect(serialize(doc, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "iframe-embed",
+            attributes,
+          },
+        ],
+        marks: [],
+      });
     });
   });
   describe("reddit", () => {
     test.each([
       [
         "https://www.reddit.com/r/pics/comments/r9p0tp/my_great_grandfather_killed_a_nazi_and_took_this/?utm_source=share&utm_medium=web2x&context=3",
-        '<iframe src="https://www.redditmedia.com/r/pics/comments/r9p0tp/my_great_grandfather_killed_a_nazi_and_took_this/?ref_source=embed&ref=share&embed=true&showmedia=false" height="141" width="640" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>',
+        {
+          url: "https://www.redditmedia.com/r/pics/comments/r9p0tp/my_great_grandfather_killed_a_nazi_and_took_this/?ref_source=embed&ref=share&embed=true&showmedia=false",
+          height: "141",
+          width: "640",
+          sandbox: "allow-scripts allow-same-origin allow-popups",
+        },
       ],
       [
         "https://www.reddit.com/r/CryptoCurrency/comments/r9fni8/tether_usdt_created_1500000000_worth_of_usdt_out/?utm_source=share&utm_medium=web2x&context=3",
-        '<iframe src="https://www.redditmedia.com/r/CryptoCurrency/comments/r9fni8/tether_usdt_created_1500000000_worth_of_usdt_out/?ref_source=embed&ref=share&embed=true&showmedia=false" height="141" width="640" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>',
+        {
+          url: "https://www.redditmedia.com/r/CryptoCurrency/comments/r9fni8/tether_usdt_created_1500000000_worth_of_usdt_out/?ref_source=embed&ref=share&embed=true&showmedia=false",
+          height: "141",
+          width: "640",
+          sandbox: "allow-scripts allow-same-origin allow-popups",
+        },
       ],
-    ])("%s", (url, rendered) => {
+    ])("%s", (url, attributes) => {
       let doc = URLSource.fromRaw(url).convertTo(OffsetSource);
-      expect(EmbedRenderer.render(doc)).toBe(rendered);
+      expect(serialize(doc, { withStableIds: true })).toEqual({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "iframe-embed",
+            attributes,
+          },
+        ],
+        marks: [],
+      });
     });
   });
 });


### PR DESCRIPTION
This adds a guard to ensure that `\uFFFC` isn't in the resulting serialized text and updates tests that were previously using the HIR to test for correct structure to instead use `serialize`.