### PR TITLE
fix: bug in extractSlices sorting function caused weird behavior with some table and dataset documents

### DIFF
--- a/packages/@atjson/util/test/extract-slices.test.ts
+++ b/packages/@atjson/util/test/extract-slices.test.ts
@@ -1,4 +1,4 @@
-import { extractSlices } from "../src";
+import { TokenType, compareSliceTokens, extractSlices } from "../src";
 
 describe("extractSlices", () => {
   test("no slices", () => {
@@ -877,7 +877,7 @@ describe("extractSlices", () => {
     });
   });
 
-  describe("weird ck bug", () => {
+  describe("ck table data", () => {
     const example1 = {
       text: "￼￼￼Name￼Age￼Job￼Laios￼19￼Fighter￼Marcille￼50￼Mage￼Chilchuck￼29￼Trapsmith￼Senshi￼112￼Cook",
       blocks: [
@@ -1309,6 +1309,89 @@ describe("extractSlices", () => {
       expect(slices.get("e1458d1e-da47-4b78-b001-69b289708e75")?.text).toBe(
         "￼Name"
       );
+    });
+  });
+
+  describe("compareSliceTokens", () => {
+    test("sorts slices", () => {
+      const sliceTokens = [
+        {
+          id: "1",
+          index: 2,
+          type: TokenType.SLICE_END,
+          mark: { start: 0, end: 2 },
+        },
+        {
+          id: "3",
+          index: 2,
+          type: TokenType.SLICE_START,
+          mark: { start: 2, end: 4 },
+        },
+        {
+          id: "3",
+          index: 4,
+          type: TokenType.SLICE_END,
+          mark: { start: 2, end: 4 },
+        },
+        {
+          id: "2",
+          index: 6,
+          type: TokenType.SLICE_END,
+          mark: { start: 2, end: 6 },
+        },
+        {
+          id: "2",
+          index: 2,
+          type: TokenType.SLICE_START,
+          mark: { start: 2, end: 6 },
+        },
+        {
+          id: "1",
+          index: 0,
+          type: TokenType.SLICE_START,
+          mark: { start: 0, end: 2 },
+        },
+      ];
+
+      let expected = [...sliceTokens].sort(compareSliceTokens);
+      expect(expected).toMatchObject([
+        {
+          id: "1",
+          index: 0,
+          type: TokenType.SLICE_START,
+          mark: { start: 0, end: 2 },
+        },
+        {
+          id: "1",
+          index: 2,
+          type: TokenType.SLICE_END,
+          mark: { start: 0, end: 2 },
+        },
+        {
+          id: "2",
+          index: 2,
+          type: TokenType.SLICE_START,
+          mark: { start: 2, end: 6 },
+        },
+        {
+          id: "3",
+          index: 2,
+          type: TokenType.SLICE_START,
+          mark: { start: 2, end: 4 },
+        },
+        {
+          id: "3",
+          index: 4,
+          type: TokenType.SLICE_END,
+          mark: { start: 2, end: 4 },
+        },
+        {
+          id: "2",
+          index: 6,
+          type: TokenType.SLICE_END,
+          mark: { start: 2, end: 6 },
+        },
+      ]);
     });
   });
 });

--- a/packages/@atjson/util/test/extract-slices.test.ts
+++ b/packages/@atjson/util/test/extract-slices.test.ts
@@ -876,4 +876,439 @@ describe("extractSlices", () => {
       });
     });
   });
