### PR TITLE
fix: type of Join.join arg to Annotation<any>

### DIFF
--- a/packages/@atjson/document/src/join.ts
+++ b/packages/@atjson/document/src/join.ts
@@ -135,7 +135,7 @@ export class Join<Left extends string, Right extends string> {
     filter: (
       lhs: Record<Left, Annotation<any>> &
         Record<Right, Array<Annotation<any>>>,
-      rhs: Annotation
+      rhs: Annotation<any>
     ) => boolean
   ): never | Join<Left, Right | J> {
     if (rightCollection.document !== this.leftJoin.document) {
@@ -173,7 +173,7 @@ export class Join<Left extends string, Right extends string> {
     filter: (
       lhs: Record<Left, Annotation<any>> &
         Record<Right, Array<Annotation<any>>>,
-      rhs: Annotation
+      rhs: Annotation<any>
     ) => boolean
   ): never | Join<Left, Right | J> {
     return this.outerJoin(rightCollection, filter).where(


### PR DESCRIPTION
small bugfix for the Join API so that the arguments to Join.join can be cast to their correct annotation subtypes