### PR TITLE
fix(react): rearchitect Node so Children.map can be used by consumers

### DIFF
--- a/packages/@atjson/react/src/components/Slice.ts
+++ b/packages/@atjson/react/src/components/Slice.ts
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from "react";
 import { createElement, Fragment, useContext, useMemo } from "react";
-import { createTree, ROOT } from "@atjson/util";
+import { Block, createTree, InternalMark, ROOT } from "@atjson/util";
 import { Node } from "./Node";
 import { SliceContext } from "../contexts";
 
@@ -26,8 +26,24 @@ export function Slice(props: {
     [value]
   );
 
+  let children = useMemo(() => {
+    if (tree && ROOT in tree) {
+      return tree[ROOT] as Array<InternalMark | Block | string>;
+    }
+    return [""];
+  }, [tree]);
+
   if (tree) {
-    return createElement(Node, { map: tree, id: ROOT });
+    return createElement(
+      Fragment,
+      {},
+      children.map((child) => {
+        if (typeof child === "string") {
+          return child;
+        }
+        return createElement(Node, { value: child, map: tree! });
+      })
+    );
   } else {
     return createElement(Fragment, {}, fallback);
   }

--- a/packages/@atjson/react/src/components/Slice.ts
+++ b/packages/@atjson/react/src/components/Slice.ts
@@ -1,6 +1,6 @@
 import type { ReactElement, ReactNode } from "react";
 import { createElement, Fragment, useContext, useMemo } from "react";
-import { Block, createTree, InternalMark, ROOT } from "@atjson/util";
+import { createTree, ROOT } from "@atjson/util";
 import { Node } from "./Node";
 import { SliceContext } from "../contexts";
 
@@ -27,8 +27,8 @@ export function Slice(props: {
   );
 
   let children = useMemo(() => {
-    if (tree && ROOT in tree) {
-      return tree[ROOT] as Array<InternalMark | Block | string>;
+    if (tree && tree.has(ROOT)) {
+      return tree.get(ROOT) ?? [""];
     }
     return [""];
   }, [tree]);

--- a/packages/@atjson/react/src/index.ts
+++ b/packages/@atjson/react/src/index.ts
@@ -1,8 +1,8 @@
-import type { Block, Mark } from "@atjson/util";
+import type { Block, InternalMark, Mark } from "@atjson/util";
 import { ROOT, createTree, extractSlices } from "@atjson/util";
 import { ComponentContext, ComponentProvider, SliceContext } from "./contexts";
 import { Node, Slice } from "./components";
-import { useMemo, createElement } from "react";
+import { useMemo, createElement, Fragment } from "react";
 
 export { ComponentContext, ComponentProvider, Slice };
 
@@ -22,10 +22,26 @@ export default function Text(props: {
     return [createTree(doc), slices] as const;
   }, [props.value]);
 
+  let children = useMemo(() => {
+    if (ROOT in tree) {
+      return tree[ROOT] as Array<InternalMark | Block | string>;
+    }
+    return [""];
+  }, [tree]);
+
   return createElement(
     SliceContext.Provider,
     { value: slices },
-    createElement(Node, { map: tree, id: ROOT })
+    createElement(
+      Fragment,
+      {},
+      children.map((child) => {
+        if (typeof child === "string") {
+          return child;
+        }
+        return createElement(Node, { value: child, map: tree });
+      })
+    )
   );
 }
 Text.displayName = "Text";

--- a/packages/@atjson/react/src/index.ts
+++ b/packages/@atjson/react/src/index.ts
@@ -1,4 +1,4 @@
-import type { Block, InternalMark, Mark } from "@atjson/util";
+import type { Block, Mark } from "@atjson/util";
 import { ROOT, createTree, extractSlices } from "@atjson/util";
 import { ComponentContext, ComponentProvider, SliceContext } from "./contexts";
 import { Node, Slice } from "./components";
@@ -23,8 +23,8 @@ export default function Text(props: {
   }, [props.value]);
 
   let children = useMemo(() => {
-    if (ROOT in tree) {
-      return tree[ROOT] as Array<InternalMark | Block | string>;
+    if (tree.has(ROOT)) {
+      return tree.get(ROOT) ?? [""];
     }
     return [""];
   }, [tree]);
@@ -39,7 +39,7 @@ export default function Text(props: {
         if (typeof child === "string") {
           return child;
         }
-        return createElement(Node, { value: child, map: tree });
+        return createElement(Node, { value: child, map: tree, key: child.id });
       })
     )
   );

--- a/packages/@atjson/react/test/children.test.tsx
+++ b/packages/@atjson/react/test/children.test.tsx
@@ -1,0 +1,160 @@
+import * as React from "react";
+import * as ReactDOMServer from "react-dom/server";
+import Text, { ComponentProvider } from "../src";
+
+function classify(type: string) {
+  return (
+    type[0].toUpperCase() +
+    type.slice(1).replace(/-([a-z])/g, (_, letter) => {
+      return letter.toUpperCase();
+    })
+  );
+}
+
+describe("children", () => {
+  test("count", () => {
+    function ListItem(props: React.PropsWithChildren) {
+      return <li>{props.children}</li>;
+    }
+
+    function List(props: React.PropsWithChildren) {
+      expect(React.Children.count(props.children)).toBe(4);
+      return <ul>{props.children}</ul>;
+    }
+
+    expect(
+      ReactDOMServer.renderToStaticMarkup(
+        <ComponentProvider
+          value={{
+            keyOf(annotation) {
+              return classify(annotation.type);
+            },
+            blocks: { List, ListItem },
+            marks: {},
+          }}
+        >
+          <Text
+            value={{
+              text: "\uFFFC\uFFFCOne fish\uFFFCTwo fish\uFFFCRed fish\uFFFCBlue fish",
+              blocks: [
+                {
+                  id: "B0",
+                  type: "list",
+                  parents: [],
+                  selfClosing: false,
+                  attributes: {},
+                },
+                {
+                  id: "B1",
+                  type: "list-item",
+                  parents: ["list"],
+                  selfClosing: false,
+                  attributes: {},
+                },
+                {
+                  id: "B2",
+                  type: "list-item",
+                  parents: ["list"],
+                  selfClosing: false,
+                  attributes: {},
+                },
+                {
+                  id: "B3",
+                  type: "list-item",
+                  parents: ["list"],
+                  selfClosing: false,
+                  attributes: {},
+                },
+                {
+                  id: "B4",
+                  type: "list-item",
+                  parents: ["list"],
+                  selfClosing: false,
+                  attributes: {},
+                },
+              ],
+
+              marks: [],
+            }}
+          />
+        </ComponentProvider>
+      )
+    ).toMatchInlineSnapshot(
+      `"<ul><li>One fish</li><li>Two fish</li><li>Red fish</li><li>Blue fish</li></ul>"`
+    );
+  });
+
+  test("map", () => {
+    function List(props: React.PropsWithChildren) {
+      expect(React.Children.count(props.children)).toBe(4);
+      return (
+        <ul>
+          {React.Children.map(props.children, (child) => {
+            return <li>{child} fish</li>;
+          })}
+        </ul>
+      );
+    }
+
+    expect(
+      ReactDOMServer.renderToStaticMarkup(
+        <ComponentProvider
+          value={{
+            keyOf(annotation) {
+              return classify(annotation.type);
+            },
+            blocks: { List },
+            marks: {},
+          }}
+        >
+          <Text
+            value={{
+              text: "\uFFFC\uFFFCOne\uFFFCTwo\uFFFCRed\uFFFCBlue",
+              blocks: [
+                {
+                  id: "B0",
+                  type: "list",
+                  parents: [],
+                  selfClosing: false,
+                  attributes: {},
+                },
+                {
+                  id: "B1",
+                  type: "list-item",
+                  parents: ["list"],
+                  selfClosing: false,
+                  attributes: {},
+                },
+                {
+                  id: "B2",
+                  type: "list-item",
+                  parents: ["list"],
+                  selfClosing: false,
+                  attributes: {},
+                },
+                {
+                  id: "B3",
+                  type: "list-item",
+                  parents: ["list"],
+                  selfClosing: false,
+                  attributes: {},
+                },
+                {
+                  id: "B4",
+                  type: "list-item",
+                  parents: ["list"],
+                  selfClosing: false,
+                  attributes: {},
+                },
+              ],
+
+              marks: [],
+            }}
+          />
+        </ComponentProvider>
+      )
+    ).toMatchInlineSnapshot(
+      `"<ul><li>One fish</li><li>Two fish</li><li>Red fish</li><li>Blue fish</li></ul>"`
+    );
+  });
+});

--- a/packages/@atjson/react/test/slice.test.tsx
+++ b/packages/@atjson/react/test/slice.test.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+import * as ReactDOMServer from "react-dom/server";
+import Text, { ComponentProvider, Slice } from "../src";
+
+function classify(type: string) {
+  return (
+    type[0].toUpperCase() +
+    type.slice(1).replace(/-([a-z])/g, (_, letter) => {
+      return letter.toUpperCase();
+    })
+  );
+}
+
+describe("slice", () => {
+  test("single reference", () => {
+    function Photo(props: { alt: string; url: string; caption?: string }) {
+      return (
+        <figure>
+          <img src={props.url} alt={props.alt} />
+          <figcaption>
+            <Slice value={props.caption} />
+          </figcaption>
+        </figure>
+      );
+    }
+
+    expect(
+      ReactDOMServer.renderToStaticMarkup(
+        <ComponentProvider
+          value={{
+            keyOf(annotation) {
+              return classify(annotation.type);
+            },
+            blocks: { Photo },
+            marks: {},
+          }}
+        >
+          <Text
+            value={{
+              text: "\uFFFCMeowwww",
+              blocks: [
+                {
+                  id: "B0",
+                  type: "photo",
+                  parents: [],
+                  selfClosing: false,
+                  attributes: {
+                    alt: "Cat coming out of a TV in a reference to “The Ring”",
+                    caption: "M0",
+                    url: "https://i.kym-cdn.com/photos/images/newsfeed/001/233/590/acd.jpg",
+                  },
+                },
+              ],
+
+              marks: [
+                {
+                  id: "M0",
+                  type: "slice",
+                  range: "[1..8]",
+                  attributes: {},
+                },
+              ],
+            }}
+          />
+        </ComponentProvider>
+      )
+    ).toMatchInlineSnapshot(
+      `"<figure><img src="https://i.kym-cdn.com/photos/images/newsfeed/001/233/590/acd.jpg" alt="Cat coming out of a TV in a reference to “The Ring”"/><figcaption>Meowwww</figcaption></figure>"`
+    );
+  });
+});


### PR DESCRIPTION
While playing with this library, I noticed that `Children.map` was returning a single node instead of N nodes, which makes it harder to encapsulate higher order behaviors in things like groups.