### PR TITLE
fix: don't produce collapsed dataset annotations in converter

### DIFF
--- a/packages/@atjson/document/src/change.ts
+++ b/packages/@atjson/document/src/change.ts
@@ -7,16 +7,27 @@ export enum EdgeBehaviour {
   modify,
 }
 
-// the "public" API for behaviour
+/**
+ * the "public" API for behaviour
+ */
 export enum AdjacentBoundaryBehaviour {
-  // default is an alias for modify / preserveLeading
-  // modify and preserve are targeted for deprecation
+  /**
+   * alias for modify / preserveLeading
+   */
   default,
+
+  /**
+   * @deprecated use preserveLeading
+   */
   modify,
   preserveLeading,
+
+  /**
+   * @deprecated use preserveBoth
+   */
   preserve,
-  preserveTrailing,
   preserveBoth,
+  preserveTrailing,
 }
 
 export class Deletion extends Change {

--- a/packages/@atjson/document/src/serialize.ts
+++ b/packages/@atjson/document/src/serialize.ts
@@ -143,7 +143,19 @@ export type Token = {
   edgeBehaviour: { leading: EdgeBehaviour; trailing: EdgeBehaviour };
 };
 
-export function sortTokens(a: Token, b: Token) {
+export type SortableToken = {
+  index: number;
+  type: TokenType;
+  annotation: {
+    id: string;
+    type: string;
+    start: number;
+    end: number;
+    rank: number;
+  };
+};
+
+export function sortTokens(a: SortableToken, b: SortableToken) {
   let indexDelta = a.index - b.index;
   if (indexDelta !== 0) {
     return indexDelta;

--- a/packages/@atjson/document/test/serialize.test.ts
+++ b/packages/@atjson/document/test/serialize.test.ts
@@ -5,7 +5,6 @@ import {
   UnknownAnnotation,
   is,
   SliceAnnotation,
-  TextAnnotation,
 } from "../src";
 import TestSource, {
   Anchor,
@@ -17,8 +16,6 @@ import TestSource, {
   LineBreak,
   Quote,
   Instagram,
-  Locale,
-  Code,
 } from "./test-source";
 import { sortTokens, TokenType, Token, SortableToken } from "../src/serialize";
 

--- a/packages/@atjson/document/test/serialize.test.ts
+++ b/packages/@atjson/document/test/serialize.test.ts
@@ -5,6 +5,7 @@ import {
   UnknownAnnotation,
   is,
   SliceAnnotation,
+  TextAnnotation,
 } from "../src";
 import TestSource, {
   Anchor,
@@ -16,8 +17,10 @@ import TestSource, {
   LineBreak,
   Quote,
   Instagram,
+  Locale,
+  Code,
 } from "./test-source";
-import { sortTokens, TokenType, Token } from "../src/serialize";
+import { sortTokens, TokenType, Token, SortableToken } from "../src/serialize";
 
 describe("serialize", () => {
   test("errors are thrown if uFFFC is included in text", () => {
@@ -1817,5 +1820,178 @@ describe("deserialize", () => {
 
       tokens.sort(sortTokens);
     });
+  });
+});
+
+describe.skip("sorting tokens", () => {
+  /**
+   * these tests reveal an issue in the serialize function where zero-length blocks
+   * have their starts and ends sorted in an arbitrary order--and may be separated by
+   * other blocks' starts and ends at the same position.
+   *
+   * If these tests are being skipped, the bug is probably still present
+   */
+  test("sorts 0 length blocks test 1", () => {
+    let tokens: SortableToken[] = [
+      {
+        index: 0,
+        type: TokenType.BLOCK_END,
+        annotation: { id: "1", start: 0, end: 0, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "2", start: 0, end: 5, rank: 5, type: "div" },
+      },
+      {
+        index: 10,
+        type: TokenType.BLOCK_END,
+        annotation: { id: "3", start: 0, end: 10, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "3", start: 0, end: 10, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "1", start: 0, end: 0, rank: 5, type: "div" },
+      },
+      {
+        index: 5,
+        type: TokenType.BLOCK_END,
+        annotation: { id: "2", start: 0, end: 5, rank: 5, type: "div" },
+      },
+    ];
+
+    let sortedTokens: SortableToken[] = [
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "1", start: 0, end: 0, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_END,
+        annotation: { id: "1", start: 0, end: 0, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "3", start: 0, end: 10, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "2", start: 0, end: 5, rank: 5, type: "div" },
+      },
+      {
+        index: 5,
+        type: TokenType.BLOCK_END,
+        annotation: { id: "2", start: 0, end: 5, rank: 5, type: "div" },
+      },
+      {
+        index: 10,
+        type: TokenType.BLOCK_END,
+        annotation: { id: "3", start: 0, end: 10, rank: 5, type: "div" },
+      },
+    ];
+
+    tokens.sort(sortTokens);
+
+    expect(tokens).toMatchObject(sortedTokens);
+  });
+  test("sorts 0 length blocks test 2", () => {
+    let tokens: SortableToken[] = [
+      {
+        index: 0,
+        type: TokenType.BLOCK_END,
+        annotation: { id: "1", start: 0, end: 0, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "2", start: 0, end: 5, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "1", start: 0, end: 0, rank: 5, type: "div" },
+      },
+      {
+        index: 5,
+        type: TokenType.BLOCK_END,
+        annotation: { id: "2", start: 0, end: 5, rank: 5, type: "div" },
+      },
+    ];
+
+    let sortedTokens: SortableToken[] = [
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "1", start: 0, end: 0, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_END,
+        annotation: { id: "1", start: 0, end: 0, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "2", start: 0, end: 5, rank: 5, type: "div" },
+      },
+      {
+        index: 5,
+        type: TokenType.BLOCK_END,
+        annotation: { id: "2", start: 0, end: 5, rank: 5, type: "div" },
+      },
+    ];
+
+    tokens.sort(sortTokens);
+
+    expect(tokens).toMatchObject(sortedTokens);
+  });
+  test("sorts 0 length blocks test 3", () => {
+    let tokens: SortableToken[] = [
+      {
+        index: 0,
+        type: TokenType.BLOCK_END,
+        annotation: { id: "1", start: 0, end: 0, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "2", start: 0, end: 100, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "1", start: 0, end: 0, rank: 5, type: "div" },
+      },
+    ];
+
+    let sortedTokens: SortableToken[] = [
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "1", start: 0, end: 0, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_END,
+        annotation: { id: "1", start: 0, end: 0, rank: 5, type: "div" },
+      },
+      {
+        index: 0,
+        type: TokenType.BLOCK_START,
+        annotation: { id: "2", start: 0, end: 100, rank: 5, type: "div" },
+      },
+    ];
+
+    tokens.sort(sortTokens);
+
+    expect(tokens).toMatchObject(sortedTokens);
   });
 });

--- a/packages/@atjson/offset-annotations/src/utils/convert-html-tables.ts
+++ b/packages/@atjson/offset-annotations/src/utils/convert-html-tables.ts
@@ -215,8 +215,6 @@ export function convertHTMLTablesToDataSet(
     let dataSet = new DataSet({
       ...table,
       id: undefined,
-      start: table.start,
-      end: table.start,
       attributes: {
         schema: Object.fromEntries(dataSetSchemaEntries),
         records: dataRows,

--- a/packages/@atjson/source-commonmark/test/__snapshots__/extensions.test.ts.snap
+++ b/packages/@atjson/source-commonmark/test/__snapshots__/extensions.test.ts.snap
@@ -5,37 +5,6 @@ exports[`tables converting 1`] = `
   "blocks": [
     {
       "attributes": {
-        "columns": [
-          {
-            "name": "name",
-            "slice": "M00000000",
-            "textAlign": "left",
-          },
-          {
-            "name": "age",
-            "slice": "M00000001",
-            "textAlign": "right",
-          },
-          {
-            "name": "job",
-            "slice": "M00000002",
-          },
-          {
-            "name": "notes",
-            "slice": "M00000003",
-            "textAlign": "center",
-          },
-        ],
-        "dataSet": "B00000001",
-        "showColumnHeaders": true,
-      },
-      "id": "B00000000",
-      "parents": [],
-      "selfClosing": false,
-      "type": "table",
-    },
-    {
-      "attributes": {
         "records": [
           {
             "age": {
@@ -117,19 +86,47 @@ exports[`tables converting 1`] = `
           "notes": "rich_text",
         },
       },
-      "id": "B00000001",
-      "parents": [
-        "table",
-      ],
+      "id": "B00000000",
+      "parents": [],
       "selfClosing": false,
       "type": "data-set",
+    },
+    {
+      "attributes": {
+        "columns": [
+          {
+            "name": "name",
+            "slice": "M00000000",
+            "textAlign": "left",
+          },
+          {
+            "name": "age",
+            "slice": "M00000001",
+            "textAlign": "right",
+          },
+          {
+            "name": "job",
+            "slice": "M00000002",
+          },
+          {
+            "name": "notes",
+            "slice": "M00000003",
+            "textAlign": "center",
+          },
+        ],
+        "dataSet": "B00000000",
+        "showColumnHeaders": true,
+      },
+      "id": "B00000001",
+      "parents": [],
+      "selfClosing": false,
+      "type": "table",
     },
     {
       "attributes": {},
       "id": "B00000002",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -139,7 +136,6 @@ exports[`tables converting 1`] = `
       "id": "B00000003",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -149,7 +145,6 @@ exports[`tables converting 1`] = `
       "id": "B00000004",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -159,7 +154,6 @@ exports[`tables converting 1`] = `
       "id": "B00000005",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -169,7 +163,6 @@ exports[`tables converting 1`] = `
       "id": "B00000006",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -179,7 +172,6 @@ exports[`tables converting 1`] = `
       "id": "B00000007",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -189,7 +181,6 @@ exports[`tables converting 1`] = `
       "id": "B00000008",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -199,7 +190,6 @@ exports[`tables converting 1`] = `
       "id": "B00000009",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -209,7 +199,6 @@ exports[`tables converting 1`] = `
       "id": "B0000000a",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -219,7 +208,6 @@ exports[`tables converting 1`] = `
       "id": "B0000000b",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -229,7 +217,6 @@ exports[`tables converting 1`] = `
       "id": "B0000000c",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -239,7 +226,6 @@ exports[`tables converting 1`] = `
       "id": "B0000000d",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -249,7 +235,6 @@ exports[`tables converting 1`] = `
       "id": "B0000000e",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -259,7 +244,6 @@ exports[`tables converting 1`] = `
       "id": "B0000000f",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -269,7 +253,6 @@ exports[`tables converting 1`] = `
       "id": "B00000010",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -279,7 +262,6 @@ exports[`tables converting 1`] = `
       "id": "B00000011",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -289,7 +271,6 @@ exports[`tables converting 1`] = `
       "id": "B00000012",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -299,7 +280,6 @@ exports[`tables converting 1`] = `
       "id": "B00000013",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -309,7 +289,6 @@ exports[`tables converting 1`] = `
       "id": "B00000014",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -319,7 +298,6 @@ exports[`tables converting 1`] = `
       "id": "B00000015",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -329,7 +307,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000000",
@@ -339,7 +317,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000001",
@@ -349,7 +327,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000002",
@@ -359,7 +337,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000003",
@@ -383,7 +361,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000006",
@@ -393,7 +371,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000007",
@@ -403,7 +381,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000008",
@@ -413,7 +391,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000009",
@@ -435,7 +413,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M0000000c",
@@ -445,7 +423,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M0000000d",
@@ -455,7 +433,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M0000000e",
@@ -465,7 +443,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M0000000f",
@@ -475,7 +453,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000010",
@@ -485,7 +463,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000011",
@@ -495,7 +473,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000012",
@@ -505,7 +483,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000013",
@@ -521,7 +499,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000015",
@@ -531,7 +509,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000016",
@@ -541,7 +519,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000017",
@@ -551,7 +529,7 @@ exports[`tables converting 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000001",
+          "B00000000",
         ],
       },
       "id": "M00000018",

--- a/packages/@atjson/source-commonmark/test/__snapshots__/extensions.test.ts.snap
+++ b/packages/@atjson/source-commonmark/test/__snapshots__/extensions.test.ts.snap
@@ -129,6 +129,7 @@ exports[`tables converting 1`] = `
       "id": "B00000002",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -138,6 +139,7 @@ exports[`tables converting 1`] = `
       "id": "B00000003",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -147,6 +149,7 @@ exports[`tables converting 1`] = `
       "id": "B00000004",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -156,6 +159,7 @@ exports[`tables converting 1`] = `
       "id": "B00000005",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -165,6 +169,7 @@ exports[`tables converting 1`] = `
       "id": "B00000006",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -174,6 +179,7 @@ exports[`tables converting 1`] = `
       "id": "B00000007",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -183,6 +189,7 @@ exports[`tables converting 1`] = `
       "id": "B00000008",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -192,6 +199,7 @@ exports[`tables converting 1`] = `
       "id": "B00000009",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -201,6 +209,7 @@ exports[`tables converting 1`] = `
       "id": "B0000000a",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -210,6 +219,7 @@ exports[`tables converting 1`] = `
       "id": "B0000000b",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -219,6 +229,7 @@ exports[`tables converting 1`] = `
       "id": "B0000000c",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -228,6 +239,7 @@ exports[`tables converting 1`] = `
       "id": "B0000000d",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -237,6 +249,7 @@ exports[`tables converting 1`] = `
       "id": "B0000000e",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -246,6 +259,7 @@ exports[`tables converting 1`] = `
       "id": "B0000000f",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -255,6 +269,7 @@ exports[`tables converting 1`] = `
       "id": "B00000010",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -264,6 +279,7 @@ exports[`tables converting 1`] = `
       "id": "B00000011",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -273,6 +289,7 @@ exports[`tables converting 1`] = `
       "id": "B00000012",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -282,6 +299,7 @@ exports[`tables converting 1`] = `
       "id": "B00000013",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -291,6 +309,7 @@ exports[`tables converting 1`] = `
       "id": "B00000014",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -300,6 +319,7 @@ exports[`tables converting 1`] = `
       "id": "B00000015",
       "parents": [
         "table",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",

--- a/packages/@atjson/source-html/test/__snapshots__/table.test.ts.snap
+++ b/packages/@atjson/source-html/test/__snapshots__/table.test.ts.snap
@@ -662,22 +662,13 @@ exports[`tables valid tables converts column alignments 1`] = `
             "textAlign": "right",
           },
         ],
-        "dataSet": "B00000003",
+        "dataSet": "B00000002",
         "showColumnHeaders": true,
       },
       "id": "B00000001",
       "parents": [],
       "selfClosing": false,
       "type": "table",
-    },
-    {
-      "attributes": {},
-      "id": "B00000002",
-      "parents": [
-        "table",
-      ],
-      "selfClosing": false,
-      "type": "text",
     },
     {
       "attributes": {
@@ -768,20 +759,29 @@ exports[`tables valid tables converts column alignments 1`] = `
           "notes": "rich_text",
         },
       },
-      "id": "B00000003",
+      "id": "B00000002",
       "parents": [
         "table",
-        "text",
       ],
       "selfClosing": false,
       "type": "data-set",
     },
     {
       "attributes": {},
+      "id": "B00000003",
+      "parents": [
+        "table",
+        "data-set",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
       "id": "B00000004",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -791,7 +791,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000005",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -801,7 +801,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000006",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -811,7 +811,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000007",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -821,7 +821,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000008",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -831,7 +831,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000009",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -841,7 +841,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000000a",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -851,7 +851,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000000b",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -861,7 +861,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000000c",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -871,7 +871,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000000d",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -881,7 +881,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000000e",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -891,7 +891,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000000f",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -901,7 +901,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000010",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -911,7 +911,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000011",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -921,7 +921,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000012",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -931,7 +931,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000013",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -941,7 +941,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000014",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -951,7 +951,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000015",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -961,7 +961,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000016",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -971,7 +971,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000017",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -981,7 +981,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000018",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -991,7 +991,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000019",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1001,7 +1001,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000001a",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1011,7 +1011,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000001b",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1021,7 +1021,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000001c",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1031,7 +1031,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000001d",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1041,7 +1041,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000001e",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1051,7 +1051,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000001f",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1061,7 +1061,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000020",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1071,7 +1071,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000021",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1081,7 +1081,7 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000022",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1089,19 +1089,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {},
       "id": "B00000023",
-      "parents": [
-        "table",
-        "text",
-      ],
-      "selfClosing": false,
-      "type": "text",
-    },
-    {
-      "attributes": {},
-      "id": "B00000024",
-      "parents": [
-        "table",
-      ],
+      "parents": [],
       "selfClosing": false,
       "type": "text",
     },
@@ -1110,41 +1098,41 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000000",
-      "range": "(20..25]",
+      "range": "(19..24]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000001",
-      "range": "(33..37]",
+      "range": "(32..36]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000002",
-      "range": "(45..49]",
+      "range": "(44..48]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000003",
-      "range": "(57..99]",
+      "range": "(56..98]",
       "type": "slice",
     },
     {
@@ -1152,196 +1140,196 @@ exports[`tables valid tables converts column alignments 1`] = `
         "url": "https://en.wikipedia.org/wiki/Delicious_in_Dungeon",
       },
       "id": "M00000004",
-      "range": "(67..92)",
+      "range": "(66..91)",
       "type": "link",
     },
     {
       "attributes": {},
       "id": "M00000005",
-      "range": "(78..83]",
+      "range": "(77..82]",
       "type": "italic",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000006",
-      "range": "(123..128]",
+      "range": "(122..127]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000007",
-      "range": "(135..138]",
+      "range": "(134..137]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000008",
-      "range": "(146..154]",
+      "range": "(145..153]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000009",
-      "range": "(162..248]",
+      "range": "(161..247]",
       "type": "slice",
     },
     {
       "attributes": {},
       "id": "M0000000a",
-      "range": "(213..226]",
+      "range": "(212..225]",
       "type": "italic",
     },
     {
       "attributes": {},
       "id": "M0000000b",
-      "range": "(220..226]",
+      "range": "(219..225]",
       "type": "bold",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M0000000c",
-      "range": "(266..274]",
+      "range": "(265..273]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M0000000d",
-      "range": "(281..285]",
+      "range": "(280..284]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M0000000e",
-      "range": "(293..298]",
+      "range": "(292..297]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M0000000f",
-      "range": "(306..452]",
+      "range": "(305..451]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000010",
-      "range": "(470..475]",
+      "range": "(469..474]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000011",
-      "range": "(482..485]",
+      "range": "(481..484]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000012",
-      "range": "(493..500]",
+      "range": "(492..499]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000013",
-      "range": "(508..683]",
+      "range": "(507..682]",
       "type": "slice",
     },
     {
       "attributes": {},
       "id": "M00000014",
-      "range": "(522..527]",
+      "range": "(521..526]",
       "type": "italic",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000015",
-      "range": "(701..709]",
+      "range": "(700..708]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000016",
-      "range": "(716..719]",
+      "range": "(715..718]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000017",
-      "range": "(727..733]",
+      "range": "(726..732]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000018",
-      "range": "(741..915]",
+      "range": "(740..914]",
       "type": "slice",
     },
   ],
   "text": "￼
-￼￼￼
+￼￼
   
     
       ￼name￼
@@ -1425,22 +1413,13 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
             "name": "column 4",
           },
         ],
-        "dataSet": "B00000003",
+        "dataSet": "B00000002",
         "showColumnHeaders": false,
       },
       "id": "B00000001",
       "parents": [],
       "selfClosing": false,
       "type": "table",
-    },
-    {
-      "attributes": {},
-      "id": "B00000002",
-      "parents": [
-        "table",
-      ],
-      "selfClosing": false,
-      "type": "text",
     },
     {
       "attributes": {
@@ -1503,20 +1482,29 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
           "column 4": "rich_text",
         },
       },
-      "id": "B00000003",
+      "id": "B00000002",
       "parents": [
         "table",
-        "text",
       ],
       "selfClosing": false,
       "type": "data-set",
     },
     {
       "attributes": {},
+      "id": "B00000003",
+      "parents": [
+        "table",
+        "data-set",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
       "id": "B00000004",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1526,7 +1514,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B00000005",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1536,7 +1524,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B00000006",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1546,7 +1534,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B00000007",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1556,7 +1544,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B00000008",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1566,7 +1554,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B00000009",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1576,7 +1564,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B0000000a",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1586,7 +1574,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B0000000b",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1596,7 +1584,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B0000000c",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1606,7 +1594,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B0000000d",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1616,7 +1604,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B0000000e",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1624,19 +1612,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
     {
       "attributes": {},
       "id": "B0000000f",
-      "parents": [
-        "table",
-        "text",
-      ],
-      "selfClosing": false,
-      "type": "text",
-    },
-    {
-      "attributes": {},
-      "id": "B00000010",
-      "parents": [
-        "table",
-      ],
+      "parents": [],
       "selfClosing": false,
       "type": "text",
     },
@@ -1645,106 +1621,106 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000000",
-      "range": "(20..25]",
+      "range": "(19..24]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000001",
-      "range": "(42..50]",
+      "range": "(41..49]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000002",
-      "range": "(57..61]",
+      "range": "(56..60]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000003",
-      "range": "(69..74]",
+      "range": "(68..73]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000004",
-      "range": "(92..97]",
+      "range": "(91..96]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000005",
-      "range": "(104..111]",
+      "range": "(103..110]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000006",
-      "range": "(129..137]",
+      "range": "(128..136]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000007",
-      "range": "(144..147]",
+      "range": "(143..146]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000008",
-      "range": "(155..161]",
+      "range": "(154..160]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000009",
-      "range": "(169..343]",
+      "range": "(168..342]",
       "type": "slice",
     },
   ],
   "text": "￼
-￼￼￼
+￼￼
   
     
       laios
@@ -1804,22 +1780,13 @@ exports[`tables valid tables converts simple tables 1`] = `
             "slice": "M00000003",
           },
         ],
