### PR TITLE
chore: remove half the parse tokens from source-commonmark

### DIFF
--- a/packages/@atjson/source-commonmark/src/parser.ts
+++ b/packages/@atjson/source-commonmark/src/parser.ts
@@ -234,8 +234,6 @@ export default class Parser {
 
     let closingToken = yield;
 
-    this.content += "\uFFFC";
-
     let end = this.content.length;
     let attributes = Object.assign(getAttributes(open), attrs || {});
     if (name === "heading") {
@@ -248,20 +246,11 @@ export default class Parser {
     if (this.handlers[name]) {
       Object.assign(attributes, this.handlers[name](open, closingToken));
     }
-    this.annotations.push(
-      new ParseAnnotation({
-        start: end - 1,
-        end,
-        attributes: {
-          reason: `${name}_close`,
-        },
-      }),
-      {
-        type: `-commonmark-${name}`,
-        start,
-        end,
-        attributes,
-      }
-    );
+    this.annotations.push({
+      type: `-commonmark-${name}`,
+      start,
+      end,
+      attributes,
+    });
   }
 }

--- a/packages/@atjson/source-commonmark/test/extensions-test.ts
+++ b/packages/@atjson/source-commonmark/test/extensions-test.ts
@@ -34,7 +34,7 @@ describe("strikethrough", () => {
       [
         {
           "attributes": {},
-          "end": 8,
+          "end": 7,
           "id": "00000003",
           "start": 1,
           "type": "-commonmark-s",
@@ -56,23 +56,23 @@ describe("strikethrough", () => {
       [
         {
           "attributes": {},
-          "end": 17,
+          "end": 14,
           "id": "00000001",
           "start": 0,
           "type": "-offset-paragraph",
         },
         {
           "attributes": {},
-          "end": 8,
+          "end": 7,
           "id": "00000003",
           "start": 1,
           "type": "-offset-strikethrough",
         },
         {
           "attributes": {},
-          "end": 16,
-          "id": "00000006",
-          "start": 9,
+          "end": 14,
+          "id": "00000005",
+          "start": 8,
           "type": "-offset-italic",
         },
       ]


### PR DESCRIPTION
Remove half of the parse tokens generated by the parser, reducing the size of `N` in `O(N)` by a 1/3.

The math for this is:
- 1 starting `+uFFFC` token and a parse token
- the markdown token
- 1 ending `+uFFFC` token and a parse token

So, from the following markdown, `**hello, world**`, we create: `+uFFFChello, world+uFFFC`. This pull request changes this to be `+uFFFChello, world`.

