### PR TITLE
fix: escape text that looks like numbered lists

### DIFF
--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -141,7 +141,8 @@ function escapePunctuation(
     .replace(/(^[\s]*)>/g, "$1\\>") // Escape >
     .replace(/(^[^[]*)(\].*$)/g, "$1\\$2") // Escape bare closing brackets ]
     .replace(/(\]\()/g, "]\\(") // Escape parenthesis ](
-    .replace(/^(\s*\d+)\.(\s+)/gm, "$1\\.$2") // Escape list items; not all numbers
+    .replace(/^(\s*\d+)\.(\s+)/gm, "$1\\.$2") // Escape list items with text following; not all numbers
+    .replace(/^(\s*\d+)\.$/gm, "$1\\.") // Escape list items with no text following
     .replace(/(^[\s]*)-/g, "$1\\-") // `  - list item`
     .replace(/(\r\n|\r|\n)([\s]*)-/g, "$1$2\\-"); // `- list item\n - list item`
 

--- a/packages/@atjson/renderer-commonmark/test/escaped-text.test.ts
+++ b/packages/@atjson/renderer-commonmark/test/escaped-text.test.ts
@@ -1,3 +1,4 @@
+import { deserialize } from "@atjson/document";
 import OffsetSource, { Paragraph } from "@atjson/offset-annotations";
 import CommonmarkSource from "@atjson/source-commonmark";
 import CommonmarkRenderer from "../src";
@@ -26,4 +27,27 @@ describe("commonmark", () => {
       expect(document.equals(roundTrip)).toBe(true);
     }
   );
+
+  test.each([
+    ["following text", "1. Something", "1\\. Something"],
+    ["end of line", "1.", "1\\."],
+  ])("text that looks like list item with %s", (_, text, md) => {
+    const document = deserialize(
+      {
+        text: `\uFFFC${text}`,
+        blocks: [
+          {
+            id: "B00000000",
+            type: "text",
+            parents: [],
+            selfClosing: false,
+            attributes: {},
+          },
+        ],
+        marks: [],
+      },
+      OffsetSource
+    );
+    expect(CommonmarkRenderer.render(document)).toBe(md);
+  });
 });


### PR DESCRIPTION
We previously did this for examples like
```
1. some text 
```
where we had text following the numbered list, but were not doing so for cases like
```
1.
```
where the end-of-line occurred right after the period