-        "dataSet": "B00000003",
+        "dataSet": "B00000002",
         "showColumnHeaders": true,
       },
       "id": "B00000001",
       "parents": [],
       "selfClosing": false,
       "type": "table",
-    },
-    {
-      "attributes": {},
-      "id": "B00000002",
-      "parents": [
-        "table",
-      ],
-      "selfClosing": false,
-      "type": "text",
     },
     {
       "attributes": {
@@ -1910,20 +1877,29 @@ exports[`tables valid tables converts simple tables 1`] = `
           "notes": "rich_text",
         },
       },
-      "id": "B00000003",
+      "id": "B00000002",
       "parents": [
         "table",
-        "text",
       ],
       "selfClosing": false,
       "type": "data-set",
     },
     {
       "attributes": {},
+      "id": "B00000003",
+      "parents": [
+        "table",
+        "data-set",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
       "id": "B00000004",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1933,7 +1909,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000005",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1943,7 +1919,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000006",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1953,7 +1929,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000007",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1963,7 +1939,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000008",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1973,7 +1949,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000009",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1983,7 +1959,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000000a",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1993,7 +1969,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000000b",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2003,7 +1979,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000000c",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2013,7 +1989,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000000d",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2023,7 +1999,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000000e",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2033,7 +2009,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000000f",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2043,7 +2019,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000010",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2053,7 +2029,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000011",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2063,7 +2039,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000012",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2073,7 +2049,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000013",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2083,7 +2059,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000014",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2093,7 +2069,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000015",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2103,7 +2079,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000016",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2113,7 +2089,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000017",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2123,7 +2099,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000018",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2133,7 +2109,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000019",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2143,7 +2119,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000001a",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2153,7 +2129,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000001b",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2163,7 +2139,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000001c",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2173,7 +2149,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000001d",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2183,7 +2159,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000001e",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2193,7 +2169,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000001f",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2203,7 +2179,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000020",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2213,7 +2189,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000021",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2223,7 +2199,7 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000022",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2231,19 +2207,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {},
       "id": "B00000023",
-      "parents": [
-        "table",
-        "text",
-      ],
-      "selfClosing": false,
-      "type": "text",
-    },
-    {
-      "attributes": {},
-      "id": "B00000024",
-      "parents": [
-        "table",
-      ],
+      "parents": [],
       "selfClosing": false,
       "type": "text",
     },
@@ -2252,41 +2216,41 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000000",
-      "range": "(20..25]",
+      "range": "(19..24]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000001",
-      "range": "(33..37]",
+      "range": "(32..36]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000002",
-      "range": "(45..49]",
+      "range": "(44..48]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000003",
-      "range": "(57..99]",
+      "range": "(56..98]",
       "type": "slice",
     },
     {
@@ -2294,196 +2258,196 @@ exports[`tables valid tables converts simple tables 1`] = `
         "url": "https://en.wikipedia.org/wiki/Delicious_in_Dungeon",
       },
       "id": "M00000004",
-      "range": "(67..92)",
+      "range": "(66..91)",
       "type": "link",
     },
     {
       "attributes": {},
       "id": "M00000005",
-      "range": "(78..83]",
+      "range": "(77..82]",
       "type": "italic",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000006",
-      "range": "(123..128]",
+      "range": "(122..127]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000007",
-      "range": "(135..138]",
+      "range": "(134..137]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000008",
-      "range": "(146..154]",
+      "range": "(145..153]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000009",
-      "range": "(162..248]",
+      "range": "(161..247]",
       "type": "slice",
     },
     {
       "attributes": {},
       "id": "M0000000a",
-      "range": "(213..226]",
+      "range": "(212..225]",
       "type": "italic",
     },
     {
       "attributes": {},
       "id": "M0000000b",
-      "range": "(220..226]",
+      "range": "(219..225]",
       "type": "bold",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M0000000c",
-      "range": "(266..274]",
+      "range": "(265..273]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M0000000d",
-      "range": "(281..285]",
+      "range": "(280..284]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M0000000e",
-      "range": "(293..298]",
+      "range": "(292..297]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M0000000f",
-      "range": "(306..452]",
+      "range": "(305..451]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000010",
-      "range": "(470..475]",
+      "range": "(469..474]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000011",
-      "range": "(482..485]",
+      "range": "(481..484]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000012",
-      "range": "(493..500]",
+      "range": "(492..499]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000013",
-      "range": "(508..683]",
+      "range": "(507..682]",
       "type": "slice",
     },
     {
       "attributes": {},
       "id": "M00000014",
-      "range": "(522..527]",
+      "range": "(521..526]",
       "type": "italic",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000015",
-      "range": "(701..709]",
+      "range": "(700..708]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000016",
-      "range": "(716..719]",
+      "range": "(715..718]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000017",
-      "range": "(727..733]",
+      "range": "(726..732]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000018",
-      "range": "(741..915]",
+      "range": "(740..914]",
       "type": "slice",
     },
   ],
   "text": "￼
