### PR TITLE
BlueskyEmbed

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/bluesky-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/bluesky-embed.ts
@@ -12,6 +12,11 @@ export class BlueskyEmbed extends BlockAnnotation<{
   cid: string;
 
   /**
+   * The web URL to the post.
+   */
+  url: string;
+
+  /**
    * Layout information, used to indicate mutually
    * exclusive layouts, for example sizes, floats, etc.
    */

--- a/packages/@atjson/offset-annotations/src/annotations/bluesky-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/bluesky-embed.ts
@@ -1,0 +1,33 @@
+import { BlockAnnotation } from "@atjson/document";
+
+export class BlueskyEmbed extends BlockAnnotation<{
+  /**
+   * The at protocol uri of the Bluesky embed
+   */
+  uri: string;
+
+  /**
+   * The IPFS content id of the post.
+   */
+  cid: string;
+
+  /**
+   * Layout information, used to indicate mutually
+   * exclusive layouts, for example sizes, floats, etc.
+   */
+  layout?: string;
+
+  /**
+   * A named identifier used to quickly jump to this item
+   */
+  anchorName?: string;
+
+  /**
+   * The post content at the time of embedding, ususally
+   * a textual representation of the content with some links.
+   */
+  content?: string;
+}> {
+  static vendorPrefix = "offset";
+  static type = "bluesky-embed";
+}

--- a/packages/@atjson/offset-annotations/src/annotations/index.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/index.ts
@@ -1,4 +1,5 @@
 export * from "./blockquote";
+export * from "./bluesky-embed";
 export * from "./bold";
 export * from "./ceros-embed";
 export * from "./cne-audio-embed";

--- a/packages/@atjson/offset-annotations/src/index.ts
+++ b/packages/@atjson/offset-annotations/src/index.ts
@@ -1,6 +1,7 @@
 import Document from "@atjson/document";
 import {
   Blockquote,
+  BlueskyEmbed,
   Bold,
   CerosEmbed,
   CneAudioEmbed,
@@ -12,11 +13,11 @@ import {
   FireworkEmbed,
   FixedIndent,
   GiphyEmbed,
-  GroupItem,
   Group,
-  HTML,
+  GroupItem,
   Heading,
   HorizontalRule,
+  HTML,
   IframeEmbed,
   Image,
   InstagramEmbed,
@@ -49,6 +50,7 @@ export default class OffsetSource extends Document {
   static contentType = "application/vnd.atjson+offset";
   static schema = [
     Blockquote,
+    BlueskyEmbed,
     Bold,
     CerosEmbed,
     CneAudioEmbed,

--- a/packages/@atjson/renderer-html/src/index.ts
+++ b/packages/@atjson/renderer-html/src/index.ts
@@ -1,6 +1,7 @@
 import {
   AudioEnvironments,
   Blockquote,
+  BlueskyEmbed,
   CerosEmbed,
   CneAudioEmbed,
   CneEventRegistrationEmbed,
@@ -315,6 +316,21 @@ export default class HTMLRenderer extends Renderer {
     }).join(" ")}>${
       slice ? this.render(slice) : `A post shared on Instagram`
     }</a></p></div></blockquote> <script async src="//www.instagram.com/embed.js"></script>`;
+  }
+
+  *BlueskyEmbed(embed: Block<BlueskyEmbed>) {
+    let slice =
+      embed.attributes.content != null &&
+      this.getSlice(embed.attributes.content);
+
+    return `<blockquote ${this.htmlAttributes({
+      id: embed.attributes.anchorName,
+      class: "bluesky-embed",
+      "data-bluesky-uri": embed.attributes.uri,
+      "data-bluesky-cid": embed.attributes.cid,
+    }).join(" ")}>${
+      slice ? this.render(slice) : ""
+    }</blockquote><script async src="https://embed.bsky.app/static/embed.js" charset="utf-8"></script>`;
   }
 
   *FacebookEmbed(embed: Block<FacebookEmbed>) {

--- a/packages/@atjson/renderer-html/test/bluesky-embed.test.ts
+++ b/packages/@atjson/renderer-html/test/bluesky-embed.test.ts
@@ -1,0 +1,116 @@
+import OffsetSource, { BlueskyEmbed } from "@atjson/offset-annotations";
+import { ParseAnnotation } from "@atjson/document";
+import Renderer from "../src";
+
+describe("BlueskyEmbed", () => {
+  test("no content", () => {
+    let doc = new OffsetSource({
+      content: "\uFFFC",
+      annotations: [
+        new BlueskyEmbed({
+          start: 0,
+          end: 1,
+          attributes: {
+            cid: "bafyreicg7axsdp6b7f4uj75ggdfhrdl52cqpjah45scox3prmqflwg557i",
+            uri: "at://did:plc:xrr5j2okn7ew2zvcwsxus3gb/app.bsky.feed.post/3kshwuxmy5o2y",
+          },
+        }),
+        new ParseAnnotation({
+          start: 0,
+          end: 1,
+        }),
+      ],
+    });
+
+    expect(Renderer.render(doc)).toEqual(
+      `<blockquote class="bluesky-embed" data-bluesky-uri="at://did:plc:xrr5j2okn7ew2zvcwsxus3gb/app.bsky.feed.post/3kshwuxmy5o2y" data-bluesky-cid="bafyreicg7axsdp6b7f4uj75ggdfhrdl52cqpjah45scox3prmqflwg557i"></blockquote><script async src="https://embed.bsky.app/static/embed.js" charset="utf-8"></script>`
+    );
+  });
+
+  test("with content", () => {
+    expect(
+      Renderer.render({
+        blocks: [
+          {
+            attributes: {
+              cid: "bafyreicg7axsdp6b7f4uj75ggdfhrdl52cqpjah45scox3prmqflwg557i",
+              content: "M00000000",
+              uri: "at://did:plc:xrr5j2okn7ew2zvcwsxus3gb/app.bsky.feed.post/3kshwuxmy5o2y",
+            },
+            id: "B00000000",
+            parents: [],
+            selfClosing: false,
+            type: "bluesky-embed",
+          },
+          {
+            attributes: {},
+            id: "B00000001",
+            parents: ["bluesky-embed"],
+            selfClosing: false,
+            type: "text",
+          },
+          {
+            attributes: {},
+            id: "B00000002",
+            parents: ["bluesky-embed", "text"],
+            selfClosing: true,
+            type: "line-break",
+          },
+          {
+            attributes: {},
+            id: "B00000003",
+            parents: ["bluesky-embed", "text"],
+            selfClosing: true,
+            type: "line-break",
+          },
+          {
+            attributes: {},
+            id: "B00000004",
+            parents: ["bluesky-embed", "text"],
+            selfClosing: true,
+            type: "line-break",
+          },
+        ],
+
+        marks: [
+          {
+            attributes: {
+              refs: ["B00000000"],
+            },
+            id: "M00000000",
+            range: "(1..144]",
+            type: "slice",
+          },
+          {
+            attributes: {
+              url: "https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y?ref_src=embed",
+            },
+            id: "M00000001",
+            range: "(63..79)",
+            type: "link",
+          },
+          {
+            attributes: {
+              url: "https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb?ref_src=embed",
+            },
+            id: "M00000002",
+            range: "(96..119)",
+            type: "link",
+          },
+          {
+            attributes: {
+              url: "https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y?ref_src=embed",
+            },
+            id: "M00000003",
+            range: "(121..144)",
+            type: "link",
+          },
+        ],
+
+        text: "￼￼Lap time al fresco. Photo from my collection, no date/info.￼￼[image or embed]￼— Cats of Yore (@catsofyore.bsky.social) May 14, 2024 at 3:43 PM",
+      })
+    ).toMatchInlineSnapshot(
+      `"<blockquote class="bluesky-embed" data-bluesky-uri="at://did:plc:xrr5j2okn7ew2zvcwsxus3gb/app.bsky.feed.post/3kshwuxmy5o2y" data-bluesky-cid="bafyreicg7axsdp6b7f4uj75ggdfhrdl52cqpjah45scox3prmqflwg557i">Lap time al fresco. Photo from my collection, no date/info.<br /><br /><a href="https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y?ref_src=embed">[image or embed]</a><br />&#x2014; Cats of Yore (<a href="https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb?ref_src=embed">@catsofyore.bsky.social</a>) <a href="https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y?ref_src=embed">May 14, 2024 at 3:43 PM</a></blockquote><script async src="https://embed.bsky.app/static/embed.js" charset="utf-8"></script>"`
+    );
+  });
+});

