### PR TITLE
fix: new URL for Ceros detection was not in try / catch

### DIFF
--- a/packages/@atjson/source-html/src/converter/third-party-embeds.ts
+++ b/packages/@atjson/source-html/src/converter/third-party-embeds.ts
@@ -14,7 +14,11 @@ function isCerosOriginDomainsScript(a: Annotation<any>) {
   if (src && src.indexOf("//") === 0) {
     src = `https:${src}`;
   }
-  return src && new URL(src).hostname === "view.ceros.com";
+  try {
+    return src && new URL(src).hostname === "view.ceros.com";
+  } catch (error) {
+    return false;
+  }
 }
 
 function isCerosContainer(a: Annotation<any>) {


### PR DESCRIPTION
This was causing failures when running performance checks.