### PR TITLE
Setup publishing to happen via github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Docs
 on:
   push:
-    branches: [latest]
+    branches: [main]
 
 jobs:
   deploy_storybook:

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           path: baseline
-          ref: latest
+          ref: main
       - uses: actions/checkout@v3
         with:
           path: current

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,35 @@
+name: Prerelease
+on:
+  push:
+    branches: ["!main"]
+
+jobs:
+  publish:
+    environment: npm-prerelease
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.14.0"
+      - name: Install Dependencies
+        run: npm ci --no-optional
+      - name: Configure git
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/$GITHUB_REPOSITORY
+        env:
+          GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
+      - name: Fetch tags
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+        env:
+          GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
+      - name: Lerna publish
+        run: $(npm bin)/lerna publish --dist-tag dev --preid dev --conventional-prerelease --yes
+        env:
+          GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.ROBOT_NPM_TOKEN}}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,20 +1,36 @@
-name: Prerelease
+name: Pre-release
 on:
-  push:
-    branches: ["!main"]
+  issue_comment:
+    types: [created]
 
 jobs:
-  publish:
-    environment: npm-prerelease
+  lerna_publish:
     runs-on: ubuntu-latest
+    if: ${{github.event.issue.pull_request && contains(github.event.comment.body, "@copilot-robot prerelease")}}
     steps:
+      - uses: actions/github-script@v3
+        with:
+          script: |
+            try {
+              const result = await github.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.event.comment.id,
+                content: "+1"
+              });
+              return result.data
+            } catch (err) {
+              core.info(`Failed to set reaction error ${err}`)
+            }
+        env:
+          GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-node@v3
         with:
-          node-version: "16.14.0"
+          node-version: "16.13.0"
       - name: Install Dependencies
         run: npm ci --no-optional
       - name: Configure git
@@ -29,7 +45,36 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
       - name: Lerna publish
-        run: $(npm bin)/lerna publish --dist-tag dev --preid dev --conventional-prerelease --yes
+        id: publish
+        run: |
+          $(npm bin)/lerna publish\
+            --dist-tag "dev-${GITHUB_REF#refs/heads/}"\
+            --preid "dev-${GITHUB_REF#refs/heads/}"\
+            --conventional-prerelease\
+            -m 'chore(prerelease): publish'\
+            --yes
+            --summary-file
+          echo 'RESULTS<<EOF' >> $GITHUB_OUTPUT
+          cat ./lerna-publish-summary.json >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
           NODE_AUTH_TOKEN: ${{secrets.ROBOT_NPM_TOKEN}}
+      - uses: actions/github-script@v3
+        with:
+          script: |
+            try {
+              let packageInfo = JSON.parse(process.env.PUBLISH_RESULT);
+              const result = await github.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                content: `Hi, @${GITHUB_ACTOR}, a pre-release has been published:\n\n${packageInfo.map(package => `- ${package.packageName}@${package.version}`).join("\n")}`
+              });
+              return result.data
+            } catch (err) {
+              core.info(`Failed to reply to user with pre-release info ${err}`)
+            }
+        env:
+          GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
+          PUBLISH_RESULT: ${{steps.publish.outputs.RESULT}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    environment: npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.14.0"
+      - name: Install Dependencies
+        run: npm ci --no-optional
+      - name: Configure git
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/$GITHUB_REPOSITORY
+        env:
+          GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
+      - name: Fetch tags
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+        env:
+          GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
+      - name: Lerna publish
+        run: $(npm bin)/lerna publish --conventional-graduate --conventional-commits --yes
+        env:
+          GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.ROBOT_NPM_TOKEN}}


### PR DESCRIPTION
This adds two pipelines for releasing atjson (by prerelease and release) so developers can self-manage releases automatically via github's UI. Both prereleases and releases have blockers on them, which require an approval by any developer at Condé right now.