### PR TITLE
feat: update markdown-it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "jest-environment-jsdom": "29.4.3",
         "lerna": "6.5.1",
         "lint-staged": "13.1.2",
-        "markdown-it": "10.0.0",
+        "markdown-it": "13.0.1",
         "minimist": "1.2.8",
         "prettier": "2.8.4",
         "react": "17.0.2",
@@ -12924,10 +12924,9 @@
       "dev": true
     },
     "node_modules/linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-      "dev": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
@@ -13584,14 +13583,13 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
-      "dev": true,
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       },
@@ -13599,11 +13597,21 @@
         "markdown-it": "bin/markdown-it.js"
       }
     },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
     "node_modules/markdown-it/node_modules/entities": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
-      "dev": true
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/mdurl": {
       "version": "1.0.1",
@@ -18051,8 +18059,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@atjson/offset-annotations": "0.46.3",
-        "entities": "4.4.0",
-        "markdown-it": "12.3.2"
+        "entities": "~3.0.1",
+        "markdown-it": "13.0.1"
       },
       "devDependencies": {
         "@atjson/document": "0.28.1"
@@ -18061,35 +18069,16 @@
         "@atjson/document": ">=0.26.0"
       }
     },
-    "packages/@atjson/source-commonmark/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "packages/@atjson/source-commonmark/node_modules/linkify-it": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-      "dependencies": {
-        "uc.micro": "^1.0.1"
+    "packages/@atjson/source-commonmark/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
-    },
-    "packages/@atjson/source-commonmark/node_modules/markdown-it": {
-      "version": "12.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      }
-    },
-    "packages/@atjson/source-commonmark/node_modules/markdown-it/node_modules/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
     },
     "packages/@atjson/source-gdocs-paste": {
       "version": "0.25.17",
@@ -18355,41 +18344,14 @@
       "requires": {
         "@atjson/document": "0.28.1",
         "@atjson/offset-annotations": "0.46.3",
-        "entities": "4.4.0",
-        "markdown-it": "12.3.2"
+        "entities": "~3.0.1",
+        "markdown-it": "13.0.1"
       },
       "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "linkify-it": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-          "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-          "requires": {
-            "uc.micro": "^1.0.1"
-          }
-        },
-        "markdown-it": {
-          "version": "12.3.2",
-          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-          "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-          "requires": {
-            "argparse": "^2.0.1",
-            "entities": "~2.1.0",
-            "linkify-it": "^3.0.1",
-            "mdurl": "^1.0.1",
-            "uc.micro": "^1.0.5"
-          },
-          "dependencies": {
-            "entities": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-              "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
-            }
-          }
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
         }
       }
     },
@@ -28046,10 +28008,9 @@
       "dev": true
     },
     "linkify-it": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-      "dev": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
       "requires": {
         "uc.micro": "^1.0.1"
       }
@@ -28542,23 +28503,26 @@
       "dev": true
     },
     "markdown-it": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
-      "dev": true,
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
       "requires": {
-        "argparse": "^1.0.7",
-        "entities": "~2.0.0",
-        "linkify-it": "^2.0.0",
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       },
       "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
         "entities": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
-          "dev": true
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jest-environment-jsdom": "29.4.3",
     "lerna": "6.5.1",
     "lint-staged": "13.1.2",
-    "markdown-it": "10.0.0",
+    "markdown-it": "13.0.1",
     "minimist": "1.2.8",
     "prettier": "2.8.4",
     "react": "17.0.2",

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -145,6 +145,20 @@ function escapePunctuation(
   }
 }
 
