### PR TITLE
chore: use utf8 charset when encoding entities

### DIFF
--- a/packages/@atjson/renderer-html/src/index.ts
+++ b/packages/@atjson/renderer-html/src/index.ts
@@ -95,7 +95,7 @@ export default class HTMLRenderer extends Renderer {
   }
 
   text(text: string) {
-    return entities.encode(text);
+    return entities.encode(text, { mode: entities.EncodingMode.UTF8 });
   }
 
   htmlAttributes(attributes: {

--- a/packages/@atjson/renderer-html/test/encoding.test.ts
+++ b/packages/@atjson/renderer-html/test/encoding.test.ts
@@ -1,0 +1,38 @@
+import Renderer from "../src";
+
+describe("encoding entities", () => {
+  test("Japanese", () => {
+    let doc = {
+      text: "\uFFFC同性の両親",
+      blocks: [
+        {
+          attributes: {},
+          id: "B00000000",
+          parents: [],
+          selfClosing: false,
+          type: "paragraph",
+        },
+      ],
+      marks: [],
+    };
+
+    expect(Renderer.render(doc)).toEqual("<p>同性の両親</p>");
+  });
+  test("HTML reserved entities", () => {
+    let doc = {
+      text: "\uFFFC<>&",
+      blocks: [
+        {
+          attributes: {},
+          id: "B00000000",
+          parents: [],
+          selfClosing: false,
+          type: "paragraph",
+        },
+      ],
+      marks: [],
+    };
+
+    expect(Renderer.render(doc)).toEqual("<p>&lt;&gt;&amp;</p>");
+  });
+});


### PR DESCRIPTION
Use the UTF8 encoding mode when encoding entities in the HTML renderer. This things like Japanese characters won't be encoded but reserved HTML characters like <, >, & will still be