+
+  describe("weird ck bug", () => {
+    const example1 = {
+      text: "￼￼￼Name￼Age￼Job￼Laios￼19￼Fighter￼Marcille￼50￼Mage￼Chilchuck￼29￼Trapsmith￼Senshi￼112￼Cook",
+      blocks: [
+        {
+          id: "22d9c97b-ff4a-4eed-bbc7-d2555970bb2d",
+          type: "table",
+          parents: [],
+          selfClosing: false,
+          attributes: {
+            dataSet: "64e70965-f06d-4bbe-b917-2a5fe50c6bf8",
+            columns: [
+              {
+                name: "Name",
+                slice: "e1458d1e-da47-4b78-b001-69b289708e75",
+              },
+              {
+                name: "Age",
+                slice: "b6a5f50f-7857-4c2f-a756-50e6fff60d02",
+              },
+              {
+                name: "Job",
+                slice: "545e74b6-1024-4554-8eb6-30ab7c456157",
+              },
+            ],
+            showColumnHeaders: true,
+          },
+        },
+        {
+          id: "64e70965-f06d-4bbe-b917-2a5fe50c6bf8",
+          type: "data-set",
+          parents: ["table"],
+          selfClosing: false,
+          attributes: {
+            schema: {
+              Name: "rich_text",
+              Age: "rich_text",
+              Job: "rich_text",
+            },
+            records: [
+              {
+                Name: {
+                  slice: "2c7b4ad9-0780-46b1-bcdd-b571f78eccd4",
+                  jsonValue: "Laios",
+                },
+                Age: {
+                  slice: "c79644a5-6633-42e4-b0ca-238284cfb8bd",
+                  jsonValue: "19",
+                },
+                Job: {
+                  slice: "2aa60e32-7a25-474b-bfb2-c17a1f5ff547",
+                  jsonValue: "Fighter",
+                },
+              },
+              {
+                Name: {
+                  slice: "ffccbc61-d64a-4db4-b335-c42721b33406",
+                  jsonValue: "Marcille",
+                },
+                Age: {
+                  slice: "dd72e1af-b133-4a0d-9611-93a1bbc14c5a",
+                  jsonValue: "50",
+                },
+                Job: {
+                  slice: "68939eac-5330-4d5e-92fc-c8704a92f4b1",
+                  jsonValue: "Mage",
+                },
+              },
+              {
+                Name: {
+                  slice: "d4ddfaf7-963c-4b46-9b0d-96525336ff0c",
+                  jsonValue: "Chilchuck",
+                },
+                Age: {
+                  slice: "272ee2c9-d445-4ce0-ada7-9e357896d383",
+                  jsonValue: "29",
+                },
+                Job: {
+                  slice: "d293ed7e-738f-41f1-b827-f31af79562ce",
+                  jsonValue: "Trapsmith",
+                },
+              },
+              {
+                Name: {
+                  slice: "15e93cd3-5007-4519-9bf7-48e8a209f1c1",
+                  jsonValue: "Senshi",
+                },
+                Age: {
+                  slice: "1912fe3e-3c09-4c02-8a57-5d6ef8448e43",
+                  jsonValue: "112",
+                },
+                Job: {
+                  slice: "13f25a6f-c009-492c-9d13-43696fdc2741",
+                  jsonValue: "Cook",
+                },
+              },
+            ],
+          },
+        },
+        {
+          id: "43760116-7d37-47d6-9e85-72bde766683d",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "ffb764fd-a73e-4e9a-ba8d-494ae95428fa",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "0691b6ce-888d-4c60-b8d7-215a5af84c9d",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "bfe818ad-a78c-4562-9ed8-cdf57b4ca782",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "04330eef-d24e-4417-865b-f13bdea44bef",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "f235f2fb-c299-41c6-87aa-033f02d96d52",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "9106b2f1-0590-4e09-a39e-649ad4b9b7ca",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "53c7f318-6b8f-4060-a976-3e6c4d8a5838",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "fb5c6608-188c-4711-9ad7-aafc985f4525",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "57c737a5-c86c-4d58-9408-2d31bfa23e93",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "e43cfe7d-c594-45e1-b2ab-9e8da463be31",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "86de8916-0655-4eb7-80f5-b91409558966",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "9423c530-a801-4c3c-be33-3c290fa1e2c6",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "a6e9a738-2a81-4547-960d-dc306a2b94da",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "a8f597ce-3bb8-450b-acd2-a753cf97feb9",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+      ],
+      marks: [
+        {
+          id: "e1458d1e-da47-4b78-b001-69b289708e75",
+          type: "slice",
+          range: "(2..7]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "b6a5f50f-7857-4c2f-a756-50e6fff60d02",
+          type: "slice",
+          range: "(7..11]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "545e74b6-1024-4554-8eb6-30ab7c456157",
+          type: "slice",
+          range: "(11..15]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "2c7b4ad9-0780-46b1-bcdd-b571f78eccd4",
+          type: "slice",
+          range: "(16..21]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "c79644a5-6633-42e4-b0ca-238284cfb8bd",
+          type: "slice",
+          range: "(21..24]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "2aa60e32-7a25-474b-bfb2-c17a1f5ff547",
+          type: "slice",
+          range: "(24..32]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "ffccbc61-d64a-4db4-b335-c42721b33406",
+          type: "slice",
+          range: "(33..41]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "dd72e1af-b133-4a0d-9611-93a1bbc14c5a",
+          type: "slice",
+          range: "(41..44]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "68939eac-5330-4d5e-92fc-c8704a92f4b1",
+          type: "slice",
+          range: "(44..49]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "d4ddfaf7-963c-4b46-9b0d-96525336ff0c",
+          type: "slice",
+          range: "(50..59]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "272ee2c9-d445-4ce0-ada7-9e357896d383",
+          type: "slice",
+          range: "(59..62]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "d293ed7e-738f-41f1-b827-f31af79562ce",
+          type: "slice",
+          range: "(62..72]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "15e93cd3-5007-4519-9bf7-48e8a209f1c1",
+          type: "slice",
+          range: "(73..79]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "1912fe3e-3c09-4c02-8a57-5d6ef8448e43",
+          type: "slice",
+          range: "(79..83]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "13f25a6f-c009-492c-9d13-43696fdc2741",
+          type: "slice",
+          range: "(83..88]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+      ],
+    };
+
+    const example2 = {
+      text: "￼￼￼Name￼Age￼Job",
+      blocks: [
+        {
+          id: "22d9c97b-ff4a-4eed-bbc7-d2555970bb2d",
+          type: "table",
+          parents: [],
+          selfClosing: false,
+          attributes: {
+            dataSet: "64e70965-f06d-4bbe-b917-2a5fe50c6bf8",
+            columns: [
+              {
+                name: "Name",
+                slice: "e1458d1e-da47-4b78-b001-69b289708e75",
+              },
+              {
+                name: "Age",
+                slice: "b6a5f50f-7857-4c2f-a756-50e6fff60d02",
+              },
+              {
+                name: "Job",
+                slice: "545e74b6-1024-4554-8eb6-30ab7c456157",
+              },
+            ],
+            showColumnHeaders: true,
+          },
+        },
+        {
+          id: "64e70965-f06d-4bbe-b917-2a5fe50c6bf8",
+          type: "data-set",
+          parents: ["table"],
+          selfClosing: false,
+          attributes: {
+            schema: {
+              Name: "rich_text",
+              Age: "rich_text",
+              Job: "rich_text",
+            },
+            records: [],
+          },
+        },
+        {
+          id: "43760116-7d37-47d6-9e85-72bde766683d",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "ffb764fd-a73e-4e9a-ba8d-494ae95428fa",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "0691b6ce-888d-4c60-b8d7-215a5af84c9d",
+          type: "text",
+          parents: ["table", "data-set"],
+          selfClosing: false,
+          attributes: {},
+        },
+      ],
+      marks: [
+        {
+          id: "e1458d1e-da47-4b78-b001-69b289708e75",
+          type: "slice",
+          range: "(2..7]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "b6a5f50f-7857-4c2f-a756-50e6fff60d02",
+          type: "slice",
+          range: "(7..11]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+        {
+          id: "545e74b6-1024-4554-8eb6-30ab7c456157",
+          type: "slice",
+          range: "(11..15]",
+          attributes: {
+            refs: ["64e70965-f06d-4bbe-b917-2a5fe50c6bf8"],
+          },
+        },
+      ],
+    };
+    test("example1", () => {
+      let [, slices] = extractSlices(example1);
+      expect(slices.get("e1458d1e-da47-4b78-b001-69b289708e75")?.text).toBe(
+        "￼Name"
+      );
+    });
+
+    test("example2", () => {
+      let [, slices] = extractSlices(example2);
+
+      expect(slices.get("e1458d1e-da47-4b78-b001-69b289708e75")?.text).toBe(
+        "￼Name"
+      );
+    });
+  });
 });

--- a/packages/@atjson/util/test/extract-slices.test.ts
+++ b/packages/@atjson/util/test/extract-slices.test.ts
@@ -1296,6 +1296,217 @@ describe("extractSlices", () => {
         },
       ],
     };
