### PR TITLE
fix: sorting start/end tokens for zero-length marks

### DIFF
--- a/packages/@atjson/document/src/serialize.ts
+++ b/packages/@atjson/document/src/serialize.ts
@@ -152,9 +152,12 @@ export function sortTokens(a: Token, b: Token) {
     return indexDelta;
   }
 
-  // Handle start before end for a 0 length mark
+  // Handle start before end for a 0 length mark:
+  // We're assuming that one of `a` or `b` is a start
+  // token and the other is the end token. Sort the start
+  // token first
   if (a.annotation.id === b.annotation.id) {
-    return START_TOKENS.indexOf(a.type) ? 1 : -1;
+    return START_TOKENS.indexOf(a.type) !== -1 ? -1 : 1;
   }
 
   // Sort end tokens before start tokens

--- a/packages/@atjson/document/test/serialize-test.ts
+++ b/packages/@atjson/document/test/serialize-test.ts
@@ -793,6 +793,115 @@ describe("serialize", () => {
         });
       });
     });
+
+    test("0 length marks are sorted start -> end", () => {
+      let paragraph = new Paragraph({
+        id: "B00000000",
+        start: 0,
+        end: 5,
+      });
+      let bold = new Bold({
+        id: "M00000000",
+        start: 1,
+        end: 1,
+      });
+      let italic = new Italic({
+        id: "M00000001",
+        start: 3,
+        end: 3,
+      });
+      let tokens = [
+        {
+          annotation: paragraph,
+          type: "block",
+          edgeBehaviour: Paragraph.edgeBehaviour,
+        },
+        {
+          annotation: bold,
+          type: "mark",
+          edgeBehaviour: Bold.edgeBehaviour,
+        },
+        {
+          annotation: italic,
+          type: "mark",
+          edgeBehaviour: Italic.edgeBehaviour,
+        },
+      ].reduce((E, description) => {
+        E.push(
+          {
+            type:
+              description.type === "block"
+                ? TokenType.BLOCK_END
+                : TokenType.MARK_END,
+            index: description.annotation.start,
+            annotation: description.annotation,
+            shared: { start: -1 },
+            selfClosing: false,
+            edgeBehaviour: description.edgeBehaviour,
+          },
+          {
+            type:
+              description.type === "block"
+                ? TokenType.BLOCK_START
+                : TokenType.MARK_START,
+            index: description.annotation.start,
+            annotation: description.annotation,
+            shared: { start: -1 },
+            selfClosing: false,
+            edgeBehaviour: description.edgeBehaviour,
+          }
+        );
+        return E;
+      }, [] as Token[]);
+
+      tokens.sort(sortTokens);
+
+      expect(
+        tokens.map((token) => {
+          switch (token.type) {
+            case TokenType.BLOCK_START:
+              return { id: token.annotation.id, type: "BLOCK_START" };
+            case TokenType.BLOCK_END:
+              return { id: token.annotation.id, type: "BLOCK_END" };
+            case TokenType.MARK_START:
+              return { id: token.annotation.id, type: "MARK_START" };
+            case TokenType.MARK_END:
+              return { id: token.annotation.id, type: "MARK_END" };
+            case TokenType.PARSE_START:
+              return { id: token.annotation.id, type: "PARSE_START" };
+            case TokenType.PARSE_END:
+              return { id: token.annotation.id, type: "PARSE_END" };
+          }
+        })
+      ).toMatchInlineSnapshot(`
+        [
+          {
+            "id": "B00000000",
+            "type": "BLOCK_START",
+          },
+          {
+            "id": "B00000000",
+            "type": "BLOCK_END",
+          },
+          {
+            "id": "M00000000",
+            "type": "MARK_START",
+          },
+          {
+            "id": "M00000000",
+            "type": "MARK_END",
+          },
+          {
+            "id": "M00000001",
+            "type": "MARK_START",
+          },
+          {
+            "id": "M00000001",
+            "type": "MARK_END",
+          },
+        ]
+      `);
+    });
   });
 });
 


### PR DESCRIPTION
Fix a bug where we were sorting the MARK_END token before the MARK_START token for zero-length marks. In the case we have:
* two tokens with the same index
* and the same annotation ID we assume that one of them is the start and the other is the end token. If the first is the start token, return -1 in the comparator to sort it first