### PR TITLE
fix: handle empty markdown table headers in proprietary packages

### DIFF
--- a/packages/@atjson/source-commonmark/src/converter/index.ts
+++ b/packages/@atjson/source-commonmark/src/converter/index.ts
@@ -93,19 +93,7 @@ CommonmarkSource.defineConverterTo(
       .set({ type: "-offset-paragraph" });
     doc.where({ type: "-commonmark-strong" }).set({ type: "-offset-bold" });
 
-    convertHTMLTablesToDataSet(doc, "commonmark").forEach((table) => {
-      /**
-       * if a markdown table has no text in its column headers, we have decided to
-       * store that as a table with no header section at all
-       */
-      if (
-        table.attributes.columns.every(
-          (column) => column.name === "" || column.name == null
-        )
-      ) {
-        table.attributes.showColumnHeaders = false;
-      }
-    });
+    convertHTMLTablesToDataSet(doc, "commonmark");
 
     return doc;
   }

--- a/packages/@atjson/source-commonmark/test/extensions.test.ts
+++ b/packages/@atjson/source-commonmark/test/extensions.test.ts
@@ -119,25 +119,6 @@ describe("tables", () => {
     ).toMatchSnapshot();
   });
 
-  test("empty header row creates headless table", () => {
-    const headlessTableExample = `
-|   |   |
-| - | - |
-| a | b |
-| c | d |
-`;
-    let doc =
-      MarkdownItSource.fromRaw(headlessTableExample).convertTo(OffsetSource);
-
-    let tables = doc.where((annotation) => is(annotation, Table));
-
-    expect(tables.length).toBe(1);
-
-    tables.forEach((table) => {
-      expect(table.attributes.showColumnHeaders).toBe(false);
-    });
-  });
-
   test("duplicate column headers produce distinct column names", () => {
     const duplicateColumnsTableExample = `
 | head | head |


### PR DESCRIPTION
Some of the logic we recently introduced around table headers isn't really general-purpose; the decision to equate "markdown table with no text in header cells" with "html table with no thead section" is a particular decision for our own technologies, and makes more sense to implement in a private package rather than the public atjson repo