### PR TITLE
fix: handle zero-width marks when adjusting for whitespace

### DIFF
--- a/packages/@atjson/source-gdocs-paste/src/converter.ts
+++ b/packages/@atjson/source-gdocs-paste/src/converter.ts
@@ -320,11 +320,19 @@ GDocsSource.defineConverterTo(OffsetSource, (doc) => {
     .update((mark) => {
       let start = mark.start;
       let end = mark.end;
-      while (doc.content[start].match(/\s/) && start < end) {
+      while (
+        start < end &&
+        doc.content[start] &&
+        doc.content[start].match(/\s/)
+      ) {
         start++;
       }
 
-      while (doc.content[end - 1].match(/\s/) && end > start) {
+      while (
+        end > start &&
+        doc.content[end - 1] &&
+        doc.content[end - 1].match(/\s/)
+      ) {
         end--;
       }
 


### PR DESCRIPTION
Pasted content from GDocs may contain a number of zero-width marks. When these appeared at the beginning of the content, we'd hit a bug when trying to adjust the marks for whitespace.