### PR TITLE
feat: accordion copilot-11963

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/accordion-item.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/accordion-item.ts
@@ -1,0 +1,16 @@
+import { BlockAnnotation } from "@atjson/document";
+
+export class AccordionItem extends BlockAnnotation<{
+  /**
+   * A named identifier used to store the title of the
+   * content in the panel
+   */
+  header: string;
+  /**
+   * A named identifier used to store the content
+   */
+  panel: string;
+}> {
+  static type = "accordion-item";
+  static vendorPrefix = "offset";
+}

--- a/packages/@atjson/offset-annotations/src/annotations/accordion.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/accordion.ts
@@ -1,0 +1,23 @@
+import { BlockAnnotation } from "@atjson/document";
+/**
+ * An Accordion contains a collection of accordion items that
+ * are arranged vertically.
+ * Each accordion item contains a header and a panel
+ * The header contains the title of the content in the panel
+ * The panel could contain text, pictures, embeds, videos
+ *
+ */
+export class Accordion extends BlockAnnotation<{
+  /**
+   * A named identifier used to represent the layout
+   * like full page width or half
+   */
+  layout?: string;
+  /**
+   * A named identifier used to quickly jump to this item
+   */
+  anchorName?: string;
+}> {
+  static type = "accordion";
+  static vendorPrefix = "offset";
+}

--- a/packages/@atjson/offset-annotations/src/annotations/index.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/index.ts
@@ -39,3 +39,5 @@ export * from "./tiktok-embed";
 export * from "./twitter-embed";
 export * from "./underline";
 export * from "./video-embed";
+export * from "./accordion";
+export * from "./accordion-item";

--- a/packages/@atjson/offset-annotations/src/index.ts
+++ b/packages/@atjson/offset-annotations/src/index.ts
@@ -39,6 +39,8 @@ import {
   TwitterEmbed,
   Underline,
   VideoEmbed,
+  Accordion,
+  AccordionItem,
 } from "./annotations";
 
 export * from "./annotations";
@@ -86,5 +88,7 @@ export default class OffsetSource extends Document {
     TwitterEmbed,
     Underline,
     VideoEmbed,
+    Accordion,
+    AccordionItem,
   ];
 }


### PR DESCRIPTION
This PR introduces offset annotations for accordion and accordion items which will be used in the body field of a content type.
Accordion is used to group contextual data together in the form of header and content

- Accordion holds the attributes of layout and anchorName
- AccordionItem has attributes as header and panel. 
1. Header stores the title of the content in the panel. 
2. Panel holds the content