### PR TITLE
chore: update actions to most recent versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.11.1"
       - name: Install
@@ -25,8 +25,8 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.11.1"
       - name: Docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,8 +8,8 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.11.1"
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -6,14 +6,14 @@ jobs:
   perf:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.11.1"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: baseline
           ref: main
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: current
       - name: 🐢 Performance
@@ -29,7 +29,7 @@ jobs:
           npm run typecheck
           npx ts-node ./perf-kit/index.ts profile --out current
           npx ts-node ./perf-kit/index.ts compare baseline current
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             const fs = require("fs/promises");
@@ -57,7 +57,7 @@ jobs:
                 });
               }
             }
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: performance-profiles
           path: ./current/perf-kit/profiles

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{github.event.issue.pull_request && contains(github.event.comment.body, '@copilot-robot prerelease')}}
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             try {
@@ -24,7 +24,7 @@ jobs:
             }
         env:
           GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v7
         id: get-ref-name
         with:
           result-encoding: string
@@ -40,7 +40,7 @@ jobs:
             return result.data.head.ref;
         env:
           GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -55,7 +55,7 @@ jobs:
         env:
           BRANCH_NAME: ${{steps.get-ref-name.outputs.result}}
           GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           always-auth: true
           node-version: "20.11.1"
@@ -80,7 +80,7 @@ jobs:
           BRANCH_NAME: ${{steps.get-ref-name.outputs.result}}
           GITHUB_TOKEN: ${{secrets.ROBOT_GITHUB_TOKEN}}
           NODE_AUTH_TOKEN: ${{secrets.ROBOT_NPM_TOKEN}}
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         if: ${{ success() }}
         with:
           github-token: ${{secrets.ROBOT_GITHUB_TOKEN}}
@@ -99,7 +99,7 @@ jobs:
             } catch (err) {
               core.info(`Failed to reply to user with pre-release info ${err}`)
             }
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         if: ${{ failure() }}
         with:
           github-token: ${{secrets.ROBOT_GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ jobs:
     environment: npm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           always-auth: true
           node-version: "20.11.1"


### PR DESCRIPTION
Github has deprecated upload-artifact@v3. This updates our github actions dependencies to the most recent versions of each of them.