### PR TITLE
feat: add option to include parse tokens in serialize

### DIFF
--- a/packages/@atjson/document/test/serialize.test.ts
+++ b/packages/@atjson/document/test/serialize.test.ts
@@ -871,6 +871,148 @@ describe("serialize", () => {
         });
       });
 
+      test("includeParseTokens = true", () => {
+        expect(
+          serialize(
+            new TestSource({
+              content: "<p>hello, <em>world</em></p>",
+              annotations: [
+                new Paragraph({
+                  start: 0,
+                  end: 28,
+                }),
+                new ParseAnnotation({
+                  start: 0,
+                  end: 3,
+                }),
+                new Italic({
+                  start: 10,
+                  end: 24,
+                  attributes: {},
+                }),
+                new ParseAnnotation({
+                  start: 10,
+                  end: 14,
+                }),
+                new ParseAnnotation({
+                  start: 19,
+                  end: 24,
+                }),
+                new ParseAnnotation({
+                  start: 24,
+                  end: 28,
+                }),
+              ],
+            }),
+            { includeParseTokens: true, withStableIds: true }
+          )
+        ).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {},
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "paragraph",
+              },
+            ],
+            "marks": [
+              {
+                "attributes": {},
+                "id": "M00000000",
+                "range": "(1..4]",
+                "type": "parse-token",
+              },
+              {
+                "attributes": {},
+                "id": "M00000001",
+                "range": "(11..15]",
+                "type": "parse-token",
+              },
+              {
+                "attributes": {},
+                "id": "M00000002",
+                "range": "(11..25]",
+                "type": "italic",
+              },
+              {
+                "attributes": {},
+                "id": "M00000003",
+                "range": "(20..25]",
+                "type": "parse-token",
+              },
+              {
+                "attributes": {},
+                "id": "M00000004",
+                "range": "(25..29]",
+                "type": "parse-token",
+              },
+            ],
+            "text": "￼<p>hello, <em>world</em></p>",
+          }
+        `);
+      });
+
+      test("includeParseTokens = false", () => {
+        expect(
+          serialize(
+            new TestSource({
+              content: "<p>hello, <em>world</em></p>",
+              annotations: [
+                new Paragraph({
+                  start: 0,
+                  end: 28,
+                }),
+                new ParseAnnotation({
+                  start: 0,
+                  end: 3,
+                }),
+                new Italic({
+                  start: 10,
+                  end: 24,
+                  attributes: {},
+                }),
+                new ParseAnnotation({
+                  start: 10,
+                  end: 14,
+                }),
+                new ParseAnnotation({
+                  start: 19,
+                  end: 24,
+                }),
+                new ParseAnnotation({
+                  start: 24,
+                  end: 28,
+                }),
+              ],
+            }),
+            { includeParseTokens: false, withStableIds: true }
+          )
+        ).toMatchInlineSnapshot(`
+          {
+            "blocks": [
+              {
+                "attributes": {},
+                "id": "B00000000",
+                "parents": [],
+                "selfClosing": false,
+                "type": "paragraph",
+              },
+            ],
+            "marks": [
+              {
+                "attributes": {},
+                "id": "M00000000",
+                "range": "(8..13]",
+                "type": "italic",
+              },
+            ],
+            "text": "￼hello, world",
+          }
+        `);
+      });
+
       test("text block insertion", () => {
         expect(
           serialize(


### PR DESCRIPTION
This adds an option to include parse tokens in serialization to Peritext, which is helpful in cases where someone wants to view source of a document in a case like viewing the HTML tokens of the document, while allowing for text highlighting. The feature is also useful for debugging cases where you may want to see if some data is getting truncated unintentionally.

A feature like this was used for the hytradboi talk I did on wikitext parsing. In trying to ensure that everything is working well on `main` with the quite extensive changes in the last year, I'm trying to update that project to see if there are any issues with the new format :)

Regardless of this feature, the changes to the `sortTokens` function may improve performance in some cases and be more legible for other developers