### PR TITLE
fix: accordion tables copilot-12204

### DIFF
--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -772,8 +772,8 @@ export default class CommonmarkRenderer extends Renderer {
     const previousState = { ...this.state };
     this.state.inlineOnly = true;
 
-    const dataSet = context.document.blocks.find(
-      (block) => block.id === table.attributes.dataSet
+    const dataSet = context.document.blocks.find((block) =>
+      block.id.includes(table.attributes.dataSet)
     ) as Block<DataSet> | undefined;
 
     if (!dataSet) {

--- a/packages/@atjson/renderer-html/src/index.ts
+++ b/packages/@atjson/renderer-html/src/index.ts
@@ -433,8 +433,8 @@ export default class HTMLRenderer extends Renderer {
   }
 
   *Table(table: Block<Table>, context: Context) {
-    const dataSet = context.document.blocks.find(
-      (block) => block.id === table.attributes.dataSet
+    const dataSet = context.document.blocks.find((block) =>
+      block.id.includes(table.attributes.dataSet)
     ) as Block<DataSet> | undefined;
 
     if (!dataSet) {


### PR DESCRIPTION
This PR addresses an issue where tables are not being rendered inside an accordion.
When table is placed inside another block type like an accordion, The table block id will be a concatenation of "parent/accordion block id + table data set id" so the check is being converted from "===" to "includes"