+function escapeDescription(text: string) {
+  let escaped = text
+    .replace(/([#!*+=\\^_`{|}~])/g, "\\\\$1")
+    .replace(/(\[)([^\]]*$)/g, "\\\\$1$2") // Escape bare opening brackets [
+    .replace(/(^[\s]*)>/g, "$1\\\\>") // Escape >
+    .replace(/(\]\()/g, "]\\\\(") // Escape parenthesis ](
+    .replace(/(^[^[]*)(\].*$)/g, "$1\\\\$2") // Escape bare closing brackets ]
+    .replace(/^(\s*\d+)\.(\s+)/gm, "$1\\\\.$2") // Escape list items; not all numbers
+    .replace(/(^[\s]*)-/g, "$1\\\\-") // `  - list item`
+    .replace(/(\r\n|\r|\n)([\s]*)-/g, "$1$2\\\\-"); // `- list item\n - list item`
+
+  return escapeEntities(escaped);
+}
+
 function escapeHtmlEntities(text: string) {
   return text
     .replace(/&([^\s]+);/g, "\\&$1;")
@@ -357,7 +371,7 @@ export default class CommonmarkRenderer extends Renderer {
    * ![CommonMark](http://commonmark.org/images/markdown-mark.png)
    */
   *Image(image: Image): Generator<void, string, string[]> {
-    let description = escapePunctuation(image.attributes.description || "");
+    let description = escapeDescription(image.attributes.description || "");
     if (image.attributes.title) {
       let title = image.attributes.title.replace(/"/g, '\\"');
       return `![${description}](${image.attributes.url} "${title}")`;

--- a/packages/@atjson/renderer-commonmark/test/commonmark-spec-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-spec-test.ts
@@ -84,8 +84,8 @@ Object.keys(unitTestsBySection).forEach((moduleName) => {
           }
 
           if (!original.equals(deserializedGenerated)) {
-            expect(original.canonical().withStableIds().toJSON()).toEqual(
-              deserializedGenerated.canonical().withStableIds().toJSON()
+            expect(serialize(original, { withStableIds: true })).toEqual(
+              serialize(deserializedGenerated, { withStableIds: true })
             );
           } else {
             expect(original.equals(deserializedGenerated)).toBe(true);

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -44,7 +44,7 @@ describe("commonmark", () => {
     });
 
     expect(CommonmarkRenderer.render(document)).toBe(
-      "![Image descriptions \\![are escaped]\\(example.jpg)](http://commonmark.org/images/markdown-mark.png)"
+      "![Image descriptions \\\\![are escaped]\\\\(example.jpg)](http://commonmark.org/images/markdown-mark.png)"
     );
   });
 

--- a/packages/@atjson/source-commonmark/package.json
+++ b/packages/@atjson/source-commonmark/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@atjson/offset-annotations": "0.46.3",
-    "entities": "4.4.0",
-    "markdown-it": "12.3.2"
+    "entities": "~3.0.1",
+    "markdown-it": "13.0.1"
   },
   "devDependencies": {
     "@atjson/document": "0.28.1"

--- a/packages/@atjson/source-commonmark/src/converter.ts
+++ b/packages/@atjson/source-commonmark/src/converter.ts
@@ -1,4 +1,4 @@
-import OffsetSource, { CodeBlock } from "@atjson/offset-annotations";
+import OffsetSource, { CodeBlock, Image } from "@atjson/offset-annotations";
 import CommonmarkSource from "./source";
 
 CommonmarkSource.defineConverterTo(
@@ -48,16 +48,20 @@ CommonmarkSource.defineConverterTo(
       .where({ type: "-commonmark-html_inline" })
       .set({ type: "-offset-html", attributes: { "-offset-style": "inline" } });
 
-    doc
-      .where({ type: "-commonmark-image" })
-      .set({ type: "-offset-image" })
-      .rename({
-        attributes: {
-          "-commonmark-src": "-offset-url",
-          "-commonmark-title": "-offset-title",
-          "-commonmark-alt": "-offset-description",
-        },
-      });
+    doc.where({ type: "-commonmark-image" }).update((image) => {
+      doc.replaceAnnotation(
+        image,
+        new Image({
+          start: image.start,
+          end: image.end,
+          attributes: {
+            url: image.attributes.src,
+            title: image.attributes.title,
+            description: image.attributes.alt,
+          },
+        })
+      );
+    });
 
     doc
       .where({ type: "-commonmark-link" })


### PR DESCRIPTION
This updates markdown-it to 13.0.1 (the most recent version of markdown-it) along with a change to entities to match the version specified. This contains some fixes which can be checked in https://github.com/CondeNast/atjson/pull/1319

