### PR TITLE
chore: add captions to firework embed

### DIFF
--- a/packages/@atjson/source-html/src/annotations/firework-embed.ts
+++ b/packages/@atjson/source-html/src/annotations/firework-embed.ts
@@ -15,6 +15,7 @@ export class FireworkEmbed extends ObjectAnnotation<
     pip?: boolean;
     player_minimize?: boolean;
     branding?: boolean;
+    captions?: boolean;
   }
 > {
   static vendorPrefix = "html";

--- a/packages/@atjson/source-html/src/annotations/firework-embed.ts
+++ b/packages/@atjson/source-html/src/annotations/firework-embed.ts
@@ -2,6 +2,9 @@
 import { ObjectAnnotation } from "@atjson/document";
 import { GlobalAttributes } from "../global-attributes";
 
+// See https://docs.firework.com/home/web/integration-guide/components/embed-feed
+// for documentation on this.
+
 export class FireworkEmbed extends ObjectAnnotation<
   GlobalAttributes & {
     id: string;

--- a/packages/@atjson/source-html/test/firework-embed-test.ts
+++ b/packages/@atjson/source-html/test/firework-embed-test.ts
@@ -30,7 +30,7 @@ describe("Firework embeds", () => {
 
   test("without channel name", () => {
     let doc = HTMLSource.fromRaw(
-      `<fw-embed-feed id="firework-embed-2" playlist="def" mode="row" open_in="_modal" max_videos="0" placement="middle" player_placement="bottom-right" pip="false" player_minimize="false" branding="false"></fw-embed-feed>`
+      `<fw-embed-feed id="firework-embed-2" playlist="def" mode="row" open_in="_modal" max_videos="0" placement="middle" player_placement="bottom-right" pip="false" captions="false" player_minimize="false" branding="false"></fw-embed-feed>`
     ).convertTo(OffsetSource);
 
     expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
@@ -55,7 +55,7 @@ describe("Firework embeds", () => {
 
   test("without channel open_in", () => {
     let doc = HTMLSource.fromRaw(
-      `<fw-embed-feed id="firework-embed-3" channel="vanity_fair" playlist="hij" mode="row" max_videos="0" placement="middle" player_placement="bottom-right" pip="false" player_minimize="false" branding="false"></fw-embed-feed>`
+      `<fw-embed-feed id="firework-embed-3" channel="vanity_fair" playlist="hij" mode="row" max_videos="0" placement="middle" player_placement="bottom-right" pip="false" captions="false" player_minimize="false" branding="false"></fw-embed-feed>`
     ).convertTo(OffsetSource);
 
     expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
@@ -80,7 +80,7 @@ describe("Firework embeds", () => {
 
   test("combined playlist and channel", () => {
     let doc = HTMLSource.fromRaw(
-      `<fw-embed-feed id="firework-embed-3" channel="undefined" playlist="allure|hij" mode="row" max_videos="0" placement="middle" player_placement="bottom-right" pip="false" player_minimize="false" branding="false"></fw-embed-feed>`
+      `<fw-embed-feed id="firework-embed-3" channel="undefined" playlist="allure|hij" mode="row" max_videos="0" placement="middle" player_placement="bottom-right" pip="false" captions="false" player_minimize="false" branding="false"></fw-embed-feed>`
     ).convertTo(OffsetSource);
 
     expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`


### PR DESCRIPTION
We need to update the parameters of the firework embed to allow for captions="false"

The current firework embed that is pasted into copilot looks like this:

```
<fw-embed-feed
  channel="voguemagazine" 
  playlist="gp7a2o"
  mode="row"
  open_in="default"
  max_videos="0"
  placement="middle"
  player_placement="bottom-right">
</fw-embed-feed>
```

We need to add the captions parameter to the accepted params in the Copilot UI.

AC:

captions=”false” is added to the accepted params for the firework embed in Copilot