-￼￼￼
+￼￼
   
     
       ￼name￼
@@ -2567,22 +2531,13 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
             "name": "column 4",
           },
         ],
-        "dataSet": "B00000003",
+        "dataSet": "B00000002",
         "showColumnHeaders": false,
       },
       "id": "B00000001",
       "parents": [],
       "selfClosing": false,
       "type": "table",
-    },
-    {
-      "attributes": {},
-      "id": "B00000002",
-      "parents": [
-        "table",
-      ],
-      "selfClosing": false,
-      "type": "text",
     },
     {
       "attributes": {
@@ -2673,20 +2628,29 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
           "column 4": "rich_text",
         },
       },
-      "id": "B00000003",
+      "id": "B00000002",
       "parents": [
         "table",
-        "text",
       ],
       "selfClosing": false,
       "type": "data-set",
     },
     {
       "attributes": {},
+      "id": "B00000003",
+      "parents": [
+        "table",
+        "data-set",
+      ],
+      "selfClosing": false,
+      "type": "text",
+    },
+    {
+      "attributes": {},
       "id": "B00000004",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2696,7 +2660,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000005",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2706,7 +2670,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000006",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2716,7 +2680,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000007",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2726,7 +2690,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000008",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2736,7 +2700,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000009",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2746,7 +2710,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000000a",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2756,7 +2720,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000000b",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2766,7 +2730,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000000c",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2776,7 +2740,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000000d",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2786,7 +2750,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000000e",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2796,7 +2760,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000000f",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2806,7 +2770,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000010",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2816,7 +2780,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000011",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2826,7 +2790,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000012",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2836,7 +2800,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000013",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2846,7 +2810,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000014",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2856,7 +2820,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000015",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2866,7 +2830,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000016",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2876,7 +2840,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000017",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2886,7 +2850,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000018",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2896,7 +2860,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000019",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2906,7 +2870,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000001a",
       "parents": [
         "table",
-        "text",
+        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2914,19 +2878,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {},
       "id": "B0000001b",
-      "parents": [
-        "table",
-        "text",
-      ],
-      "selfClosing": false,
-      "type": "text",
-    },
-    {
-      "attributes": {},
-      "id": "B0000001c",
-      "parents": [
-        "table",
-      ],
+      "parents": [],
       "selfClosing": false,
       "type": "text",
     },
@@ -2935,184 +2887,184 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000000",
-      "range": "(20..25]",
+      "range": "(19..24]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000001",
-      "range": "(32..35]",
+      "range": "(31..34]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000002",
-      "range": "(43..51]",
+      "range": "(42..50]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000003",
-      "range": "(59..145]",
+      "range": "(58..144]",
       "type": "slice",
     },
     {
       "attributes": {},
       "id": "M00000004",
-      "range": "(110..123]",
+      "range": "(109..122]",
       "type": "italic",
     },
     {
       "attributes": {},
       "id": "M00000005",
-      "range": "(117..123]",
+      "range": "(116..122]",
       "type": "bold",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000006",
-      "range": "(163..171]",
+      "range": "(162..170]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000007",
-      "range": "(178..182]",
+      "range": "(177..181]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000008",
-      "range": "(190..195]",
+      "range": "(189..194]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000009",
-      "range": "(203..349]",
+      "range": "(202..348]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M0000000a",
-      "range": "(367..372]",
+      "range": "(366..371]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M0000000b",
-      "range": "(379..382]",
+      "range": "(378..381]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M0000000c",
-      "range": "(390..397]",
+      "range": "(389..396]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M0000000d",
-      "range": "(405..580]",
+      "range": "(404..579]",
       "type": "slice",
     },
     {
       "attributes": {},
       "id": "M0000000e",
-      "range": "(419..424]",
+      "range": "(418..423]",
       "type": "italic",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M0000000f",
-      "range": "(598..606]",
+      "range": "(597..605]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000010",
-      "range": "(613..616]",
+      "range": "(612..615]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000011",
-      "range": "(624..630]",
+      "range": "(623..629]",
       "type": "slice",
     },
     {
       "attributes": {
         "refs": [
-          "B00000003",
+          "B00000002",
         ],
       },
       "id": "M00000012",
-      "range": "(638..812]",
+      "range": "(637..811]",
       "type": "slice",
     },
   ],
   "text": "￼