+
+    const example3 = {
+      text: "￼￼￼a￼b￼c￼d￼e￼f￼g￼h￼i",
+      blocks: [
+        {
+          id: "9f5a80b5-6ca1-4a44-82fb-88503b87a56e",
+          type: "table",
+          parents: [],
+          selfClosing: false,
+          attributes: {
+            dataSet: "0bb17fff-f655-4143-b1ef-2e55a3bee452",
+            columns: [
+              {
+                name: "a",
+                slice: "e789303b-6e43-49b2-8085-fb3d0b92b205",
+              },
+              {
+                name: "b",
+                slice: "82691fbd-810c-4d07-806f-7a93b9f24ddf",
+              },
+              {
+                name: "c",
+                slice: "49ef4f9f-10ad-44a0-8bd6-33ff918e24e5",
+              },
+            ],
+            showColumnHeaders: true,
+          },
+        },
+        {
+          id: "0bb17fff-f655-4143-b1ef-2e55a3bee452",
+          type: "data-set",
+          parents: ["table"],
+          selfClosing: false,
+          attributes: {
+            schema: {
+              a: "rich_text",
+              b: "rich_text",
+              c: "rich_text",
+            },
+            records: [
+              {
+                a: {
+                  slice: "d1922e94-4ac8-4b11-8018-15eb9b92f800",
+                  jsonValue: "d",
+                },
+                b: {
+                  slice: "ff4cba8c-5711-4445-8c79-21c943d74035",
+                  jsonValue: "e",
+                },
+                c: {
+                  slice: "5c0bf563-6cf4-4ea3-8491-7303829fb0cb",
+                  jsonValue: "f",
+                },
+              },
+              {
+                a: {
+                  slice: "0ff6f5c2-7caa-4f2c-8f1e-0cb41e2b75e9",
+                  jsonValue: "g",
+                },
+                b: {
+                  slice: "980f58bf-8551-41c7-953c-7d8762d857b6",
+                  jsonValue: "h",
+                },
+                c: {
+                  slice: "60cbc077-2eb4-4e29-a473-b91d57802f65",
+                  jsonValue: "i",
+                },
+              },
+            ],
+          },
+        },
+        {
+          id: "22a3dcdb-fc08-4aef-a959-f76b73bf61d6",
+          type: "text",
+          parents: ["table"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "b0b6665e-5540-4187-8c61-ef8e773dbd83",
+          type: "text",
+          parents: ["table"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "718a148a-2ac1-46de-8093-d597810d8631",
+          type: "text",
+          parents: ["table"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "7d85d645-183f-46d2-8561-8db045637518",
+          type: "text",
+          parents: ["table"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "4b017f7d-4fc5-4f64-b9fc-67cb941f948f",
+          type: "text",
+          parents: ["table"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "c4aa0815-19eb-4e60-ac84-24df48377e6d",
+          type: "text",
+          parents: ["table"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "cfca0b62-c398-4568-85d0-b5ecb5c327fb",
+          type: "text",
+          parents: ["table"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "0c3a7841-c0d0-4157-8c40-485a5896be64",
+          type: "text",
+          parents: ["table"],
+          selfClosing: false,
+          attributes: {},
+        },
+        {
+          id: "82307468-d844-48c6-a5fc-8e62e2f992a1",
+          type: "text",
+          parents: ["table"],
+          selfClosing: false,
+          attributes: {},
+        },
+      ],
+      marks: [
+        {
+          id: "e789303b-6e43-49b2-8085-fb3d0b92b205",
+          type: "slice",
+          range: "(2..4]",
+          attributes: {
+            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+          },
+        },
+        {
+          id: "82691fbd-810c-4d07-806f-7a93b9f24ddf",
+          type: "slice",
+          range: "(4..6]",
+          attributes: {
+            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+          },
+        },
+        {
+          id: "49ef4f9f-10ad-44a0-8bd6-33ff918e24e5",
+          type: "slice",
+          range: "(6..8]",
+          attributes: {
+            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+          },
+        },
+        {
+          id: "d1922e94-4ac8-4b11-8018-15eb9b92f800",
+          type: "slice",
+          range: "(9..10]",
+          attributes: {
+            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+          },
+        },
+        {
+          id: "ff4cba8c-5711-4445-8c79-21c943d74035",
+          type: "slice",
+          range: "(10..12]",
+          attributes: {
+            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+          },
+        },
+        {
+          id: "5c0bf563-6cf4-4ea3-8491-7303829fb0cb",
+          type: "slice",
+          range: "(12..14]",
+          attributes: {
+            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+          },
+        },
+        {
+          id: "0ff6f5c2-7caa-4f2c-8f1e-0cb41e2b75e9",
+          type: "slice",
+          range: "(15..16]",
+          attributes: {
+            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+          },
+        },
+        {
+          id: "980f58bf-8551-41c7-953c-7d8762d857b6",
+          type: "slice",
+          range: "(16..18]",
+          attributes: {
+            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+          },
+        },
+        {
+          id: "60cbc077-2eb4-4e29-a473-b91d57802f65",
+          type: "slice",
+          range: "(18..20]",
+          attributes: {
+            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+          },
+        },
+      ],
+    };
+
     test("example1", () => {
       let [, slices] = extractSlices(example1);
       expect(slices.get("e1458d1e-da47-4b78-b001-69b289708e75")?.text).toBe(
@@ -1308,6 +1519,14 @@ describe("extractSlices", () => {
 
       expect(slices.get("e1458d1e-da47-4b78-b001-69b289708e75")?.text).toBe(
         "￼Name"
+      );
+    });
+
+    test("example3", () => {
+      let [, slices] = extractSlices(example3);
+
+      expect(slices.get("e789303b-6e43-49b2-8085-fb3d0b92b205")?.text).toBe(
+        "￼a"
       );
     });
   });
@@ -1390,6 +1609,88 @@ describe("extractSlices", () => {
           index: 6,
           type: TokenType.SLICE_END,
           mark: { start: 2, end: 6 },
+        },
+      ]);
+    });
+
+    test("nests coinciding ranges", () => {
+      const sliceTokens = [
+        {
+          id: "abc",
+          index: 0,
+          type: TokenType.SLICE_START,
+          mark: { start: 0, end: 2 },
+        },
+        {
+          id: "def",
+          index: 0,
+          type: TokenType.SLICE_START,
+          mark: { start: 0, end: 2 },
+        },
+        {
+          id: "abc",
+          index: 2,
+          type: TokenType.SLICE_END,
+          mark: { start: 0, end: 2 },
+        },
+        {
+          id: "def",
+          index: 2,
+          type: TokenType.SLICE_END,
+          mark: { start: 0, end: 2 },
+        },
+        {
+          id: "ghi",
+          index: 2,
+          type: TokenType.SLICE_END,
+          mark: { start: 0, end: 2 },
+        },
+        {
+          id: "ghi",
+          index: 0,
+          type: TokenType.SLICE_START,
+          mark: { start: 0, end: 2 },
+        },
+      ];
+
+      let expected = [...sliceTokens].sort(compareSliceTokens);
+
+      expect(expected).toMatchObject([
+        {
+          id: "abc",
+          index: 0,
+          type: TokenType.SLICE_START,
+          mark: { start: 0, end: 2 },
+        },
+        {
+          id: "def",
+          index: 0,
+          type: TokenType.SLICE_START,
+          mark: { start: 0, end: 2 },
+        },
+        {
+          id: "ghi",
+          index: 0,
+          type: TokenType.SLICE_START,
+          mark: { start: 0, end: 2 },
+        },
+        {
+          id: "ghi",
+          index: 2,
+          type: TokenType.SLICE_END,
+          mark: { start: 0, end: 2 },
+        },
+        {
+          id: "def",
+          index: 2,
+          type: TokenType.SLICE_END,
+          mark: { start: 0, end: 2 },
+        },
+        {
+          id: "abc",
+          index: 2,
+          type: TokenType.SLICE_END,
+          mark: { start: 0, end: 2 },
         },
       ]);
     });

--- a/packages/@atjson/util/test/extract-slices.test.ts
+++ b/packages/@atjson/util/test/extract-slices.test.ts
@@ -1298,34 +1298,34 @@ describe("extractSlices", () => {
     };
 
     const example3 = {
-      text: "￼￼￼a￼b￼c￼d￼e￼f￼g￼h￼i",
+      text: "￼￼￼abcdefghi",
       blocks: [
         {
-          id: "9f5a80b5-6ca1-4a44-82fb-88503b87a56e",
+          id: "736fd0ca-eff5-4690-b587-563010dbc989",
           type: "table",
           parents: [],
           selfClosing: false,
           attributes: {
-            dataSet: "0bb17fff-f655-4143-b1ef-2e55a3bee452",
+            dataSet: "11989adb-858e-4861-8330-59e10b612fd9",
             columns: [
               {
                 name: "a",
-                slice: "e789303b-6e43-49b2-8085-fb3d0b92b205",
+                slice: "a6e8a1a8-537e-469c-9c7c-2eb7a43f1994",
               },
               {
                 name: "b",
-                slice: "82691fbd-810c-4d07-806f-7a93b9f24ddf",
+                slice: "b2023136-2a9a-4cf3-97d4-2270c33b5de6",
               },
               {
                 name: "c",
-                slice: "49ef4f9f-10ad-44a0-8bd6-33ff918e24e5",
+                slice: "53eda282-ea66-443d-a894-cbcd0f887f4a",
               },
             ],
             showColumnHeaders: true,
           },
         },
         {
-          id: "0bb17fff-f655-4143-b1ef-2e55a3bee452",
+          id: "11989adb-858e-4861-8330-59e10b612fd9",
           type: "data-set",
           parents: ["table"],
           selfClosing: false,
@@ -1338,29 +1338,29 @@ describe("extractSlices", () => {
             records: [
               {
                 a: {
-                  slice: "d1922e94-4ac8-4b11-8018-15eb9b92f800",
+                  slice: "ad56e97f-4c1a-43e6-a6f2-e3f9081e80cd",
                   jsonValue: "d",
                 },
                 b: {
-                  slice: "ff4cba8c-5711-4445-8c79-21c943d74035",
+                  slice: "d1ce8735-8b83-41b4-b254-9172ca2610c5",
                   jsonValue: "e",
                 },
                 c: {
-                  slice: "5c0bf563-6cf4-4ea3-8491-7303829fb0cb",
+                  slice: "052d1352-8659-4ca2-8fc3-caafa0be0eaa",
                   jsonValue: "f",
                 },
               },
               {
                 a: {
-                  slice: "0ff6f5c2-7caa-4f2c-8f1e-0cb41e2b75e9",
+                  slice: "e18aedd9-8978-4f18-80f2-461d8aae25de",
                   jsonValue: "g",
                 },
                 b: {
-                  slice: "980f58bf-8551-41c7-953c-7d8762d857b6",
+                  slice: "8695d332-1cc1-4f9c-b9af-0abde2f68bb7",
                   jsonValue: "h",
                 },
                 c: {
-                  slice: "60cbc077-2eb4-4e29-a473-b91d57802f65",
+                  slice: "252a6926-368a-439b-9c21-be3fd5e9dd46",
                   jsonValue: "i",
                 },
               },
@@ -1368,63 +1368,7 @@ describe("extractSlices", () => {
           },
         },
         {
-          id: "22a3dcdb-fc08-4aef-a959-f76b73bf61d6",
-          type: "text",
-          parents: ["table"],
-          selfClosing: false,
-          attributes: {},
-        },
-        {
-          id: "b0b6665e-5540-4187-8c61-ef8e773dbd83",
-          type: "text",
-          parents: ["table"],
-          selfClosing: false,
-          attributes: {},
-        },
-        {
-          id: "718a148a-2ac1-46de-8093-d597810d8631",
-          type: "text",
-          parents: ["table"],
-          selfClosing: false,
-          attributes: {},
-        },
-        {
-          id: "7d85d645-183f-46d2-8561-8db045637518",
-          type: "text",
-          parents: ["table"],
-          selfClosing: false,
-          attributes: {},
-        },
-        {
-          id: "4b017f7d-4fc5-4f64-b9fc-67cb941f948f",
-          type: "text",
-          parents: ["table"],
-          selfClosing: false,
-          attributes: {},
-        },
-        {
-          id: "c4aa0815-19eb-4e60-ac84-24df48377e6d",
-          type: "text",
-          parents: ["table"],
-          selfClosing: false,
-          attributes: {},
-        },
-        {
-          id: "cfca0b62-c398-4568-85d0-b5ecb5c327fb",
-          type: "text",
-          parents: ["table"],
-          selfClosing: false,
-          attributes: {},
-        },
-        {
-          id: "0c3a7841-c0d0-4157-8c40-485a5896be64",
-          type: "text",
-          parents: ["table"],
-          selfClosing: false,
-          attributes: {},
-        },
-        {
-          id: "82307468-d844-48c6-a5fc-8e62e2f992a1",
+          id: "9a720f35-1a23-4bf4-8c9d-bae9b4dac928",
           type: "text",
           parents: ["table"],
           selfClosing: false,
@@ -1433,75 +1377,75 @@ describe("extractSlices", () => {
       ],
       marks: [
         {
-          id: "e789303b-6e43-49b2-8085-fb3d0b92b205",
+          id: "a6e8a1a8-537e-469c-9c7c-2eb7a43f1994",
           type: "slice",
-          range: "(2..4]",
+          range: "(3..4]",
           attributes: {
-            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+            refs: ["11989adb-858e-4861-8330-59e10b612fd9"],
           },
         },
         {
-          id: "82691fbd-810c-4d07-806f-7a93b9f24ddf",
+          id: "b2023136-2a9a-4cf3-97d4-2270c33b5de6",
           type: "slice",
-          range: "(4..6]",
+          range: "(4..5]",
           attributes: {
-            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+            refs: ["11989adb-858e-4861-8330-59e10b612fd9"],
           },
         },
         {
-          id: "49ef4f9f-10ad-44a0-8bd6-33ff918e24e5",
+          id: "53eda282-ea66-443d-a894-cbcd0f887f4a",
           type: "slice",
-          range: "(6..8]",
+          range: "(5..6]",
           attributes: {
-            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+            refs: ["11989adb-858e-4861-8330-59e10b612fd9"],
           },
         },
         {
-          id: "d1922e94-4ac8-4b11-8018-15eb9b92f800",
+          id: "ad56e97f-4c1a-43e6-a6f2-e3f9081e80cd",
+          type: "slice",
+          range: "(6..7]",
+          attributes: {
+            refs: ["11989adb-858e-4861-8330-59e10b612fd9"],
+          },
+        },
+        {
+          id: "d1ce8735-8b83-41b4-b254-9172ca2610c5",
+          type: "slice",
+          range: "(7..8]",
+          attributes: {
+            refs: ["11989adb-858e-4861-8330-59e10b612fd9"],
+          },
+        },
+        {
+          id: "052d1352-8659-4ca2-8fc3-caafa0be0eaa",
+          type: "slice",
+          range: "(8..9]",
+          attributes: {
+            refs: ["11989adb-858e-4861-8330-59e10b612fd9"],
+          },
+        },
+        {
+          id: "e18aedd9-8978-4f18-80f2-461d8aae25de",
           type: "slice",
           range: "(9..10]",
           attributes: {
-            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+            refs: ["11989adb-858e-4861-8330-59e10b612fd9"],
           },
         },
         {
-          id: "ff4cba8c-5711-4445-8c79-21c943d74035",
+          id: "8695d332-1cc1-4f9c-b9af-0abde2f68bb7",
           type: "slice",
-          range: "(10..12]",
+          range: "(10..11]",
           attributes: {
-            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+            refs: ["11989adb-858e-4861-8330-59e10b612fd9"],
           },
         },
         {
-          id: "5c0bf563-6cf4-4ea3-8491-7303829fb0cb",
+          id: "252a6926-368a-439b-9c21-be3fd5e9dd46",
           type: "slice",
-          range: "(12..14]",
+          range: "(11..12]",
           attributes: {
-            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
-          },
-        },
-        {
-          id: "0ff6f5c2-7caa-4f2c-8f1e-0cb41e2b75e9",
-          type: "slice",
-          range: "(15..16]",
-          attributes: {
-            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
-          },
-        },
-        {
-          id: "980f58bf-8551-41c7-953c-7d8762d857b6",
-          type: "slice",
-          range: "(16..18]",
-          attributes: {
-            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
-          },
-        },
-        {
-          id: "60cbc077-2eb4-4e29-a473-b91d57802f65",
-          type: "slice",
-          range: "(18..20]",
-          attributes: {
-            refs: ["0bb17fff-f655-4143-b1ef-2e55a3bee452"],
+            refs: ["11989adb-858e-4861-8330-59e10b612fd9"],
           },
         },
       ],
@@ -1525,7 +1469,7 @@ describe("extractSlices", () => {
     test("example3", () => {
       let [, slices] = extractSlices(example3);
 
-      expect(slices.get("e789303b-6e43-49b2-8085-fb3d0b92b205")?.text).toBe(
+      expect(slices.get("a6e8a1a8-537e-469c-9c7c-2eb7a43f1994")?.text).toBe(
         "￼a"
       );
     });


### PR DESCRIPTION
A bug in the sorting function used internally by the `extractSlices` util caused cascading errors in the logic of the function, eventually causing the renderer for tables in markdown and html to duplicate the contents of some cells into their neighbors.

While fixing this bug, I also added some documentary comments to explain the logic and behavior of this sorting function, along with tests that show real data that was affected by the bug in `extractSlices` as well as specific abstracted test cases for the problematic sorting logic.