### PR TITLE
fix: normalize mark boundaries from google docs paste

### DIFF
--- a/packages/@atjson/source-gdocs-paste/src/converter.ts
+++ b/packages/@atjson/source-gdocs-paste/src/converter.ts
@@ -1,6 +1,7 @@
 import {
   Annotation,
   BlockAnnotation,
+  InlineAnnotation,
   ParseAnnotation,
   compareAnnotations,
   is,
@@ -311,6 +312,24 @@ GDocsSource.defineConverterTo(OffsetSource, (doc) => {
         })
       );
       item.end--;
+    });
+
+  // adjust marks to not cover whitespace at the start / end positions
+  doc
+    .where((a) => a instanceof InlineAnnotation)
+    .update((mark) => {
+      let start = mark.start;
+      let end = mark.end;
+      while (doc.content[start].match(/\s/) && start < end) {
+        start++;
+      }
+
+      while (doc.content[end - 1].match(/\s/) && end > start) {
+        end--;
+      }
+
+      mark.start = start;
+      mark.end = end;
     });
 
   return doc;

--- a/website/src/components/GDocsPasteDemo.tsx
+++ b/website/src/components/GDocsPasteDemo.tsx
@@ -1,3 +1,4 @@
+import { serialize } from "@atjson/document";
 import OffsetSource from "@atjson/offset-annotations";
 import GoogleDocsPasteSource from "@atjson/source-gdocs-paste";
 import CodeBlock from "@theme/CodeBlock";
@@ -6,9 +7,10 @@ import { FC, useState } from "react";
 import { TextArea } from "./TextArea";
 
 const AtjsonBlock: FC<{ document: OffsetSource }> = (props) => {
-  let { schema, ...json } = props.document.toJSON();
   return (
-    <CodeBlock className="json">{JSON.stringify(json, null, 2)}</CodeBlock>
+    <CodeBlock className="json">
+      {JSON.stringify(serialize(props.document), null, 2)}
+    </CodeBlock>
   );
 };
 


### PR DESCRIPTION
This adjusts whitespace from Google Docs paste so when rendering to HTML, marks are sticky to text instead of wrapping around whitespace (which happens fairly often due to imprecise UI in Google Docs)