### PR TITLE
fix: handle four and five star formatting of markdown

### DIFF
--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -1,3 +1,4 @@
+import { deserialize } from "@atjson/document";
 import OffsetSource from "@atjson/offset-annotations";
 import CommonmarkSource from "@atjson/source-commonmark";
 import CommonmarkRenderer from "../src";
@@ -756,6 +757,48 @@ After all the lists
 
     expect(CommonmarkRenderer.render(document)).toBe(
       "**bold**_then italic_\n\n_italic_**then bold**\n\n"
+    );
+  });
+
+  test("five * are avoided", () => {
+    let document = deserialize(
+      {
+        text: "\uFFFCSpace: the final frontier",
+        blocks: [
+          {
+            id: "B00000000",
+            type: "text",
+            parents: [],
+            selfClosing: false,
+            attributes: {},
+          },
+        ],
+        marks: [
+          {
+            id: "M00000000",
+            type: "bold",
+            range: "[1..6]",
+            attributes: {},
+          },
+          {
+            id: "M00000001",
+            type: "italic",
+            range: "[1..6]",
+            attributes: {},
+          },
+          {
+            id: "M00000002",
+            type: "bold",
+            range: "[6..26]",
+            attributes: {},
+          },
+        ],
+      },
+      OffsetSource
+    );
+
+    expect(CommonmarkRenderer.render(document)).toBe(
+      "*__Space__***: the final frontier**"
     );
   });
 


### PR DESCRIPTION
For a _very_ specific case, we need to invert the nesting of bold and italic, since markdown can't handle four / five star delimiter runs when parsing.

Previously, we were producing invalid markdown that looked like the following:

> ```md
> ***Space*****: the final frontier**
> ```
> 
> ***Space*****: the final frontier**

The five star run is invalid, and using a naïve approach, we could adjust this so we fix the italic mark to render as an underscore, which would produce:

> ```md
> **_Space_****: the final frontier**
> ```
> 
> **_Space_****: the final frontier**


But this is also an invalid delimiter run!

We have to re-orient the bold and italic marks in the tree to create the following markdown, which is the only valid structure:

> ```md
> *__Space__***: the final frontier**
> ```
>
> *__Space__***: the final frontier**


Another solution here would be healing the mark ranges, which would produce less markup, and the same visual result:

> ```md
> ***Space*: the final frontier**
> ```
>
> ***Space*: the final frontier**

We are choosing not to handle this right now, since these _are_ cases that may come up when markdown is written.