### PR TITLE
combine major updates into single pr

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,14 @@
 {
   "extends": ["config:base"],
   "timezone": "America/New_York",
-  "schedule": ["after 10pm and before 5am on every weekday", "every weekend"],
+  "schedule": ["on the 2nd and 4th day instance on Monday after 8pm"],
   "rebaseStalePrs": false,
   "packageRules": [
+    {
+      "groupName": "major deps",
+      "groupSlug": "major-deps",
+      "matchUpdateTypes": ["major"]
+    },
     {
       "updateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
@@ -16,11 +21,6 @@
       "packagePatterns": ["@docusaurus/*"],
       "groupName": "docusaurus monorepo",
       "groupSlug": "docusaurus-monorepo"
-    },
-    {
-      "packagePatterns": ["@types/*"],
-      "groupName": "Type Declarations",
-      "groupSlug": "type-declarations"
     },
     {
       "packagePatterns": ["eslint", "eslint-plugin-*", "@typescript-eslint/*"],


### PR DESCRIPTION
This PR brings the renovate schedule in line with the other repos owned by the content team and unifies all major deps into 1 PR. it also removes the @types-specific rule so that those packages get merged automatically if they are minor or patch updates.