### PR TITLE
chore: replace iframe render by script

### DIFF
--- a/packages/@atjson/renderer-html/src/index.ts
+++ b/packages/@atjson/renderer-html/src/index.ts
@@ -261,13 +261,15 @@ export default class HTMLRenderer extends Renderer {
 
   // CNE Audio embed
   *CneAudioEmbed(embed: Block<CneAudioEmbed>) {
-    return yield* this.$("iframe", {
-      id: embed.attributes.anchorName,
-      src: `https://embed-audio.cnevids.com/iframe/${embed.attributes.audioType}/${embed.attributes.audioId}`,
-      frameborder: "0",
-      height: "244",
-      sandbox: "allow-scripts allow-popups allow-popups-to-escape-sandbox",
-    });
+    let slot = `<div id="${embed.id}"></div>`;
+    if (embed.attributes.anchorName) {
+      slot = `<div id="${embed.attributes.anchorName}">${slot}</div>`;
+    }
+    let url = new URL(
+      `https://embed-audio.cnevids.com/script/${embed.attributes.audioType}/${embed.attributes.audioId}?target=js-audio`
+    );
+    url.searchParams.set("target", embed.id);
+    return `<script src="${url.toString()}" defer></script>${slot}`;
   }
 
   *Underline() {

--- a/packages/@atjson/renderer-html/test/renderer.test.ts
+++ b/packages/@atjson/renderer-html/test/renderer.test.ts
@@ -565,6 +565,7 @@ describe("renderer-html", () => {
         new CneAudioEmbed({
           start: 0,
           end: 1,
+          id: "B00000000",
           attributes: {
             anchorName: "podcast",
             audioType: "episode",
@@ -581,7 +582,7 @@ describe("renderer-html", () => {
     expect(
       Renderer.render(serialize(doc, { withStableIds: true }))
     ).toMatchInlineSnapshot(
-      `"<iframe id="podcast" src="https://embed-audio.cnevids.com/iframe/episode/bb2ef05b-de71-469a-b0a5-829f2a54dac6" frameborder="0" height="244" sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"></iframe>"`
+      `"<script src="https://embed-audio.cnevids.com/script/episode/bb2ef05b-de71-469a-b0a5-829f2a54dac6?target=B00000000" defer></script><div id="podcast"><div id="B00000000"></div></div>"`
     );
   });
 });


### PR DESCRIPTION
hey @tim-evans thanks a lot for your contributions I really appreciate your support!

I don't have yet a deep understanding about every packages in atjson, but I would like to render always the script version because `iframe` and `script` have different capabilities in terms of tracking interacion and also depending of the audioType have different height. If this looks good four you, please merge to the WIP branch.

Thanks!