### PR TITLE
feat: explicit Link attributes for images

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/image.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/image.ts
@@ -1,4 +1,5 @@
-import { ObjectAnnotation } from "@atjson/document";
+import { ObjectAnnotation, AttributesOf } from "@atjson/document";
+import { Link } from "./link";
 
 export class Image extends ObjectAnnotation<{
   /**
@@ -24,6 +25,11 @@ export class Image extends ObjectAnnotation<{
    * A named identifier used to quickly jump to this item
    */
   anchorName?: string;
+
+  /**
+   * Optional link attributes
+   */
+  link?: AttributesOf<Link>;
 }> {
   static vendorPrefix = "offset";
   static type = "image";

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -404,11 +404,25 @@ export default class CommonmarkRenderer extends Renderer {
    */
   *Image(image: Image): Generator<void, string, string[]> {
     let description = escapeDescription(image.attributes.description || "");
+    let imageMarkdown = "";
     if (image.attributes.title) {
       let title = image.attributes.title.replace(/"/g, '\\"');
-      return `![${description}](${image.attributes.url} "${title}")`;
+      imageMarkdown = `![${description}](${image.attributes.url} "${title}")`;
+    } else {
+      imageMarkdown = `![${description}](${image.attributes.url})`;
     }
-    return `![${description}](${image.attributes.url})`;
+
+    if (image.attributes.link?.url) {
+      let { url, title } = image.attributes.link;
+      url = url.replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+      let body = url;
+      if (title) {
+        title = title.replace(/"/g, '\\"');
+        body = `${url} "${title}"`;
+      }
+      return `[${imageMarkdown}](${body})`;
+    }
+    return imageMarkdown;
   }
 
   /**

--- a/packages/@atjson/renderer-commonmark/test/commonmark.test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark.test.ts
@@ -59,12 +59,13 @@ describe("commonmark", () => {
             parents: [],
             selfClosing: true,
             attributes: {
-              description: "December 11, 1995 P. 41",
+              description:
+                '"Cute As a Puppy" by cogdogblog is marked with CC0 1.0.',
               link: {
-                url: "http://archives.newyorker.com/?i=1995-12-11#folio=040",
-                title: "Image Title",
+                url: "https://openverse.org/image/63744ab3-8b2e-4892-a218-5c50943b45b3",
+                title: "Cute as a Puppy | Openverse",
               },
-              url: "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040",
+              url: "https://live.staticflickr.com/1238/916815136_41e5571707_b.jpg",
             },
           },
         ],
@@ -72,7 +73,7 @@ describe("commonmark", () => {
         marks: [],
       })
     ).toBe(
-      '[![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040)](http://archives.newyorker.com/?i=1995-12-11#folio=040 "Image Title")'
+      '[!["Cute As a Puppy" by cogdogblog is marked with CC0 1.0.](https://live.staticflickr.com/1238/916815136_41e5571707_b.jpg)](https://openverse.org/image/63744ab3-8b2e-4892-a218-5c50943b45b3 "Cute as a Puppy | Openverse")'
     );
   });
 
@@ -93,9 +94,10 @@ describe("commonmark", () => {
             parents: ["text"],
             selfClosing: true,
             attributes: {
-              description: "December 11, 1995 P. 41",
+              description:
+                '"Cute As a Puppy" by cogdogblog is marked with CC0 1.0.',
               link: undefined,
-              url: "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040",
+              url: "https://live.staticflickr.com/1238/916815136_41e5571707_b.jpg",
             },
           },
         ],
@@ -105,14 +107,14 @@ describe("commonmark", () => {
             range: "(1..2)",
             type: "link",
             attributes: {
-              url: "http://archives.newyorker.com/?i=1995-12-11#folio=040",
-              title: "Link Title",
+              url: "https://openverse.org/image/63744ab3-8b2e-4892-a218-5c50943b45b3",
+              title: "Cute as a Puppy | Openverse",
             },
           },
         ],
       })
     ).toBe(
-      '[![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040)](http://archives.newyorker.com/?i=1995-12-11#folio=040 "Link Title")'
+      '[!["Cute As a Puppy" by cogdogblog is marked with CC0 1.0.](https://live.staticflickr.com/1238/916815136_41e5571707_b.jpg)](https://openverse.org/image/63744ab3-8b2e-4892-a218-5c50943b45b3 "Cute as a Puppy | Openverse")'
     );
   });
 

--- a/packages/@atjson/renderer-commonmark/test/commonmark.test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark.test.ts
@@ -57,6 +57,7 @@ describe("commonmark", () => {
             id: "B01",
             type: "image",
             parents: [],
+            selfClosing: true,
             attributes: {
               description: "December 11, 1995 P. 41",
               link: {
@@ -72,6 +73,46 @@ describe("commonmark", () => {
       })
     ).toBe(
       '[![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040)](http://archives.newyorker.com/?i=1995-12-11#folio=040 "Image Title")'
+    );
+  });
+
+  test("backwards compatibility for link around an image", () => {
+    expect(
+      CommonmarkRenderer.render({
+        text: "\uFFFC\uFFFC",
+        blocks: [
+          {
+            id: "B00",
+            type: "text",
+            parents: [],
+            attributes: {},
+          },
+          {
+            id: "B01",
+            type: "image",
+            parents: ["text"],
+            selfClosing: true,
+            attributes: {
+              description: "December 11, 1995 P. 41",
+              link: undefined,
+              url: "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040",
+            },
+          },
+        ],
+        marks: [
+          {
+            id: "M01",
+            range: "(1..2)",
+            type: "link",
+            attributes: {
+              url: "http://archives.newyorker.com/?i=1995-12-11#folio=040",
+              title: "Link Title",
+            },
+          },
+        ],
+      })
+    ).toBe(
+      '[![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040)](http://archives.newyorker.com/?i=1995-12-11#folio=040 "Link Title")'
     );
   });
 

--- a/packages/@atjson/renderer-commonmark/test/commonmark.test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark.test.ts
@@ -48,6 +48,33 @@ describe("commonmark", () => {
     );
   });
 
+  test("images with link", () => {
+    expect(
+      CommonmarkRenderer.render({
+        text: "\uFFFC",
+        blocks: [
+          {
+            id: "B01",
+            type: "image",
+            parents: [],
+            attributes: {
+              description: "December 11, 1995 P. 41",
+              link: {
+                url: "http://archives.newyorker.com/?i=1995-12-11#folio=040",
+                title: "Image Title",
+              },
+              url: "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040",
+            },
+          },
+        ],
+
+        marks: [],
+      })
+    ).toBe(
+      '[![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040)](http://archives.newyorker.com/?i=1995-12-11#folio=040 "Image Title")'
+    );
+  });
+
   test("a plain text document with virtual paragraphs", () => {
     let document = new OffsetSource({
       content:

--- a/packages/@atjson/source-commonmark/src/converter/image.ts
+++ b/packages/@atjson/source-commonmark/src/converter/image.ts
@@ -1,0 +1,59 @@
+import Document, { Annotation } from "@atjson/document";
+import { Image } from "@atjson/offset-annotations";
+import { Link as MDLink } from "../annotations/link";
+
+function getWrappingLink(doc: Document, links: Annotation<unknown>[]) {
+  if (links.length !== 1) {
+    return;
+  }
+
+  const link = links[0];
+  const linkSlice = doc
+    .slice(link.start, link.end, function isInside(a) {
+      return link.start <= a.start && a.end <= link.end;
+    })
+    .canonical();
+
+  // only set the link attribute if the wrapping link only covers
+  // the image. we do not support links wrapping multiple images or image + text
+  // at this time
+  if (linkSlice.content === "" && linkSlice.annotations.length === 2) {
+    return link as MDLink;
+  }
+
+  return;
+}
+
+export const convertImage = (doc: Document) => {
+  const images = doc.where({ type: "-commonmark-image" }).as("image");
+  const links = doc.where({ type: "-commonmark-link" }).as("links");
+
+  images
+    .outerJoin(links, function isImageInsideLink(image, link) {
+      return link.start <= image.start && image.end <= link.end;
+    })
+    .update(({ image, links }) => {
+      const link = getWrappingLink(doc, links);
+      doc.replaceAnnotation(
+        image,
+        new Image({
+          start: image.start,
+          end: image.end,
+          attributes: {
+            url: image.attributes.src,
+            title: image.attributes.title,
+            description: image.attributes.alt,
+            link: link
+              ? {
+                  url: link.attributes.href,
+                  title: link.attributes.title,
+                }
+              : undefined,
+          },
+        })
+      );
+      if (link) {
+        doc.removeAnnotation(link);
+      }
+    });
+};

--- a/packages/@atjson/source-commonmark/src/converter/index.ts
+++ b/packages/@atjson/source-commonmark/src/converter/index.ts
@@ -1,9 +1,9 @@
 import OffsetSource, {
   CodeBlock,
-  Image,
   convertHTMLTablesToDataSet,
 } from "@atjson/offset-annotations";
 import CommonmarkSource from "../source";
+import { convertImage } from "./image";
 
 CommonmarkSource.defineConverterTo(
   OffsetSource,
@@ -52,20 +52,7 @@ CommonmarkSource.defineConverterTo(
       .where({ type: "-commonmark-html_inline" })
       .set({ type: "-offset-html", attributes: { "-offset-style": "inline" } });
 
-    doc.where({ type: "-commonmark-image" }).update((image) => {
-      doc.replaceAnnotation(
-        image,
-        new Image({
-          start: image.start,
-          end: image.end,
-          attributes: {
-            url: image.attributes.src,
-            title: image.attributes.title,
-            description: image.attributes.alt,
-          },
-        })
-      );
-    });
+    convertImage(doc);
 
     doc
       .where({ type: "-commonmark-link" })

--- a/packages/@atjson/source-commonmark/test/extensions.test.ts
+++ b/packages/@atjson/source-commonmark/test/extensions.test.ts
@@ -258,7 +258,7 @@ describe("links around images", () => {
     `);
   });
 
-  test("are kept separate when the link wraps text + image", () => {
+  test("are kept separate when the link wraps image + text", () => {
     let doc = CommonmarkSource.fromRaw(
       '[!["Cute As a Puppy" by cogdogblog is marked with CC0 1.0.](https://live.staticflickr.com/1238/916815136_41e5571707_b.jpg) Linked text after the image ](https://openverse.org/image/63744ab3-8b2e-4892-a218-5c50943b45b3 "Cute as a Puppy | Openverse")'
     ).convertTo(OffsetSource);

--- a/packages/@atjson/source-commonmark/test/extensions.test.ts
+++ b/packages/@atjson/source-commonmark/test/extensions.test.ts
@@ -178,7 +178,7 @@ describe("table with empty column header", () => {
 describe("links around images", () => {
   test("are converted to attributes on the image when the link wraps a single image", () => {
     let doc = CommonmarkSource.fromRaw(
-      `[![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040)](http://archives.newyorker.com/?i=1995-12-11#folio=040)`
+      `[!["Cute As a Puppy" by cogdogblog is marked with CC0 1.0.](https://live.staticflickr.com/1238/916815136_41e5571707_b.jpg)](https://openverse.org/image/63744ab3-8b2e-4892-a218-5c50943b45b3 "Cute as a Puppy | Openverse")`
     ).convertTo(OffsetSource);
 
     expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
@@ -193,11 +193,12 @@ describe("links around images", () => {
           },
           {
             "attributes": {
-              "description": "December 11, 1995 P. 41",
+              "description": ""Cute As a Puppy" by cogdogblog is marked with CC0 1.0.",
               "link": {
-                "url": "http://archives.newyorker.com/?i=1995-12-11#folio=040",
+                "title": "Cute as a Puppy | Openverse",
+                "url": "https://openverse.org/image/63744ab3-8b2e-4892-a218-5c50943b45b3",
               },
-              "url": "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040",
+              "url": "https://live.staticflickr.com/1238/916815136_41e5571707_b.jpg",
             },
             "id": "B00000001",
             "parents": [
@@ -215,7 +216,7 @@ describe("links around images", () => {
 
   test("are kept separate when the link wraps text + image", () => {
     let doc = CommonmarkSource.fromRaw(
-      `[text before the image ![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040)](http://archives.newyorker.com/?i=1995-12-11#folio=040)`
+      '[Linked text before the image !["Cute As a Puppy" by cogdogblog is marked with CC0 1.0.](https://live.staticflickr.com/1238/916815136_41e5571707_b.jpg)](https://openverse.org/image/63744ab3-8b2e-4892-a218-5c50943b45b3 "Cute as a Puppy | Openverse")'
     ).convertTo(OffsetSource);
 
     expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
@@ -230,8 +231,8 @@ describe("links around images", () => {
           },
           {
             "attributes": {
-              "description": "December 11, 1995 P. 41",
-              "url": "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040",
+              "description": ""Cute As a Puppy" by cogdogblog is marked with CC0 1.0.",
+              "url": "https://live.staticflickr.com/1238/916815136_41e5571707_b.jpg",
             },
             "id": "B00000001",
             "parents": [
@@ -244,21 +245,22 @@ describe("links around images", () => {
         "marks": [
           {
             "attributes": {
-              "url": "http://archives.newyorker.com/?i=1995-12-11#folio=040",
+              "title": "Cute as a Puppy | Openverse",
+              "url": "https://openverse.org/image/63744ab3-8b2e-4892-a218-5c50943b45b3",
             },
             "id": "M00000000",
-            "range": "(1..24)",
+            "range": "(1..31)",
             "type": "link",
           },
         ],
-        "text": "￼text before the image ￼",
+        "text": "￼Linked text before the image ￼",
       }
     `);
   });
 
   test("are kept separate when the link wraps text + image", () => {
     let doc = CommonmarkSource.fromRaw(
-      `[![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040) text after an image](http://archives.newyorker.com/?i=1995-12-11#folio=040)`
+      '[!["Cute As a Puppy" by cogdogblog is marked with CC0 1.0.](https://live.staticflickr.com/1238/916815136_41e5571707_b.jpg) Linked text after the image ](https://openverse.org/image/63744ab3-8b2e-4892-a218-5c50943b45b3 "Cute as a Puppy | Openverse")'
     ).convertTo(OffsetSource);
 
     expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
@@ -273,8 +275,8 @@ describe("links around images", () => {
           },
           {
             "attributes": {
-              "description": "December 11, 1995 P. 41",
-              "url": "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040",
+              "description": ""Cute As a Puppy" by cogdogblog is marked with CC0 1.0.",
+              "url": "https://live.staticflickr.com/1238/916815136_41e5571707_b.jpg",
             },
             "id": "B00000001",
             "parents": [
@@ -287,21 +289,22 @@ describe("links around images", () => {
         "marks": [
           {
             "attributes": {
-              "url": "http://archives.newyorker.com/?i=1995-12-11#folio=040",
+              "title": "Cute as a Puppy | Openverse",
+              "url": "https://openverse.org/image/63744ab3-8b2e-4892-a218-5c50943b45b3",
             },
             "id": "M00000000",
-            "range": "(1..22)",
+            "range": "(1..31)",
             "type": "link",
           },
         ],
-        "text": "￼￼ text after an image",
+        "text": "￼￼ Linked text after the image ",
       }
     `);
   });
 
   test("are kept separate when the link wraps image + image", () => {
     let doc = CommonmarkSource.fromRaw(
-      `[![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040) ![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=041)](http://archives.newyorker.com/?i=1995-12-11#folio=040)`
+      `[!["Cute As a Puppy" by cogdogblog is marked with CC0 1.0.](https://live.staticflickr.com/1238/916815136_41e5571707_b.jpg) !["Wild Puppy" by Philippe Vieux-Jeanton is marked with CC0 1.0](https://live.staticflickr.com/2933/14013137587_1ed8e8b012_b.jpg)](https://openverse.org/image/63744ab3-8b2e-4892-a218-5c50943b45b3 "Cute as a Puppy | Openverse")`
     ).convertTo(OffsetSource);
 
     expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
@@ -316,8 +319,8 @@ describe("links around images", () => {
           },
           {
             "attributes": {
-              "description": "December 11, 1995 P. 41",
-              "url": "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040",
+              "description": ""Cute As a Puppy" by cogdogblog is marked with CC0 1.0.",
+              "url": "https://live.staticflickr.com/1238/916815136_41e5571707_b.jpg",
             },
             "id": "B00000001",
             "parents": [
@@ -328,8 +331,8 @@ describe("links around images", () => {
           },
           {
             "attributes": {
-              "description": "December 11, 1995 P. 41",
-              "url": "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=041",
+              "description": ""Wild Puppy" by Philippe Vieux-Jeanton is marked with CC0 1.0",
+              "url": "https://live.staticflickr.com/2933/14013137587_1ed8e8b012_b.jpg",
             },
             "id": "B00000002",
             "parents": [
@@ -342,7 +345,8 @@ describe("links around images", () => {
         "marks": [
           {
             "attributes": {
-              "url": "http://archives.newyorker.com/?i=1995-12-11#folio=040",
+              "title": "Cute as a Puppy | Openverse",
+              "url": "https://openverse.org/image/63744ab3-8b2e-4892-a218-5c50943b45b3",
             },
             "id": "M00000000",
             "range": "(1..4)",

--- a/packages/@atjson/source-commonmark/test/extensions.test.ts
+++ b/packages/@atjson/source-commonmark/test/extensions.test.ts
@@ -174,3 +174,183 @@ describe("table with empty column header", () => {
     ).toMatchSnapshot();
   });
 });
+
+describe("links around images", () => {
+  test("are converted to attributes on the image when the link wraps a single image", () => {
+    let doc = CommonmarkSource.fromRaw(
+      `[![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040)](http://archives.newyorker.com/?i=1995-12-11#folio=040)`
+    ).convertTo(OffsetSource);
+
+    expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+      {
+        "blocks": [
+          {
+            "attributes": {},
+            "id": "B00000000",
+            "parents": [],
+            "selfClosing": false,
+            "type": "paragraph",
+          },
+          {
+            "attributes": {
+              "description": "December 11, 1995 P. 41",
+              "link": {
+                "url": "http://archives.newyorker.com/?i=1995-12-11#folio=040",
+              },
+              "url": "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040",
+            },
+            "id": "B00000001",
+            "parents": [
+              "paragraph",
+            ],
+            "selfClosing": true,
+            "type": "image",
+          },
+        ],
+        "marks": [],
+        "text": "￼￼",
+      }
+    `);
+  });
+
+  test("are kept separate when the link wraps text + image", () => {
+    let doc = CommonmarkSource.fromRaw(
+      `[text before the image ![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040)](http://archives.newyorker.com/?i=1995-12-11#folio=040)`
+    ).convertTo(OffsetSource);
+
+    expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+      {
+        "blocks": [
+          {
+            "attributes": {},
+            "id": "B00000000",
+            "parents": [],
+            "selfClosing": false,
+            "type": "paragraph",
+          },
+          {
+            "attributes": {
+              "description": "December 11, 1995 P. 41",
+              "url": "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040",
+            },
+            "id": "B00000001",
+            "parents": [
+              "paragraph",
+            ],
+            "selfClosing": true,
+            "type": "image",
+          },
+        ],
+        "marks": [
+          {
+            "attributes": {
+              "url": "http://archives.newyorker.com/?i=1995-12-11#folio=040",
+            },
+            "id": "M00000000",
+            "range": "(1..24)",
+            "type": "link",
+          },
+        ],
+        "text": "￼text before the image ￼",
+      }
+    `);
+  });
+
+  test("are kept separate when the link wraps text + image", () => {
+    let doc = CommonmarkSource.fromRaw(
+      `[![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040) text after an image](http://archives.newyorker.com/?i=1995-12-11#folio=040)`
+    ).convertTo(OffsetSource);
+
+    expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+      {
+        "blocks": [
+          {
+            "attributes": {},
+            "id": "B00000000",
+            "parents": [],
+            "selfClosing": false,
+            "type": "paragraph",
+          },
+          {
+            "attributes": {
+              "description": "December 11, 1995 P. 41",
+              "url": "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040",
+            },
+            "id": "B00000001",
+            "parents": [
+              "paragraph",
+            ],
+            "selfClosing": true,
+            "type": "image",
+          },
+        ],
+        "marks": [
+          {
+            "attributes": {
+              "url": "http://archives.newyorker.com/?i=1995-12-11#folio=040",
+            },
+            "id": "M00000000",
+            "range": "(1..22)",
+            "type": "link",
+          },
+        ],
+        "text": "￼￼ text after an image",
+      }
+    `);
+  });
+
+  test("are kept separate when the link wraps image + image", () => {
+    let doc = CommonmarkSource.fromRaw(
+      `[![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040) ![December 11, 1995 P. 41](https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=041)](http://archives.newyorker.com/?i=1995-12-11#folio=040)`
+    ).convertTo(OffsetSource);
+
+    expect(serialize(doc, { withStableIds: true })).toMatchInlineSnapshot(`
+      {
+        "blocks": [
+          {
+            "attributes": {},
+            "id": "B00000000",
+            "parents": [],
+            "selfClosing": false,
+            "type": "paragraph",
+          },
+          {
+            "attributes": {
+              "description": "December 11, 1995 P. 41",
+              "url": "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=040",
+            },
+            "id": "B00000001",
+            "parents": [
+              "paragraph",
+            ],
+            "selfClosing": true,
+            "type": "image",
+          },
+          {
+            "attributes": {
+              "description": "December 11, 1995 P. 41",
+              "url": "https://static.cdn.realviewdigital.com/global/content/GetImage.aspx?pguid=FC9071DC-DD99-441F-A727-1B74670350BC&i=1995-12-11&folio=041",
+            },
+            "id": "B00000002",
+            "parents": [
+              "paragraph",
+            ],
+            "selfClosing": true,
+            "type": "image",
+          },
+        ],
+        "marks": [
+          {
+            "attributes": {
+              "url": "http://archives.newyorker.com/?i=1995-12-11#folio=040",
+            },
+            "id": "M00000000",
+            "range": "(1..4)",
+            "type": "link",
+          },
+        ],
+        "text": "￼￼ ￼",
+      }
+    `);
+  });
+});


### PR DESCRIPTION
Add optional link attributes to the offset Image annotation

Update the Commonmark source to set the link attribute on Image
annotations if there is a link that wraps an image only.

Update the Commonmark renderer to render a md link around an image
if the link attribute is set