### PR TITLE
Don't mutate attributes in renderers

### DIFF
--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -587,7 +587,8 @@ export default class CommonmarkRenderer extends Renderer {
         typeof context.previous !== "string" &&
         context.previous?.type === "list" &&
         context.previous.attributes.type === "numbered" &&
-        context.previous.attributes.delimiter === "."
+        (context.previous.attributes.delimiter === "." ||
+          context.previous.attributes.delimiter == null)
       ) {
         delimiter = ")";
       }
@@ -598,12 +599,12 @@ export default class CommonmarkRenderer extends Renderer {
         typeof context.previous !== "string" &&
         context.previous?.type === "list" &&
         context.previous.attributes.type === "bulleted" &&
-        context.previous.attributes.delimiter === "-"
+        (context.previous.attributes.delimiter === "-" ||
+          context.previous.attributes.delimiter == null)
       ) {
         delimiter = "+";
       }
     }
-    list.attributes.delimiter = delimiter;
 
     let state = Object.assign({}, this.state);
 


### PR DESCRIPTION
We were passing attributes by reference down to renderers, which we previously weren't. Instead of cloning the attributes, I'm instead opting to change rendering to not mutate attributes, since it caused a significant performance hit.