### PR TITLE
fix: handle overlapping slices

### DIFF
--- a/packages/@atjson/util/src/index.ts
+++ b/packages/@atjson/util/src/index.ts
@@ -195,7 +195,7 @@ export function extractSlices(value: {
         let currentSlice = stack[stack.length - 1];
         // If there is another slice on the stack,
         // we will need to split the range
-        if (currentSlice) {
+        if (currentSlice && !token.mark.attributes.retain) {
           let currentSliceRanges = currentSlice.ranges;
           let [start, end] = currentSliceRanges.pop() as [number, number];
           currentSliceRanges.push([start, token.index], [token.index, end]);
@@ -205,8 +205,13 @@ export function extractSlices(value: {
       }
       case TokenType.SLICE_END: {
         stack.pop();
+
         let currentSlice = stack[stack.length - 1];
-        if (currentSlice && currentSlice.id !== token.id) {
+        if (
+          currentSlice &&
+          currentSlice.id !== token.id &&
+          !token.mark.attributes.retain
+        ) {
           let currentSliceRanges = currentSlice.ranges;
           let [, end] = currentSliceRanges.pop() as [number, number];
           currentSliceRanges.push([token.index, end]);

--- a/packages/@atjson/util/test/extract-slices.test.ts
+++ b/packages/@atjson/util/test/extract-slices.test.ts
@@ -383,4 +383,168 @@ describe("extractSlices", () => {
     expect(slices.get("M00000000")?.blocks[0].parents).toStrictEqual([]);
     expect(slices.get("M00000000")?.blocks[1].parents).toStrictEqual([]);
   });
+
+  describe("overlapping slices", () => {
+    test("multiple in sequence", () => {
+      const original = {
+        text: "￼ABACA",
+        blocks: [
+          {
+            id: "B00000000",
+            type: "paragraph",
+            parents: [],
+            selfClosing: false,
+            attributes: {},
+          },
+        ],
+        marks: [
+          {
+            id: "M00000000",
+            type: "slice",
+            range: "(0..6]",
+            attributes: {
+              refs: ["M00000000"],
+            },
+          },
+          {
+            id: "M00000001",
+            type: "slice",
+            range: "(2..3]",
+            attributes: {
+              refs: ["B00000000"],
+            },
+          },
+          {
+            id: "M00000002",
+            type: "slice",
+            range: "(4..5]",
+            attributes: {
+              refs: ["B00000000"],
+            },
+          },
+        ],
+      };
+      let [, slices] = extractSlices(original);
+      expect(slices.get("M00000000")?.text).toEqual("￼AAA");
+      expect(slices.get("M00000001")?.text).toEqual("￼B");
+      expect(slices.get("M00000002")?.text).toEqual("￼C");
+    });
+
+    test("start slice position matches", () => {
+      const original = {
+        text: "￼BA",
+        blocks: [
+          {
+            id: "B00000000",
+            type: "paragraph",
+            parents: [],
+            selfClosing: false,
+            attributes: {},
+          },
+        ],
+        marks: [
+          {
+            id: "M00000000",
+            type: "slice",
+            range: "(1..3]",
+            attributes: {
+              refs: ["M00000000"],
+            },
+          },
+          {
+            id: "M00000001",
+            type: "slice",
+            range: "(1..2]",
+            attributes: {
+              refs: ["B00000000"],
+            },
+          },
+        ],
+      };
+      let [, slices] = extractSlices(original);
+      expect(slices.get("M00000000")?.text).toEqual("￼A");
+      expect(slices.get("M00000001")?.text).toEqual("￼B");
+    });
+
+    test("end slice position matches", () => {
+      const original = {
+        text: "￼AB",
+        blocks: [
+          {
+            id: "B00000000",
+            type: "paragraph",
+            parents: [],
+            selfClosing: false,
+            attributes: {},
+          },
+        ],
+        marks: [
+          {
+            id: "M00000000",
+            type: "slice",
+            range: "(1..3]",
+            attributes: {
+              refs: ["M00000000"],
+            },
+          },
+          {
+            id: "M00000001",
+            type: "slice",
+            range: "(2..3]",
+            attributes: {
+              refs: ["B00000000"],
+            },
+          },
+        ],
+      };
+      let [, slices] = extractSlices(original);
+      expect(slices.get("M00000000")?.text).toEqual("￼A");
+      expect(slices.get("M00000001")?.text).toEqual("￼B");
+    });
+
+    test("multiple overlapping", () => {
+      const original = {
+        text: "￼ABCB",
+        blocks: [
+          {
+            id: "B00000000",
+            type: "paragraph",
+            parents: [],
+            selfClosing: false,
+            attributes: {},
+          },
+        ],
+        marks: [
+          {
+            id: "M00000000",
+            type: "slice",
+            range: "(1..5]",
+            attributes: {
+              refs: ["M00000000"],
+            },
+          },
+          {
+            id: "M00000001",
+            type: "slice",
+            range: "(2..5]",
+            attributes: {
+              refs: ["B00000000"],
+            },
+          },
+          {
+            id: "M00000002",
+            type: "slice",
+            range: "(3..4]",
+            attributes: {
+              refs: ["B00000000"],
+            },
+          },
+        ],
+      };
+      let [, slices] = extractSlices(original);
+      expect(slices.get("M00000000")?.text).toEqual("￼A");
+      expect(slices.get("M00000001")?.text).toEqual("￼BB");
+      expect(slices.get("M00000002")?.text).toEqual("￼C");
+    });
+  });
 });


### PR DESCRIPTION
This is a bug that I discovered with @colin-alexa during work on datasets & tables. Our current implementation of `extractSlices` does not properly handle overlapping slices, and will duplicate text since it does not handle cases where slices are nested or overlap.

To illustrate this, we may have a document that has slices inside of slices, which are 
something _very_ possible inside of tables:

| Album Art |  Info |
|-----------|-------|
| <figure><img src="https://f4.bcbits.com/img/a2682265154_10.jpg" width=200><figcaption>Debut (1993)<br/><a href="https://bjork.bandcamp.com/album/debut">Listen on Bandcamp</a></figcaption></figure> | <p>Debut is the debut studio album by Icelandic recording artist Björk as an international singer, released in July 1993 by One Little Independent Records and Elektra Entertainment. It was produced by Björk and Nellee Hooper.</p><p>It was Björk's first recording following the dissolution of her previous band, the Sugarcubes. The album departed from the rock style of her previous work and drew from an eclectic variety of styles, including electronic pop, house music, jazz, and trip-hop.</p> |
| <figure><img src="https://f4.bcbits.com/img/a4040590719_16.jpg" width=200 /><figcaption>Post (1995)<br/><a href="https://bjork.bandcamp.com/album/post">Listen on Bandcamp</a></figcaption></figure> | <p>Post is the second studio album by Icelandic recording artist Björk, released in 1995 in the United Kingdom by One Little Independent Records and in the United States by Elektra Entertainment.</p><p>Whereas Björk's previous album Debut (1993) was produced almost entirely by Nellee Hooper, Björk produced Post herself with co-producers including Hooper, 808 State's Graham Massey, and former Massive Attack member Tricky.</p><p>Continuing the style developed on Debut, Post is considered an important exponent of art-pop. It features an eclectic mixture of electronic and dance styles such as techno, trip-hop, IDM, and house, but also ambient, jazz, industrial, and experimental music.</p><p>Björk wrote most of the songs after moving to London and intended Post to convey the city's pace, urban culture, and underground club culture.</p> |

Here we have some captions on images, inside of tables.

When we represent this content for rendering, we will want the records in the dataset to have well structured documents, so that the first cell for album art looks like:

```json
{
  "text": "\uFFFC",
  "blocks": [{
    "id": "B00000000",
    "type": "image",
    "parents": [],
    "selfClosing": false,
    "attributes": {
      "src": "https://f4.bcbits.com/img/a2682265154_10.jpg",
      "caption": "M00000001"
    }
  }]
}
```

And the caption slice would be:
```json
{
  "text": "\uFFFCDebut (1993)\uFFFCListen on Bandcamp",
  "blocks": [{
    "id": "B00000000",
    "type": "text",
    "parents": [],
    "selfClosing": false,
    "attributes": {}
  }, {
    "id": "B00000001",
    "type": "line-break",
    "parents": [],
    "selfClosing": true,
    "attributes": {}
  }],
  "marks": [{
    "id": "M00000001",
    "type": "slice",
    "range": "[1..32]",
    "attributes": {
      "refs": ["B00000000"],
    }
  }]
}
```

Currently, the data cell for this would have the caption slice _included_, which will result in duplicate text in rendering:

```json
{
  "text": "\uFFFCDebut (1993)\uFFFCListen on Bandcamp",
  "blocks": [{
    "id": "B00000000",
    "type": "image",
    "parents": [],
    "selfClosing": false,
    "attributes": {
      "src": "https://f4.bcbits.com/img/a2682265154_10.jpg",
      "caption": "M00000001"
    }
  }, {
    "id": "B00000001",
    "type": "line-break",
    "parents": [],
    "selfClosing": true,
    "attributes": {}
  }],
  "marks": [{
    "id": "M00000001",
    "type": "slice",
    "range": "[1..32]",
    "attributes": {
      "refs": ["B00000000"],
    }
  }]
}
```
