### PR TITLE
fix: convert space to commas in sandbox attr

### DIFF
--- a/packages/@atjson/source-html/src/converter/index.ts
+++ b/packages/@atjson/source-html/src/converter/index.ts
@@ -1,4 +1,4 @@
-import Document, { Annotation } from "@atjson/document";
+import Document, { Annotation, AttributesOf } from "@atjson/document";
 import OffsetSource, {
   CodeBlock,
   List,
@@ -44,18 +44,21 @@ HTMLSource.defineConverterTo(OffsetSource, function HTMLToOffset(doc) {
   convertVideoEmbeds(doc);
 
   doc.where({ type: "-html-iframe" }).update(function updateIframes(iframe) {
+    const attributes = {
+      url: iframe.attributes.src,
+      height: iframe.attributes.height,
+      width: iframe.attributes.width,
+      anchorName: iframe.attributes.id,
+    } as AttributesOf<IframeEmbed>;
+    if (iframe.attributes.sandbox) {
+      attributes.sandbox = iframe.attributes.sandbox.split(" ").join(",");
+    }
     doc.replaceAnnotation(
       iframe,
       new IframeEmbed({
         start: iframe.start,
         end: iframe.end,
-        attributes: {
-          url: iframe.attributes.src,
-          height: iframe.attributes.height,
-          width: iframe.attributes.width,
-          sandbox: iframe.attributes.sandbox,
-          anchorName: iframe.attributes.id,
-        },
+        attributes,
       })
     );
   });

--- a/packages/@atjson/source-html/test/converter.test.ts
+++ b/packages/@atjson/source-html/test/converter.test.ts
@@ -548,7 +548,7 @@ describe("@atjson/source-html", () => {
       let doc = HTMLSource.fromRaw(
         `<iframe src="https://example.com"
             scrolling="no" frameborder="0"
-            allowTransparency="true" allow="encrypted-media" sandbox="allow-same-origin,allow-scripts,allow-popups,allow-popups-to-escape-sandbox,allow-forms"></iframe>`
+            allowTransparency="true" allow="encrypted-media" sandbox="allow-same-origin allow-scripts allow-popups allow-popups-to-escape-sandbox allow-forms"></iframe>`
       ).convertTo(OffsetSource);
 
       expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`


### PR DESCRIPTION
The `sandbox` attribute on an `<iframe>` element will be space- delimited, but our convention is to have this be comma-delimited on the IframeEmbed annotation