### PR TITLE
fix: strip newline when converting firework embed codes

### DIFF
--- a/packages/@atjson/source-html/src/converter/third-party-embeds.ts
+++ b/packages/@atjson/source-html/src/converter/third-party-embeds.ts
@@ -116,6 +116,10 @@ export default function convertThirdPartyEmbeds(doc: Document) {
           },
         })
       );
+      // Remove newlines from embed code
+      if (scripts.length) {
+        doc.deleteText(scripts[0].end, embed.start);
+      }
       doc.removeAnnotations(scripts);
     });
 

--- a/packages/@atjson/source-html/test/firework-embed-test.ts
+++ b/packages/@atjson/source-html/test/firework-embed-test.ts
@@ -108,7 +108,7 @@ describe("Firework embeds", () => {
       `<script async
         type="text/javascript"
         src="//asset.fwpub1.com/js/embed-feed.js"
-       ></script><fw-embed-feed
+       ></script>\n<fw-embed-feed
         channel="awesome-channel"
         playlist="jkl"
         mode="row"
@@ -145,7 +145,7 @@ describe("Firework embeds", () => {
       `<script async
         type="text/javascript"
         src="//asset.fwcdn3.com/js/embed-feed.js"
-       ></script><fw-embed-feed
+       ></script>\n<fw-embed-feed
         channel="awesome-channel"
         playlist="jkl"
         mode="row"


### PR DESCRIPTION
Firework embed codes from their CMS has newlines between the script tag and web component. This results in an unintentional newline being added to the text when pasted in to a document.