### PR TITLE
Use util instead of hir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18413,6 +18413,17 @@
         "@atjson/document": ">=0.26.0"
       }
     },
+    "packages/@atjson/react": {
+      "version": "0.1.0",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@atjson/util": "file:../util"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "packages/@atjson/renderer-commonmark": {
       "version": "0.26.4",
       "license": "Apache-2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18413,17 +18413,6 @@
         "@atjson/document": ">=0.26.0"
       }
     },
-    "packages/@atjson/react": {
-      "version": "0.1.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@atjson/util": "file:../util"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
     "packages/@atjson/renderer-commonmark": {
       "version": "0.26.4",
       "license": "Apache-2.0",

--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -26,6 +26,8 @@ import type {
   AnnotationJSON,
   AttributesOf,
   JSON,
+  Mark,
+  Block,
 } from "./internals";
 
 export {
@@ -50,6 +52,13 @@ export {
   serialize,
 };
 
-export type { AnnotationConstructor, AnnotationJSON, AttributesOf, JSON };
+export type {
+  AnnotationConstructor,
+  AnnotationJSON,
+  AttributesOf,
+  JSON,
+  Mark,
+  Block,
+};
 
 export default Document;

--- a/packages/@atjson/document/src/serialize.ts
+++ b/packages/@atjson/document/src/serialize.ts
@@ -151,6 +151,11 @@ function sortTokens(a: Token, b: Token) {
     return indexDelta;
   }
 
+  // Handle start before end for a 0 length mark
+  if (a.annotation.id === b.annotation.id) {
+    return START_TOKENS.indexOf(a.type) ? 1 : -1;
+  }
+
   // Sort end tokens before start tokens
   if (
     START_TOKENS.indexOf(a.type) !== -1 &&

--- a/packages/@atjson/document/src/serialize.ts
+++ b/packages/@atjson/document/src/serialize.ts
@@ -34,11 +34,11 @@ type Range = `${"[" | "("}${number}..${number}${"]" | ")"}`;
  * links, comments, and other information describing a range
  * of text.
  */
-type Mark = {
+export type Mark<T = null> = {
   id: string;
   type: string;
   range: Range;
-  attributes: JSONObject;
+  attributes: T extends Annotation<infer Attributes> ? Attributes : JSONObject;
 };
 
 /**
@@ -54,7 +54,7 @@ type Mark = {
  * to ensure that the correct blocks are rendered
  * in the correct place.
  */
-type Block = {
+export type Block<T = null> = {
   id: string;
   type: string;
   /**
@@ -67,7 +67,7 @@ type Block = {
   range?: Range;
   parents: string[];
   selfClosing?: boolean;
-  attributes: JSONObject;
+  attributes: T extends Annotation<infer Attributes> ? Attributes : JSONObject;
 };
 
 // @blaine and @tim-evans have been doing explorations
@@ -82,11 +82,6 @@ type Block = {
 // up being hacks in atjson where we used parse tokens
 // to handle ambiguous cases with object annotations and
 // block annotations.
-type StorageFormat = {
-  text: string;
-  blocks?: Block[];
-  marks?: Mark[];
-};
 
 function parseRange(range: Range) {
   let match = range.match(/([[|(])(\d+)\.\.(\d+)([\]|)])/);
@@ -227,7 +222,7 @@ function sortMarks(a: Mark, b: Mark) {
 export function serialize(
   doc: Document,
   options?: { withStableIds?: boolean; includeBlockRanges?: boolean }
-): StorageFormat {
+): { text: string; blocks: Block[]; marks: Mark[] } {
   // Blocks and object annotations are both stored
   // as blocks in this format. Blocks are aligned
   // with a single text character and close when
@@ -622,7 +617,7 @@ function schemaForItem(
 }
 
 export function deserialize(
-  json: StorageFormat,
+  json: { text: string; blocks?: Block[]; marks?: Mark[] },
   DocumentClass: typeof Document
 ) {
   let annotations: Annotation<any>[] = [];

--- a/packages/@atjson/document/src/serialize.ts
+++ b/packages/@atjson/document/src/serialize.ts
@@ -5,7 +5,7 @@ import {
   EdgeBehaviour,
   ObjectAnnotation,
   ParseAnnotation,
-  JSON,
+  JSONObject,
   Annotation,
   SliceAnnotation,
   UnknownAnnotation,
@@ -38,7 +38,7 @@ type Mark = {
   id: string;
   type: string;
   range: Range;
-  attributes: JSON;
+  attributes: JSONObject;
 };
 
 /**
@@ -67,7 +67,7 @@ type Block = {
   range?: Range;
   parents: string[];
   selfClosing?: boolean;
-  attributes: JSON;
+  attributes: JSONObject;
 };
 
 // @blaine and @tim-evans have been doing explorations

--- a/packages/@atjson/document/src/serialize.ts
+++ b/packages/@atjson/document/src/serialize.ts
@@ -229,7 +229,7 @@ export function serialize(
   options?: {
     withStableIds?: boolean;
     includeBlockRanges?: boolean;
-    onUnknown?: "warn" | "throw";
+    onUnknown?: "warn" | "throw" | "ignore";
   }
 ): { text: string; blocks: Block[]; marks: Mark[] } {
   // Blocks and object annotations are both stored
@@ -316,7 +316,11 @@ export function serialize(
       unknown.push(annotation);
     }
   }
-  if (options?.onUnknown && unknown.length > 0) {
+  if (
+    options?.onUnknown &&
+    unknown.length > 0 &&
+    options.onUnknown !== "ignore"
+  ) {
     let info = `Unknown annotations were found:\n${unknown
       .map(
         (annotation) =>

--- a/packages/@atjson/document/src/serialize.ts
+++ b/packages/@atjson/document/src/serialize.ts
@@ -327,7 +327,7 @@ export function serialize(
     if (options.onUnknown === "throw") {
       throw new Error(info);
     } else {
-      // eslint-ignore-next-line
+      // eslint-disable-next-line
       console.warn(info);
     }
   }

--- a/packages/@atjson/document/test/serialize-test.ts
+++ b/packages/@atjson/document/test/serialize-test.ts
@@ -55,6 +55,34 @@ describe("serialize", () => {
     `);
   });
 
+  test("errors are when throwOnUnknown is passed in", () => {
+    expect(() => {
+      serialize(
+        new TestSource({
+          content: "Hello, world",
+          annotations: [
+            new Paragraph({
+              start: 0,
+              end: 12,
+            }),
+            new UnknownAnnotation({
+              start: 8,
+              end: 12,
+              attributes: {
+                type: "subscript",
+                attributes: {},
+              },
+            }),
+          ],
+        }),
+        { throwOnUnknown: true }
+      );
+    }).toThrowErrorMatchingInlineSnapshot(`
+      "Unknown annotations were found:
+      - subscript[8..12]"
+    `);
+  });
+
   describe("blocks", () => {
     test("single block", () => {
       expect(

--- a/packages/@atjson/document/test/serialize-test.ts
+++ b/packages/@atjson/document/test/serialize-test.ts
@@ -75,7 +75,7 @@ describe("serialize", () => {
             }),
           ],
         }),
-        { throwOnUnknown: true }
+        { onUnknown: "throw" }
       );
     }).toThrowErrorMatchingInlineSnapshot(`
       "Unknown annotations were found:

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -24,29 +24,6 @@ import {
 } from "./lib/punctuation";
 export * from "./lib/punctuation";
 
-function getPreviousChar(doc: { text: string }, end: number) {
-  let previousChar = doc.text[end - 1];
-  // Block boundary
-  if (previousChar === "\uFFFC") {
-    return "";
-  }
-  return previousChar;
-}
-
-function getNextChar(
-  doc: {
-    text: string;
-  },
-  start: number
-) {
-  let nextChar = doc.text[start + 1];
-  // Block boundary
-  if (nextChar === "\uFFFC") {
-    return "";
-  }
-  return nextChar;
-}
-
 export function* splitDelimiterRuns(
   mark: Mark & { start: number; end: number },
   context: Context,
@@ -76,8 +53,15 @@ export function* splitDelimiterRuns(
     if (match[2]) {
       start += match[2].length;
     } else if (match[3]) {
-      let prevChar = getPreviousChar(context.document, mark.start);
-      if (start === 0 && prevChar && !prevChar.match(WHITESPACE_PUNCTUATION)) {
+      let previousCharacter =
+        typeof context.previous === "string"
+          ? context.previous[context.previous.length - 1]
+          : "";
+      if (
+        start === 0 &&
+        previousCharacter &&
+        !previousCharacter.match(WHITESPACE_PUNCTUATION)
+      ) {
         start += match[3].length;
       } else {
         break;
@@ -96,11 +80,12 @@ export function* splitDelimiterRuns(
         end -= 1;
         break;
       }
-      let nextChar = getNextChar(context.document, mark.end);
+      let nextCharacter =
+        typeof context.next === "string" ? context.next[0] : "";
       if (
         end === text.length &&
-        nextChar &&
-        !nextChar.match(WHITESPACE_PUNCTUATION)
+        nextCharacter &&
+        !nextCharacter.match(WHITESPACE_PUNCTUATION)
       ) {
         end -= match[5].length;
       } else {

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -922,7 +922,7 @@ After all the lists
       // *[menu.as](https://menu.as/)*\n\n\n\n__Missoni Partners with Donghia__\n\n
       test("delimiters wrapping links are not parsed as punctuation at paragraph boundaries", () => {
         let md =
-          "*[menu.as](https://menu.as/)*\n\n**Missoni Partners with Donghia**\n\n";
+          "[*menu.as*](https://menu.as/)\n\n**Missoni Partners with Donghia**\n\n";
         let mdDoc = CommonmarkSource.fromRaw(md);
         let document = mdDoc.convertTo(OffsetSource);
 
@@ -1331,8 +1331,8 @@ After all the lists
         {
           id: "1",
           type: "-offset-bold",
-          start: 0,
-          end: 0,
+          start: 1,
+          end: 1,
           attributes: {},
         },
         {
@@ -1724,7 +1724,9 @@ After all the lists
         content: "a\n\nb",
         annotations: [
           { type: "-offset-line-break", start: 1, end: 2, attributes: {} },
+          { type: "-atjson-parse-token", start: 1, end: 2, attributes: {} },
           { type: "-offset-line-break", start: 2, end: 3, attributes: {} },
+          { type: "-atjson-parse-token", start: 2, end: 3, attributes: {} },
         ],
       });
 
@@ -1746,6 +1748,7 @@ After all the lists
             attributes: { "-offset-level": 2 },
           },
           { type: "-offset-line-break", start: 1, end: 2, attributes: {} },
+          { type: "-atjson-parse-token", start: 1, end: 2, attributes: {} },
         ],
       });
 
@@ -1763,6 +1766,7 @@ After all the lists
             attributes: { "-offset-style": "inline" },
           },
           { type: "-offset-line-break", start: 1, end: 2, attributes: {} },
+          { type: "-atjson-parse-token", start: 1, end: 2, attributes: {} },
         ],
       });
 

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -32,6 +32,13 @@ describe("commonmark", () => {
               "Image descriptions ![are escaped](example.jpg)",
           },
         },
+        {
+          id: "1",
+          type: "-atjson-parse-token",
+          start: 0,
+          end: 1,
+          attributes: {},
+        },
       ],
     });
 
@@ -476,6 +483,13 @@ After all the lists
           attributes: {},
         },
         {
+          id: "p1",
+          type: "-atjson-parse-token",
+          start: 1,
+          end: 2,
+          attributes: {},
+        },
+        {
           id: "3",
           type: "-offset-paragraph",
           start: 2,
@@ -616,7 +630,7 @@ After all the lists
     });
 
     expect(CommonmarkRenderer.render(document)).toBe(
-      "**_bold then italic_** ***italic then bold***"
+      "***bold then italic*** ***italic then bold***"
     );
   });
 

--- a/packages/@atjson/renderer-commonmark/test/slice-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/slice-test.ts
@@ -60,7 +60,7 @@ describe("commonmark", () => {
     });
 
     expect(CommonmarkRenderer.render(doc)).toBe(
-      "And an *[emphasized link](https://www.bonappetit.com)*\n\n"
+      "And an [*emphasized link*](https://www.bonappetit.com)\n\n"
     );
   });
 });

--- a/packages/@atjson/renderer-hir/package.json
+++ b/packages/@atjson/renderer-hir/package.json
@@ -10,7 +10,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/hir": "0.24.2"
+    "@atjson/util": "0.2.0"
   },
   "devDependencies": {
     "@atjson/document": "0.27.1"

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -135,13 +135,22 @@ export default class Renderer {
     let renderer = new this(document, ...params.slice(1));
     let [remainder, slices] = extractSlices(
       document instanceof Document
-        ? serialize(document, { throwOnUnknown: true })
+        ? serialize(document, { onUnknown: "throw" })
         : document
     );
-    renderer.slices = slices;
-    return compile(renderer, null, createTree(remainder), ROOT, {
-      document: remainder,
-    });
+    renderer.slices = slices as Record<
+      string,
+      { text: string; marks: Mark[]; blocks: Block[] }
+    >;
+    return compile(
+      renderer,
+      null,
+      createTree(remainder) as Record<string, Array<Block | Mark | string>>,
+      ROOT,
+      {
+        document: remainder as { text: string; marks: Mark[]; blocks: Block[] },
+      }
+    );
   }
 
   private slices: Record<

--- a/packages/@atjson/renderer-hir/tsconfig.json
+++ b/packages/@atjson/renderer-hir/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "references": [{ "path": "../document" }, { "path": "../hir" }]
+  "references": [{ "path": "../document" }, { "path": "../util" }]
 }

--- a/packages/@atjson/renderer-html/src/index.ts
+++ b/packages/@atjson/renderer-html/src/index.ts
@@ -11,6 +11,7 @@ import {
   Section,
   TikTokEmbed,
 } from "@atjson/offset-annotations";
+import { Mark, Block } from "@atjson/document";
 import Renderer from "@atjson/renderer-hir";
 import * as entities from "entities";
 
@@ -91,7 +92,7 @@ export default class HTMLRenderer extends Renderer {
     return html.join("");
   }
 
-  *Blockquote(blockquote: Blockquote) {
+  *Blockquote(blockquote: Block<Blockquote>) {
     return yield* this.$("blockquote", {
       id: blockquote.attributes.anchorName,
     });
@@ -101,7 +102,7 @@ export default class HTMLRenderer extends Renderer {
     return yield* this.$("strong");
   }
 
-  *CerosEmbed(embed: CerosEmbed) {
+  *CerosEmbed(embed: Block<CerosEmbed>) {
     return `<div ${this.htmlAttributes({
       style: [
         "position: relative",
@@ -148,7 +149,7 @@ export default class HTMLRenderer extends Renderer {
     return yield* this.$("code");
   }
 
-  *CodeBlock(code: CodeBlock) {
+  *CodeBlock(code: Block<CodeBlock>) {
     let codeSnippet = yield* this.$("code");
     let attrs = this.htmlAttributes({ class: code.attributes.info });
     if (attrs.length) {
@@ -157,7 +158,7 @@ export default class HTMLRenderer extends Renderer {
     return `<pre>${codeSnippet}</pre>`;
   }
 
-  *Heading(heading: Heading) {
+  *Heading(heading: Block<Heading>) {
     let style: string | undefined;
     if (heading.attributes.alignment) {
       style = this.textAlign(heading.attributes.alignment);
@@ -172,7 +173,7 @@ export default class HTMLRenderer extends Renderer {
     return yield* this.$("hr");
   }
 
-  *Image(image: Image) {
+  *Image(image: Block<Image>) {
     return yield* this.$("img", {
       id: image.attributes.anchorName,
       src: image.attributes.url,
@@ -189,7 +190,7 @@ export default class HTMLRenderer extends Renderer {
     return yield* this.$("br");
   }
 
-  *Link(link: Link) {
+  *Link(link: Mark<Link>) {
     return yield* this.$("a", {
       href: encodeURI(link.attributes.url),
       title: link.attributes.title,
@@ -198,7 +199,7 @@ export default class HTMLRenderer extends Renderer {
     });
   }
 
-  *List(list: List) {
+  *List(list: Block<List>) {
     let tagName = list.attributes.type === "numbered" ? "ol" : "ul";
 
     return yield* this.$(tagName, {
@@ -209,13 +210,13 @@ export default class HTMLRenderer extends Renderer {
     });
   }
 
-  *ListItem(item: ListItem) {
+  *ListItem(item: Block<ListItem>) {
     return yield* this.$("li", {
       id: item.attributes.anchorName,
     });
   }
 
-  *Paragraph(paragraph: Paragraph) {
+  *Paragraph(paragraph: Block<Paragraph>) {
     let style: string | undefined;
     if (paragraph.attributes.alignment) {
       style = this.textAlign(paragraph.attributes.alignment);
@@ -223,7 +224,7 @@ export default class HTMLRenderer extends Renderer {
     return yield* this.$("p", { id: paragraph.attributes.anchorName, style });
   }
 
-  *Section(section: Section) {
+  *Section(section: Block<Section>) {
     return yield* this.$("section", {
       id: section.attributes.anchorName,
     });
@@ -246,7 +247,7 @@ export default class HTMLRenderer extends Renderer {
   }
 
   // This hook is TiktokEmbed instead of TikTokEmbed because of our classify function
-  *TiktokEmbed(embed: TikTokEmbed) {
+  *TiktokEmbed(embed: Block<TikTokEmbed>) {
     let parts = embed.attributes.url.split("/");
     let username = parts[parts.length - 3];
     let videoId = parts[parts.length - 1];

--- a/packages/@atjson/renderer-html/test/renderer-test.ts
+++ b/packages/@atjson/renderer-html/test/renderer-test.ts
@@ -21,6 +21,7 @@ import OffsetSource, {
   TikTokEmbed,
   Underline,
 } from "@atjson/offset-annotations";
+import { ParseAnnotation } from "@atjson/document";
 import Renderer from "../src";
 
 describe("renderer-html", () => {
@@ -130,7 +131,13 @@ describe("renderer-html", () => {
   test("horizontal rule", () => {
     let doc = new OffsetSource({
       content: "\uFFFC",
-      annotations: [new HorizontalRule({ start: 0, end: 1 })],
+      annotations: [
+        new HorizontalRule({ start: 0, end: 1 }),
+        new ParseAnnotation({
+          start: 0,
+          end: 1,
+        }),
+      ],
     });
 
     expect(Renderer.render(doc)).toEqual(`<hr />`);
@@ -149,7 +156,13 @@ describe("renderer-html", () => {
 
     let doc = new OffsetSource({
       content: "\uFFFC",
-      annotations: [image],
+      annotations: [
+        image,
+        new ParseAnnotation({
+          start: 0,
+          end: 1,
+        }),
+      ],
     });
 
     expect(Renderer.render(doc)).toEqual(
@@ -174,7 +187,13 @@ describe("renderer-html", () => {
   test("line break", () => {
     let doc = new OffsetSource({
       content: "\uFFFC",
-      annotations: [new LineBreak({ start: 0, end: 1 })],
+      annotations: [
+        new LineBreak({ start: 0, end: 1 }),
+        new ParseAnnotation({
+          start: 0,
+          end: 1,
+        }),
+      ],
     });
 
     expect(Renderer.render(doc)).toEqual(`<br />`);
@@ -476,6 +495,10 @@ describe("renderer-html", () => {
               aspectRatio: 2,
             },
           }),
+          new ParseAnnotation({
+            start: 0,
+            end: 1,
+          }),
         ],
       });
 
@@ -498,6 +521,10 @@ describe("renderer-html", () => {
               mobileAspectRatio: 3,
             },
           }),
+          new ParseAnnotation({
+            start: 0,
+            end: 1,
+          }),
         ],
       });
 
@@ -517,6 +544,10 @@ describe("renderer-html", () => {
           attributes: {
             url: "https://www.tiktok.com/@vogueitalia/video/6771026615137750277",
           },
+        }),
+        new ParseAnnotation({
+          start: 0,
+          end: 1,
         }),
       ],
     });

--- a/packages/@atjson/renderer-plain-text/test/text-renderer-test.ts
+++ b/packages/@atjson/renderer-plain-text/test/text-renderer-test.ts
@@ -78,6 +78,10 @@ describe("PlainTextRenderer", () => {
           start: 8,
           end: 9,
         }),
+        new ParseAnnotation({
+          start: 8,
+          end: 9,
+        }),
       ],
     });
 
@@ -90,6 +94,10 @@ describe("PlainTextRenderer", () => {
       content: "first line\uFFFCsecond line",
       annotations: [
         new LineBreak({
+          start: 10,
+          end: 11,
+        }),
+        new ParseAnnotation({
           start: 10,
           end: 11,
         }),


### PR DESCRIPTION
Effectively deprecates using `@atjson/hir` by replacing internal calling functions to use `@atjson/util` instead.

New things:
- `Mark<T>` and `Block<T>` are exported from `@atjson/document` which allow for developers to get the proper JSON from a mark or block given an annotation. (It's kind of similar to `PropsOf<T>`).
- On serialization, there's an option to throw errors or warn when encountering unknown annotations. This behavior is set to `throw` in rendering, and can be overridden as-needed.
- `@atjson/renderer-hir` uses `@atjson/util` internally and has two high level functions called `renderBlock` and `renderMark`, which act very simlarly to `renderAnnotation`.
- `@atjson/renderer-commonmark` will produce slightly different HTML than previous (ordering of bold / italic _will not_ be preserved). This is due to the rendering layer now serializing to the peritext format before passing info along to the renderer.
