### PR TITLE
chore: convert iframe `sandbox` attr

### DIFF
--- a/packages/@atjson/source-html/src/converter/index.ts
+++ b/packages/@atjson/source-html/src/converter/index.ts
@@ -53,6 +53,7 @@ HTMLSource.defineConverterTo(OffsetSource, function HTMLToOffset(doc) {
           url: iframe.attributes.src,
           height: iframe.attributes.height,
           width: iframe.attributes.width,
+          sandbox: iframe.attributes.sandbox,
           anchorName: iframe.attributes.id,
         },
       })

--- a/packages/@atjson/source-html/test/converter.test.ts
+++ b/packages/@atjson/source-html/test/converter.test.ts
@@ -544,6 +544,33 @@ describe("@atjson/source-html", () => {
       `);
     });
 
+    test("iframe embeds with sandbox", () => {
+      let doc = HTMLSource.fromRaw(
+        `<iframe src="https://example.com"
+            scrolling="no" frameborder="0"
+            allowTransparency="true" allow="encrypted-media" sandbox="allow-same-origin,allow-scripts,allow-popups,allow-popups-to-escape-sandbox,allow-forms"></iframe>`
+      ).convertTo(OffsetSource);
+
+      expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+        {
+          "blocks": [
+            {
+              "attributes": {
+                "sandbox": "allow-same-origin,allow-scripts,allow-popups,allow-popups-to-escape-sandbox,allow-forms",
+                "url": "https://example.com",
+              },
+              "id": "B00000000",
+              "parents": [],
+              "selfClosing": false,
+              "type": "iframe-embed",
+            },
+          ],
+          "marks": [],
+          "text": "￼",
+        }
+      `);
+    });
+
     describe("social embeds", () => {
       test("Facebook iframe embed", () => {
         let doc = HTMLSource.fromRaw(


### PR DESCRIPTION
Update our html-source to convert the `sandbox` attribute for iframe elements. 

This attribute is already supported in the iframe-embed annotation in the offset-annotations source