-￼￼￼
+￼￼
   
     
       laios

--- a/packages/@atjson/source-html/test/__snapshots__/table.test.ts.snap
+++ b/packages/@atjson/source-html/test/__snapshots__/table.test.ts.snap
@@ -642,36 +642,6 @@ exports[`tables valid tables converts column alignments 1`] = `
     },
     {
       "attributes": {
-        "columns": [
-          {
-            "name": "name",
-            "slice": "M00000000",
-            "textAlign": "left",
-          },
-          {
-            "name": "age",
-            "slice": "M00000001",
-          },
-          {
-            "name": "job",
-            "slice": "M00000002",
-          },
-          {
-            "name": "notes",
-            "slice": "M00000003",
-            "textAlign": "right",
-          },
-        ],
-        "dataSet": "B00000002",
-        "showColumnHeaders": true,
-      },
-      "id": "B00000001",
-      "parents": [],
-      "selfClosing": false,
-      "type": "table",
-    },
-    {
-      "attributes": {
         "records": [
           {
             "age": {
@@ -759,19 +729,46 @@ exports[`tables valid tables converts column alignments 1`] = `
           "notes": "rich_text",
         },
       },
-      "id": "B00000002",
-      "parents": [
-        "table",
-      ],
+      "id": "B00000001",
+      "parents": [],
       "selfClosing": false,
       "type": "data-set",
