### PR TITLE
fix: change types for ceros-embed / firework-embed / horizontal-rule from object to block

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/ceros-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/ceros-embed.ts
@@ -1,6 +1,6 @@
-import { ObjectAnnotation } from "@atjson/document";
+import { BlockAnnotation } from "@atjson/document";
 
-export class CerosEmbed extends ObjectAnnotation<{
+export class CerosEmbed extends BlockAnnotation<{
   url: string;
   aspectRatio: number;
   mobileAspectRatio?: number;

--- a/packages/@atjson/offset-annotations/src/annotations/firework-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/firework-embed.ts
@@ -1,6 +1,6 @@
-import { ObjectAnnotation } from "@atjson/document";
+import { BlockAnnotation } from "@atjson/document";
 
-export class FireworkEmbed extends ObjectAnnotation<{
+export class FireworkEmbed extends BlockAnnotation<{
   id: string;
   channel?: string;
   open?: "default" | "_self" | "_modal" | "_blank";

--- a/packages/@atjson/offset-annotations/src/annotations/horizontal-rule.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/horizontal-rule.ts
@@ -1,6 +1,6 @@
-import { ObjectAnnotation } from "@atjson/document";
+import { BlockAnnotation } from "@atjson/document";
 
-export class HorizontalRule extends ObjectAnnotation {
+export class HorizontalRule extends BlockAnnotation {
   static vendorPrefix = "offset";
   static type = "horizontal-rule";
 }

--- a/packages/@atjson/source-html/test/converter-test.ts
+++ b/packages/@atjson/source-html/test/converter-test.ts
@@ -1,5 +1,4 @@
 import { serialize } from "@atjson/document";
-import { HIR } from "@atjson/hir";
 import OffsetSource, { VideoURLs } from "@atjson/offset-annotations";
 import HTMLSource from "../src";
 
@@ -197,9 +196,9 @@ describe("@atjson/source-html", () => {
     });
 
     test("hr", () => {
-      let doc = HTMLSource.fromRaw("Horizontal <hr> rules!").convertTo(
-        OffsetSource
-      );
+      let doc = HTMLSource.fromRaw(
+        "<p>Horizontal</p><hr><p>rules!</p>"
+      ).convertTo(OffsetSource);
       expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
         {
           "blocks": [
@@ -208,20 +207,25 @@ describe("@atjson/source-html", () => {
               "id": "B00000000",
               "parents": [],
               "selfClosing": false,
-              "type": "text",
+              "type": "paragraph",
             },
             {
               "attributes": {},
               "id": "B00000001",
-              "parents": [
-                "text",
-              ],
-              "selfClosing": true,
+              "parents": [],
+              "selfClosing": false,
               "type": "horizontal-rule",
+            },
+            {
+              "attributes": {},
+              "id": "B00000002",
+              "parents": [],
+              "selfClosing": false,
+              "type": "paragraph",
             },
           ],
           "marks": [],
-          "text": "￼Horizontal ￼ rules!",
+          "text": "￼Horizontal￼￼rules!",
         }
       `);
     });
@@ -1183,7 +1187,7 @@ describe("@atjson/source-html", () => {
                   },
                   "id": "B00000000",
                   "parents": [],
-                  "selfClosing": true,
+                  "selfClosing": false,
                   "type": "ceros-embed",
                 },
               ],
@@ -1209,7 +1213,7 @@ describe("@atjson/source-html", () => {
                   },
                   "id": "B00000000",
                   "parents": [],
-                  "selfClosing": true,
+                  "selfClosing": false,
                   "type": "ceros-embed",
                 },
               ],
@@ -1243,7 +1247,7 @@ describe("@atjson/source-html", () => {
                   },
                   "id": "B00000000",
                   "parents": [],
-                  "selfClosing": true,
+                  "selfClosing": false,
                   "type": "ceros-embed",
                 },
               ],


### PR DESCRIPTION
After re-evaluating some types using the new serialization format, it's clear that these should be blocks and not objects.

We expect a horizontal rule to be _between_ paragraphs. I understand that `hr` is confusingly self closing, but it also doesn't have the "self-closing" properties that the peritext format we're adopting has. It always between blocks, which makes it a block, imo