### PR TITLE
fix: handle text blocks and mark nesting consistently

### DIFF
--- a/packages/@atjson/document/test/serialize-test.ts
+++ b/packages/@atjson/document/test/serialize-test.ts
@@ -4,6 +4,7 @@ import {
   serialize,
   UnknownAnnotation,
   is,
+  SliceAnnotation,
 } from "../src";
 import TestSource, {
   Anchor,
@@ -354,6 +355,77 @@ describe("serialize", () => {
           },
         ],
         marks: [],
+      });
+    });
+
+    test("continuations in blocks with parse tokens", () => {
+      expect(
+        serialize(
+          new TestSource({
+            content:
+              "<blockquote><p>“My main problem is that I have a lot of energy and I can’t say no,”</p><cite>Prue Leith</cite></blockquote>",
+            annotations: [
+              new ParseAnnotation({
+                start: 0,
+                end: 12,
+              }),
+              new ParseAnnotation({
+                start: 12,
+                end: 15,
+              }),
+              new Paragraph({
+                start: 12,
+                end: 87,
+              }),
+              new ParseAnnotation({
+                start: 83,
+                end: 87,
+              }),
+              new ParseAnnotation({
+                start: 87,
+                end: 93,
+              }),
+              new ParseAnnotation({
+                start: 103,
+                end: 110,
+              }),
+              new ParseAnnotation({
+                start: 110,
+                end: 123,
+              }),
+              new Quote({
+                start: 0,
+                end: 123,
+              }),
+              new SliceAnnotation({
+                start: 87,
+                end: 110,
+              }),
+            ],
+          })
+        )
+      ).toMatchObject({
+        text: "\uFFFC\uFFFC“My main problem is that I have a lot of energy and I can’t say no,”\uFFFCPrue Leith",
+        blocks: [
+          {
+            type: "quote",
+            parents: [],
+          },
+          {
+            type: "paragraph",
+            parents: ["quote"],
+          },
+          {
+            type: "text",
+            parents: ["quote"],
+          },
+        ],
+        marks: [
+          {
+            type: "slice",
+            range: "(70..81]",
+          },
+        ],
       });
     });
 


### PR DESCRIPTION
Previously, there were cases where text blocks could be inside or outside marks depending on whether there were parse tokens present. This was causing issues when testing equality between different formats. Markdown produced slices with `\uFFFCPrue Leith` (using the test below), whereas HTML produced slices with `Prue Leith` as the range of text.

I'm leaning to make the canonical approach `\uFFFCPrue Leith`, since when slicing out the text, it will cleanly remove both the text block and the text, where the approach currently being produced by the HTML will leave a stray `\uFFFC` token which will be created inside of the slice anyways 🙃 