+    },
+    {
+      "attributes": {
+        "columns": [
+          {
+            "name": "name",
+            "slice": "M00000000",
+            "textAlign": "left",
+          },
+          {
+            "name": "age",
+            "slice": "M00000001",
+          },
+          {
+            "name": "job",
+            "slice": "M00000002",
+          },
+          {
+            "name": "notes",
+            "slice": "M00000003",
+            "textAlign": "right",
+          },
+        ],
+        "dataSet": "B00000001",
+        "showColumnHeaders": true,
+      },
+      "id": "B00000002",
+      "parents": [],
+      "selfClosing": false,
+      "type": "table",
     },
     {
       "attributes": {},
       "id": "B00000003",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -781,7 +778,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000004",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -791,7 +787,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000005",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -801,7 +796,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000006",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -811,7 +805,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000007",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -821,7 +814,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000008",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -831,7 +823,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000009",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -841,7 +832,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000000a",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -851,7 +841,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000000b",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -861,7 +850,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000000c",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -871,7 +859,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000000d",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -881,7 +868,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000000e",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -891,7 +877,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000000f",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -901,7 +886,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000010",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -911,7 +895,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000011",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -921,7 +904,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000012",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -931,7 +913,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000013",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -941,7 +922,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000014",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -951,7 +931,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000015",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -961,7 +940,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000016",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -971,7 +949,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000017",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -981,7 +958,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000018",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -991,7 +967,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000019",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1001,7 +976,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000001a",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1011,7 +985,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000001b",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1021,7 +994,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000001c",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1031,7 +1003,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000001d",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1041,7 +1012,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000001e",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1051,7 +1021,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B0000001f",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1061,7 +1030,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000020",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1071,7 +1039,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000021",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1081,7 +1048,6 @@ exports[`tables valid tables converts column alignments 1`] = `
       "id": "B00000022",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1098,7 +1064,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000000",
@@ -1108,7 +1074,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000001",
@@ -1118,7 +1084,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000002",
@@ -1128,7 +1094,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000003",
@@ -1152,7 +1118,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000006",
@@ -1162,7 +1128,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000007",
@@ -1172,7 +1138,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000008",
@@ -1182,7 +1148,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000009",
@@ -1204,7 +1170,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M0000000c",
@@ -1214,7 +1180,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M0000000d",
@@ -1224,7 +1190,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M0000000e",
@@ -1234,7 +1200,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M0000000f",
@@ -1244,7 +1210,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000010",
@@ -1254,7 +1220,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000011",
@@ -1264,7 +1230,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000012",
@@ -1274,7 +1240,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000013",
@@ -1290,7 +1256,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000015",
@@ -1300,7 +1266,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000016",
@@ -1310,7 +1276,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000017",
@@ -1320,7 +1286,7 @@ exports[`tables valid tables converts column alignments 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000018",
@@ -1399,30 +1365,6 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
     },
     {
       "attributes": {
-        "columns": [
-          {
-            "name": "column 1",
-          },
-          {
-            "name": "column 2",
-          },
-          {
-            "name": "column 3",
-          },
-          {
-            "name": "column 4",
-          },
-        ],
-        "dataSet": "B00000002",
-        "showColumnHeaders": false,
-      },
-      "id": "B00000001",
-      "parents": [],
-      "selfClosing": false,
-      "type": "table",
-    },
-    {
-      "attributes": {
         "records": [
           {
             "column 1": {
@@ -1482,19 +1424,40 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
           "column 4": "rich_text",
         },
       },
-      "id": "B00000002",
-      "parents": [
-        "table",
-      ],
+      "id": "B00000001",
+      "parents": [],
       "selfClosing": false,
       "type": "data-set",
+    },
+    {
+      "attributes": {
+        "columns": [
+          {
+            "name": "column 1",
+          },
+          {
+            "name": "column 2",
+          },
+          {
+            "name": "column 3",
+          },
+          {
+            "name": "column 4",
+          },
+        ],
+        "dataSet": "B00000001",
+        "showColumnHeaders": false,
+      },
+      "id": "B00000002",
+      "parents": [],
+      "selfClosing": false,
+      "type": "table",
     },
     {
       "attributes": {},
       "id": "B00000003",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1504,7 +1467,6 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B00000004",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1514,7 +1476,6 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B00000005",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1524,7 +1485,6 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B00000006",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1534,7 +1494,6 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B00000007",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1544,7 +1503,6 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B00000008",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1554,7 +1512,6 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B00000009",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1564,7 +1521,6 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B0000000a",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1574,7 +1530,6 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B0000000b",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1584,7 +1539,6 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B0000000c",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1594,7 +1548,6 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B0000000d",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1604,7 +1557,6 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
       "id": "B0000000e",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1621,7 +1573,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000000",
@@ -1631,7 +1583,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000001",
@@ -1641,7 +1593,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000002",
@@ -1651,7 +1603,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000003",
@@ -1661,7 +1613,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000004",
@@ -1671,7 +1623,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000005",
@@ -1681,7 +1633,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000006",
@@ -1691,7 +1643,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000007",
@@ -1701,7 +1653,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000008",
@@ -1711,7 +1663,7 @@ exports[`tables valid tables converts jagged tables with no head section 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000009",
@@ -1759,34 +1711,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "parents": [],
       "selfClosing": false,
       "type": "text",
-    },
-    {
-      "attributes": {
-        "columns": [
-          {
-            "name": "name",
-            "slice": "M00000000",
-          },
-          {
-            "name": "age",
-            "slice": "M00000001",
-          },
-          {
-            "name": "job",
-            "slice": "M00000002",
-          },
-          {
-            "name": "notes",
-            "slice": "M00000003",
-          },
-        ],
-        "dataSet": "B00000002",
-        "showColumnHeaders": true,
-      },
-      "id": "B00000001",
-      "parents": [],
-      "selfClosing": false,
-      "type": "table",
     },
     {
       "attributes": {
@@ -1877,19 +1801,44 @@ exports[`tables valid tables converts simple tables 1`] = `
           "notes": "rich_text",
         },
       },
-      "id": "B00000002",
-      "parents": [
-        "table",
-      ],
+      "id": "B00000001",
+      "parents": [],
       "selfClosing": false,
       "type": "data-set",
+    },
+    {
+      "attributes": {
+        "columns": [
+          {
+            "name": "name",
+            "slice": "M00000000",
+          },
+          {
+            "name": "age",
+            "slice": "M00000001",
+          },
+          {
+            "name": "job",
+            "slice": "M00000002",
+          },
+          {
+            "name": "notes",
+            "slice": "M00000003",
+          },
+        ],
+        "dataSet": "B00000001",
+        "showColumnHeaders": true,
+      },
+      "id": "B00000002",
+      "parents": [],
+      "selfClosing": false,
+      "type": "table",
     },
     {
       "attributes": {},
       "id": "B00000003",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1899,7 +1848,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000004",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1909,7 +1857,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000005",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1919,7 +1866,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000006",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1929,7 +1875,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000007",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1939,7 +1884,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000008",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1949,7 +1893,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000009",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1959,7 +1902,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000000a",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1969,7 +1911,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000000b",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1979,7 +1920,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000000c",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1989,7 +1929,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000000d",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -1999,7 +1938,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000000e",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2009,7 +1947,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000000f",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2019,7 +1956,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000010",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2029,7 +1965,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000011",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2039,7 +1974,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000012",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2049,7 +1983,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000013",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2059,7 +1992,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000014",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2069,7 +2001,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000015",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2079,7 +2010,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000016",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2089,7 +2019,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000017",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2099,7 +2028,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000018",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2109,7 +2037,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000019",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2119,7 +2046,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000001a",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2129,7 +2055,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000001b",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2139,7 +2064,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000001c",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2149,7 +2073,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000001d",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2159,7 +2082,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000001e",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2169,7 +2091,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B0000001f",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2179,7 +2100,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000020",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2189,7 +2109,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000021",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2199,7 +2118,6 @@ exports[`tables valid tables converts simple tables 1`] = `
       "id": "B00000022",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2216,7 +2134,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000000",
@@ -2226,7 +2144,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000001",
@@ -2236,7 +2154,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000002",
@@ -2246,7 +2164,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000003",
@@ -2270,7 +2188,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000006",
@@ -2280,7 +2198,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000007",
@@ -2290,7 +2208,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000008",
@@ -2300,7 +2218,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000009",
@@ -2322,7 +2240,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M0000000c",
@@ -2332,7 +2250,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M0000000d",
@@ -2342,7 +2260,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M0000000e",
@@ -2352,7 +2270,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M0000000f",
@@ -2362,7 +2280,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000010",
@@ -2372,7 +2290,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000011",
@@ -2382,7 +2300,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000012",
@@ -2392,7 +2310,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000013",
@@ -2408,7 +2326,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000015",
@@ -2418,7 +2336,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000016",
@@ -2428,7 +2346,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000017",
@@ -2438,7 +2356,7 @@ exports[`tables valid tables converts simple tables 1`] = `
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000018",
@@ -2514,30 +2432,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "parents": [],
       "selfClosing": false,
       "type": "text",
-    },
-    {
-      "attributes": {
-        "columns": [
-          {
-            "name": "column 1",
-          },
-          {
-            "name": "column 2",
-          },
-          {
-            "name": "column 3",
-          },
-          {
-            "name": "column 4",
-          },
-        ],
-        "dataSet": "B00000002",
-        "showColumnHeaders": false,
-      },
-      "id": "B00000001",
-      "parents": [],
-      "selfClosing": false,
-      "type": "table",
     },
     {
       "attributes": {
@@ -2628,19 +2522,40 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
           "column 4": "rich_text",
         },
       },
-      "id": "B00000002",
-      "parents": [
-        "table",
-      ],
+      "id": "B00000001",
+      "parents": [],
       "selfClosing": false,
       "type": "data-set",
+    },
+    {
+      "attributes": {
+        "columns": [
+          {
+            "name": "column 1",
+          },
+          {
+            "name": "column 2",
+          },
+          {
+            "name": "column 3",
+          },
+          {
+            "name": "column 4",
+          },
+        ],
+        "dataSet": "B00000001",
+        "showColumnHeaders": false,
+      },
+      "id": "B00000002",
+      "parents": [],
+      "selfClosing": false,
+      "type": "table",
     },
     {
       "attributes": {},
       "id": "B00000003",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2650,7 +2565,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000004",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2660,7 +2574,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000005",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2670,7 +2583,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000006",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2680,7 +2592,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000007",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2690,7 +2601,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000008",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2700,7 +2610,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000009",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2710,7 +2619,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000000a",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2720,7 +2628,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000000b",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2730,7 +2637,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000000c",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2740,7 +2646,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000000d",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2750,7 +2655,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000000e",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2760,7 +2664,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000000f",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2770,7 +2673,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000010",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2780,7 +2682,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000011",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2790,7 +2691,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000012",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2800,7 +2700,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000013",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2810,7 +2709,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000014",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2820,7 +2718,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000015",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2830,7 +2727,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000016",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2840,7 +2736,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000017",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2850,7 +2745,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000018",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2860,7 +2754,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B00000019",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2870,7 +2763,6 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
       "id": "B0000001a",
       "parents": [
         "table",
-        "data-set",
       ],
       "selfClosing": false,
       "type": "text",
@@ -2887,7 +2779,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000000",
@@ -2897,7 +2789,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000001",
@@ -2907,7 +2799,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000002",
@@ -2917,7 +2809,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000003",
@@ -2939,7 +2831,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000006",
@@ -2949,7 +2841,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000007",
@@ -2959,7 +2851,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000008",
@@ -2969,7 +2861,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000009",
@@ -2979,7 +2871,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M0000000a",
@@ -2989,7 +2881,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M0000000b",
@@ -2999,7 +2891,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M0000000c",
@@ -3009,7 +2901,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M0000000d",
@@ -3025,7 +2917,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M0000000f",
@@ -3035,7 +2927,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000010",
@@ -3045,7 +2937,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000011",
@@ -3055,7 +2947,7 @@ exports[`tables valid tables converts uniform tables with no head section 1`] = 
     {
       "attributes": {
         "refs": [
-          "B00000002",
+          "B00000001",
         ],
       },
       "id": "M00000012",


### PR DESCRIPTION
There's a bug in the `serialize` function that causes collapsed blocks to end up occasionally consuming the entire remainder of the document due to their start and ends being reversed by the token sorting algorithm.

I added some (skipped) tests to demonstrate the problem, and changed the conversion code for tables and datasets to avoid generating problematic documents.

For future reference, the issue is fundamental to the sorting process for our tokens. start and end tokens are usually sorted end -> start, but when they belong to the same annotation they're sorted start -> end; this produces a logical contradiction that no generic nlogn sort algorithm can deal with (the comparison function is *intransitive*, so comparing A to B and B to C doesn't let you infer how A relates to C).

Fixing this without introducing some kind of N^2 sort step would require a careful rethinking of the whole serialization algorithm which I don't have time for right now....so I'm leaving the tests in as a note to self in the future