--- a/packages/@atjson/source-html/src/converter/social-embeds.ts
+++ b/packages/@atjson/source-html/src/converter/social-embeds.ts
@@ -1,4 +1,5 @@
 import Document, {
+  AdjacentBoundaryBehaviour,
   Annotation,
   ParseAnnotation,
   SliceAnnotation,
@@ -6,7 +7,12 @@ import Document, {
   UnknownAnnotation,
   is,
 } from "@atjson/document";
-import { LineBreak, SocialURLs, TikTokEmbed } from "@atjson/offset-annotations";
+import {
+  BlueskyEmbed,
+  LineBreak,
+  SocialURLs,
+  TikTokEmbed,
+} from "@atjson/offset-annotations";
 import { Script, Anchor, Blockquote } from "../annotations";
 
 function aCoversB(a: Annotation<any>, b: Annotation<any>) {
@@ -487,7 +493,7 @@ export default function (doc: Document) {
         return divs[divs.length - 2].start === parseToken.start;
       }
     )
-    .update(function joinBlockQuoteWithLinksAndScripts({
+    .update(function updateThreadsEmbeds({
       blockquote,
       divs,
       links,
@@ -544,6 +550,93 @@ export default function (doc: Document) {
         doc.deleteText(end, scripts[0].end);
         doc.deleteText(blockquote.start, start);
       }
+    });
+
+  /**
+   * Bluesky embed structure:
+   *   <blockquote class="bluesky-embed" ...></blockquote>
+   *   <script async src="https://embed.bsky.app/static/embed.js" charset="utf-8"></script>
+   */
+  doc
+    .where(function isBlueskyBlockquote(a) {
+      return is(a, Blockquote) && a.attributes.class === "bluesky-embed";
+    })
+    .as("blockquote")
+    .outerJoin(
+      doc.where({ type: "-html-script" }).as("scripts"),
+      function scriptRightAfterIframe(blockquote, script: Script) {
+        let src = script.attributes.src;
+        return (
+          (script.start === blockquote.end ||
+            script.start === blockquote.end + 1) &&
+          src != null
+        );
+      }
+    )
+    .outerJoin(
+      doc.where({ type: "-html-p" }).as("paragraphs"),
+      function scriptRightAfterIframe({ blockquote }, p) {
+        return aCoversB(blockquote, p);
+      }
+    )
+    .update(function joinBlockQuoteWithLinksAndScripts({
+      blockquote,
+      paragraphs,
+      scripts,
+    }) {
+      doc.insertText(blockquote.start, "\uFFFC");
+      let content = new SliceAnnotation({
+        start: blockquote.start + 1,
+        end: blockquote.end,
+        attributes: {
+          refs: [blockquote.id],
+        },
+      });
+
+      doc.replaceAnnotation(
+        blockquote,
+        new BlueskyEmbed({
+          id: blockquote.id,
+          start: blockquote.start,
+          end: blockquote.end,
+          attributes: {
+            uri: blockquote.attributes.dataset["bluesky-uri"],
+            cid: blockquote.attributes.dataset["bluesky-cid"],
+            content: content?.id,
+          },
+        }),
+        content,
+        new ParseAnnotation({
+          start: blockquote.start - 1,
+          end: blockquote.start,
+        }),
+        new TextAnnotation({
+          start: blockquote.start + 1,
+          end: blockquote.end,
+        })
+      );
+
+      let paragraph = paragraphs[0];
+      if (paragraph) {
+        doc.insertText(
+          paragraph.end,
+          "\uFFFC",
+          AdjacentBoundaryBehaviour.preserveTrailing
+        );
+        doc.addAnnotations(
+          new LineBreak({
+            start: paragraph.end,
+            end: paragraph.end + 1,
+          }),
+          new ParseAnnotation({
+            start: paragraph.end,
+            end: paragraph.end + 1,
+          })
+        );
+        doc.removeAnnotations(paragraphs);
+      }
+
+      doc.removeAnnotations(scripts);
     });
 
   doc.where((a) => is(a, ParseAnnotation) && a.start === a.end).remove();

--- a/packages/@atjson/source-html/test/bluesky-embed.test.ts
+++ b/packages/@atjson/source-html/test/bluesky-embed.test.ts
@@ -1,0 +1,105 @@
+import OffsetSource from "@atjson/offset-annotations";
+import HTMLSource from "../src";
+import { serialize } from "@atjson/document";
+
+describe("BlueskyEmbed", () => {
+  test("default", () => {
+    let doc = HTMLSource.fromRaw(
+      '<blockquote class="bluesky-embed" data-bluesky-uri="at://did:plc:xrr5j2okn7ew2zvcwsxus3gb/app.bsky.feed.post/3kshwuxmy5o2y" data-bluesky-cid="bafyreicg7axsdp6b7f4uj75ggdfhrdl52cqpjah45scox3prmqflwg557i"><p lang="en">Lap time al fresco. Photo from my collection, no date/info.<br><br><a href="https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y?ref_src=embed">[image or embed]</a></p>&mdash; Cats of Yore (<a href="https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb?ref_src=embed">@catsofyore.bsky.social</a>) <a href="https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y?ref_src=embed">May 14, 2024 at 3:43 PM</a></blockquote><script async src="https://embed.bsky.app/static/embed.js" charset="utf-8"></script>'
+    ).convertTo(OffsetSource);
+
+    expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+      {
+        "blocks": [
+          {
+            "attributes": {
+              "cid": "bafyreicg7axsdp6b7f4uj75ggdfhrdl52cqpjah45scox3prmqflwg557i",
+              "content": "M00000000",
+              "uri": "at://did:plc:xrr5j2okn7ew2zvcwsxus3gb/app.bsky.feed.post/3kshwuxmy5o2y",
+            },
+            "id": "B00000000",
+            "parents": [],
+            "selfClosing": false,
+            "type": "bluesky-embed",
+          },
+          {
+            "attributes": {},
+            "id": "B00000001",
+            "parents": [
+              "bluesky-embed",
+            ],
+            "selfClosing": false,
+            "type": "text",
+          },
+          {
+            "attributes": {},
+            "id": "B00000002",
+            "parents": [
+              "bluesky-embed",
+              "text",
+            ],
+            "selfClosing": true,
+            "type": "line-break",
+          },
+          {
+            "attributes": {},
+            "id": "B00000003",
+            "parents": [
+              "bluesky-embed",
+              "text",
+            ],
+            "selfClosing": true,
+            "type": "line-break",
+          },
+          {
+            "attributes": {},
+            "id": "B00000004",
+            "parents": [
+              "bluesky-embed",
+              "text",
+            ],
+            "selfClosing": true,
+            "type": "line-break",
+          },
+        ],
+        "marks": [
+          {
+            "attributes": {
+              "refs": [
+                "B00000000",
+              ],
+            },
+            "id": "M00000000",
+            "range": "(1..144]",
+            "type": "slice",
+          },
+          {
+            "attributes": {
+              "url": "https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y?ref_src=embed",
+            },
+            "id": "M00000001",
+            "range": "(63..79)",
+            "type": "link",
+          },
+          {
+            "attributes": {
+              "url": "https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb?ref_src=embed",
+            },
+            "id": "M00000002",
+            "range": "(96..119)",
+            "type": "link",
+          },
+          {
+            "attributes": {
+              "url": "https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y?ref_src=embed",
+            },
+            "id": "M00000003",
+            "range": "(121..144)",
+            "type": "link",
+          },
+        ],
+        "text": "￼￼Lap time al fresco. Photo from my collection, no date/info.￼￼[image or embed]￼— Cats of Yore (@catsofyore.bsky.social) May 14, 2024 at 3:43 PM",
+      }
+    `);
+  });
+});

--- a/packages/@atjson/source-html/test/bluesky-embed.test.ts
+++ b/packages/@atjson/source-html/test/bluesky-embed.test.ts
@@ -16,6 +16,7 @@ describe("BlueskyEmbed", () => {
               "cid": "bafyreicg7axsdp6b7f4uj75ggdfhrdl52cqpjah45scox3prmqflwg557i",
               "content": "M00000000",
               "uri": "at://did:plc:xrr5j2okn7ew2zvcwsxus3gb/app.bsky.feed.post/3kshwuxmy5o2y",
+              "url": "https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y",
             },
             "id": "B00000000",
             "parents": [],


### PR DESCRIPTION
Adds support for detecting and rendering Bluesky posts from HTML. Bluesky's at protocol uses IPFS addressing to identify content, so we need to include both a `uri`, and a `cid`, which is the IPFS content id. A `url` is also included so we have a permalink to the post in the case that the post cannot be shown due to user consent not being provided.

<img width="343" alt="image" src="https://github.com/CondeNast/atjson/assets/177701/3c44a40b-796f-4108-8061-8007f7c311a2">


```html
<blockquote class="bluesky-embed" data-bluesky-uri="at://did:plc:xrr5j2okn7ew2zvcwsxus3gb/app.bsky.feed.post/3kshwuxmy5o2y" data-bluesky-cid="bafyreicg7axsdp6b7f4uj75ggdfhrdl52cqpjah45scox3prmqflwg557i"><p lang="en">Lap time al fresco. Photo from my collection, no date/info.<br><br><a href="https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y?ref_src=embed">[image or embed]</a></p>&mdash; Cats of Yore (<a href="https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb?ref_src=embed">@catsofyore.bsky.social</a>) <a href="https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y?ref_src=embed">May 14, 2024 at 3:43 PM</a></blockquote><script async src="https://embed.bsky.app/static/embed.js" charset="utf-8"></script>
```

```json
{
  "blocks": [
    {
      "attributes": {
        "cid": "bafyreicg7axsdp6b7f4uj75ggdfhrdl52cqpjah45scox3prmqflwg557i",
        "content": "M00000000",
        "uri": "at://did:plc:xrr5j2okn7ew2zvcwsxus3gb/app.bsky.feed.post/3kshwuxmy5o2y",
        "url": "https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y",
      },
      "id": "B00000000",
      "parents": [],
      "selfClosing": false,
      "type": "bluesky-embed",
    },
    {
      "attributes": {},
      "id": "B00000001",
      "parents": [
        "bluesky-embed",
      ],
      "selfClosing": false,
      "type": "text",
    },
    {
      "attributes": {},
      "id": "B00000002",
      "parents": [
        "bluesky-embed",
        "text",
      ],
      "selfClosing": true,
      "type": "line-break",
    },
    {
      "attributes": {},
      "id": "B00000003",
      "parents": [
        "bluesky-embed",
        "text",
      ],
      "selfClosing": true,
      "type": "line-break",
    },
    {
      "attributes": {},
      "id": "B00000004",
      "parents": [
        "bluesky-embed",
        "text",
      ],
      "selfClosing": true,
      "type": "line-break",
    },
  ],
  "marks": [
    {
      "attributes": {
        "refs": [
          "B00000000",
        ],
      },
      "id": "M00000000",
      "range": "(1..144]",
      "type": "slice",
    },
    {
      "attributes": {
        "url": "https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y?ref_src=embed",
      },
      "id": "M00000001",
      "range": "(63..79)",
      "type": "link",
    },
    {
      "attributes": {
        "url": "https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb?ref_src=embed",
      },
      "id": "M00000002",
      "range": "(96..119)",
      "type": "link",
    },
    {
      "attributes": {
        "url": "https://bsky.app/profile/did:plc:xrr5j2okn7ew2zvcwsxus3gb/post/3kshwuxmy5o2y?ref_src=embed",
      },
      "id": "M00000003",
      "range": "(121..144)",
      "type": "link",
    },
  ],
  "text": "￼￼Lap time al fresco. Photo from my collection, no date/info.￼￼[image or embed]￼— Cats of Yore (@catsofyore.bsky.social) May 14, 2024 at 3:43 PM",
}
```